### PR TITLE
Redesign gauge: real logos, Auto light/dark, compact adaptive HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Two surfaces, same rings:
   Toggle it from the menu-bar item's right-click menu. Shown/hidden state is
   remembered.
 
-Dark, warm, restrained. Ember theme.
+Warm and restrained, with **Auto light/dark**: **Kaji Ember** (dark) and
+**Kaji Sun** (light) follow the system appearance.
+
+Currently surfaced: **Claude** and **Codex**. Other providers are hidden for now
+(see `Providers.visible`).
 
 ## The ring
 
@@ -23,15 +27,17 @@ One ring per provider, the 5-hour window:
 - **Gold** normally. At **≥ 80%** it deepens to a same-family **amber**,
   thickens, and grows an alert tick at the arc head — so "near the limit" reads
   even without color. No neon orange, no glow — restrained and warm.
-- Center: the provider logo (tinted to the ring color), the big used-% number,
-  and a thin 24h-ish sparkline. Official brand logos are a TODO — Unicode marks
-  stand in for now (no emoji).
-- Below: `周 {week}% · resets {countdown}`.
+- Center: the real provider logo (tinted to the ring color) — Claude's radial
+  burst, the OpenAI knot — the big used-% number, and a thin sparkline.
+- Below: the provider name + `周 {week}% · resets {countdown}`.
 
 The sparkline has no real history source — `quota.py` doesn't expose a 24h
 series. Kaji Gauge keeps a rolling buffer of the sampled 5h used-% values
-(persisted in `UserDefaults`) and draws that. It seeds empty and fills over
-time, so early on it's short or flat.
+(persisted in `UserDefaults`) and only draws it once there's genuine movement;
+a flat line is worse than none, so early on there's simply no sparkline.
+
+There is no "updated Ns ago" label — the gauge polls on its own (every 30s);
+the only status it surfaces is a small `stale` flag if a fetch fails.
 
 ## Build & run
 
@@ -71,9 +77,9 @@ defaults write dev.kaji.gauge quotaScriptPath /path/to/quota.py
 
 ## Roadmap
 
-- Light "Sun" theme (Ember ships now)
 - WidgetKit desktop widget
 - Configurable providers / marks from a settings UI
+- Real 24h sparkline (needs `quota.py` to log a rolling history)
 - Login-item autostart
 
 ## License

--- a/Sources/KajiGauge/AppDelegate.swift
+++ b/Sources/KajiGauge/AppDelegate.swift
@@ -85,7 +85,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let pop = NSPopover()
         pop.behavior = .transient
         pop.animates = true
-        let content = GaugeRowView(store: store).frame(width: 360)
+        // No fixed width — the view hugs its content (adaptive to N rings).
+        let content = GaugeRowView(store: store)
         pop.contentViewController = NSHostingController(rootView: content)
         popover = pop
     }

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -10,7 +10,9 @@ final class DraggablePanel: NSPanel {
     init(content: NSView) {
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
-            styleMask: [.borderless, .nonactivatingPanel, .hudWindow],
+            // No .hudWindow — its material forces a dark vibrancy that fights the
+            // light "Kaji Sun" theme. We paint our own warm gradient instead.
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -68,12 +70,13 @@ final class FloatingPanelController {
 
     func show() {
         if panel == nil {
+            // No fixed width — GaugeRowView paints its own warm gradient and
+            // hugs its content, so the panel fits N rings without dead space.
             let root = GaugeRowView(store: store)
-                .frame(width: 360)
-                .background(Palette.panel)
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             let hosting = NSHostingView(rootView: root)
             hosting.layer?.cornerRadius = 14
+            hosting.frame = NSRect(origin: .zero, size: hosting.fittingSize)
             let p = DraggablePanel(content: hosting)
             // Place near the top-right of the main screen on first show.
             if let screen = NSScreen.main {

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -3,79 +3,78 @@ import SwiftUI
 // MARK: - GaugeRowView
 //
 // A horizontal row of ring gauges, one per provider. Shared by both surfaces
-// (the menubar popover and the floating panel) so the two always render the
-// same content from the same store.
+// (the menubar popover and the floating panel) so they always render the same
+// content from the same store. The view sizes to its content — no fixed width —
+// so two providers don't leave a wall of dead space (it adapts to N rings).
 struct GaugeRowView: View {
     @ObservedObject var store: QuotaStore
 
+    @Environment(\.colorScheme) private var scheme
+    private var t: KajiTheme { .resolve(scheme) }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 12) {
             header
 
             if store.providers.isEmpty {
                 emptyState
             } else {
-                HStack(alignment: .top, spacing: 18) {
+                HStack(alignment: .top, spacing: 16) {
                     ForEach(store.providers) { provider in
                         RingGauge(provider: provider)
                     }
                 }
             }
-
-            footer
         }
-        .padding(16)
-        .background(Palette.bg)
+        .padding(14)
+        .background(background)
+        .fixedSize()   // hug the content in both axes — adaptive width
+    }
+
+    // Warm depth instead of flat black — matches the approved design preview's
+    // ember glow, so the native app reads as "Kaji", not generic dark.
+    private var background: some View {
+        LinearGradient(
+            colors: [t.bgTop, t.bg],
+            startPoint: .topTrailing, endPoint: .bottomLeading
+        )
     }
 
     private var header: some View {
-        HStack {
-            Text("Kaji Gauge")
+        HStack(spacing: 6) {
+            // Persimmon SUN dot — the one true Kaji brand accent.
+            Circle().fill(t.sun).frame(width: 7, height: 7)
+            Text("Kaji")
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
-                .foregroundColor(Palette.cream)
-            Spacer()
-            Text("5h quota")
-                .font(.system(size: 10))
-                .foregroundColor(Palette.ash)
+                .foregroundColor(t.cream)
+            Text("Gauge")
+                .font(.system(size: 12, weight: .regular, design: .rounded))
+                .foregroundColor(t.mute)
+            Spacer(minLength: 18)
+            // No "updated Ns ago" — the gauge polls on its own; a timestamp is
+            // noise. Only flag the abnormal case: stale data after a fetch error.
+            if store.lastError != nil, !store.providers.isEmpty {
+                Text("stale")
+                    .font(.system(size: 10))
+                    .foregroundColor(t.amber.opacity(0.9))
+            } else {
+                Text("5h quota")
+                    .font(.system(size: 10))
+                    .foregroundColor(t.ash)
+            }
         }
     }
 
     private var emptyState: some View {
         VStack(spacing: 6) {
-            Text("\u{2014}") // —
+            Text("\u{2014}")
                 .font(.system(size: 28))
-                .foregroundColor(Palette.ash)
+                .foregroundColor(t.ash)
             Text(store.lastError ?? "waiting for quota\u{2026}")
-                .font(.system(size: 10))
-                .foregroundColor(Palette.mute)
+                .font(.system(size: 11))
+                .foregroundColor(t.mute)
                 .multilineTextAlignment(.center)
         }
-        .frame(maxWidth: .infinity, minHeight: 100)
-    }
-
-    private var footer: some View {
-        HStack {
-            if let err = store.lastError, !store.providers.isEmpty {
-                Text("stale: \(err)")
-                    .font(.system(size: 9))
-                    .foregroundColor(Palette.amber.opacity(0.85))
-                    .lineLimit(1)
-            } else if let updated = store.lastUpdated {
-                Text("updated \(ResetFormat.ago(updated))")
-                    .font(.system(size: 9))
-                    .foregroundColor(Palette.ash)
-            }
-            Spacer()
-        }
-    }
-}
-
-extension ResetFormat {
-    /// Compact "Ns/Nm/Nh ago" for the last-updated footer.
-    static func ago(_ date: Date) -> String {
-        let d = -date.timeIntervalSinceNow
-        if d < 60 { return "\(Int(d))s ago" }
-        if d < 3600 { return "\(Int(d / 60))m ago" }
-        return "\(Int(d / 3600))h ago"
+        .frame(minWidth: 180, minHeight: 96)
     }
 }

--- a/Sources/KajiGauge/Palette.swift
+++ b/Sources/KajiGauge/Palette.swift
@@ -1,30 +1,67 @@
 import SwiftUI
 
-// MARK: - Kaji Ember palette (dark, warm)
+// MARK: - KajiTheme (Auto: Kaji Ember dark / Kaji Sun light)
 //
-// The product's signature warm-dark theme. A light "Sun" theme is a TODO;
-// we ship Ember now. All colors are defined here as the single source of
-// truth — never hardcode hex elsewhere.
-enum Palette {
-    static let bg     = Color(hex: 0x16100B) // deep warm black — window/popover background
-    static let panel  = Color(hex: 0x1D160F) // slightly lighter — cards / floating panel
-    static let cream  = Color(hex: 0xECE4D6) // primary text / big number
-    static let mute   = Color(hex: 0x9C9283) // captions / secondary text
-    static let ash    = Color(hex: 0x665E53) // disabled / faint
-    static let track  = Color(hex: 0x3A3026) // ring background track
-    static let sun    = Color(hex: 0xF25C05) // legacy brand SUN — NOT used in gauges (too harsh)
-    static let amber  = Color(hex: 0xC87A2A) // near-limit (>=80%): same warm family, just deeper
-    static let gold   = Color(hex: 0xD8A657) // normal ring value arc
+// The two Kaji palettes as plain value types, selected by the SwiftUI
+// `\.colorScheme` environment. Views read `@Environment(\.colorScheme)` and call
+// `KajiTheme.resolve(scheme)` — so the whole gauge flips with macOS Auto/Light/
+// Dark, deterministically (no NSColor dynamic-resolution quirks).
+//
+// Hexes are the product's ground truth:
+//   - dark  "Kaji Ember": warm charcoal + cream + ember gold.
+//   - light "Kaji Sun":   warm paper + ink + ochre gold.
+// SUN persimmon is the one brand accent, identical in both.
+struct KajiTheme {
+    let bg: Color      // window / popover background (bottom of gradient)
+    let bgTop: Color   // top of the warm background gradient
+    let panel: Color   // cards / floating panel
+    let cream: Color   // primary text / big number (ink on Sun)
+    let mute: Color    // captions / secondary text
+    let ash: Color     // faint / disabled
+    let track: Color   // ring background track
+    let gold: Color    // normal ring value arc
+    let amber: Color   // near-limit (>=80%): deeper, same warm family
+    let sun: Color     // Kaji brand persimmon — header dot
+
+    static func resolve(_ scheme: ColorScheme) -> KajiTheme {
+        scheme == .dark ? .dark : .light
+    }
+
+    static let dark = KajiTheme(
+        bg:    Color(hex: 0x16100B),
+        bgTop: Color(hex: 0x1F170F),
+        panel: Color(hex: 0x1D160F),
+        cream: Color(hex: 0xECE4D6),
+        mute:  Color(hex: 0x9C9283),
+        ash:   Color(hex: 0x665E53),
+        track: Color(hex: 0x3A3026),
+        gold:  Color(hex: 0xD8A657),
+        amber: Color(hex: 0xC87A2A),
+        sun:   Color(hex: 0xF25C05)
+    )
+
+    static let light = KajiTheme(
+        bg:    Color(hex: 0xFBF8F2),
+        bgTop: Color(hex: 0xFFFDF8),
+        panel: Color(hex: 0xFEFBF5),
+        cream: Color(hex: 0x211C15), // ink
+        mute:  Color(hex: 0x8A8174),
+        ash:   Color(hex: 0xB5AB9C),
+        track: Color(hex: 0xE2D8C6),
+        gold:  Color(hex: 0xA16207),
+        amber: Color(hex: 0xB45309),
+        sun:   Color(hex: 0xF25C05)
+    )
 }
 
 // MARK: - Hex initializer
 extension Color {
-    /// Build a Color from a 0xRRGGBB integer. Always full opacity unless an
-    /// alpha is supplied separately by the caller via `.opacity`.
+    /// Build a Color from a 0xRRGGBB integer (full opacity).
     init(hex: UInt32) {
-        let r = Double((hex >> 16) & 0xFF) / 255.0
-        let g = Double((hex >> 8) & 0xFF) / 255.0
-        let b = Double(hex & 0xFF) / 255.0
-        self.init(.sRGB, red: r, green: g, blue: b, opacity: 1.0)
+        self.init(.sRGB,
+                  red:   Double((hex >> 16) & 0xFF) / 255.0,
+                  green: Double((hex >> 8) & 0xFF) / 255.0,
+                  blue:  Double(hex & 0xFF) / 255.0,
+                  opacity: 1.0)
     }
 }

--- a/Sources/KajiGauge/ProviderLogo.swift
+++ b/Sources/KajiGauge/ProviderLogo.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+// MARK: - ProviderLogo
+//
+// The center brand mark of each ring. These are the SAME vector logos the
+// design preview uses, so the native gauge stays faithful to the approved mock:
+//   - Claude  → a radial burst of tapered lines (stroked).
+//   - OpenAI  → the official simple-icons knot (filled path, needs SVG arcs).
+//   - Gemini  → the four-point spark (filled path).
+// Anything else falls back to its Unicode mark from `Providers`.
+//
+// All paths author in a 24×24 box; the shapes scale to whatever frame we give.
+struct ProviderLogo: View {
+    let key: String
+    let color: Color
+    var size: CGFloat = 18
+
+    var body: some View {
+        Group {
+            switch key {
+            case "claude":
+                ClaudeBurst()
+                    .stroke(color, style: StrokeStyle(lineWidth: size * (2.1 / 24),
+                                                      lineCap: .round))
+            case "codex", "openai":
+                VectorLogo(pathData: BrandPaths.openai).fill(color)
+            case "gemini":
+                VectorLogo(pathData: BrandPaths.gemini).fill(color)
+            default:
+                Text(Providers.mark(for: key))
+                    .font(.system(size: size))
+                    .foregroundColor(color)
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Claude burst
+//
+// 12 radial lines from a small inner radius outward, alternating length — the
+// signature Anthropic/Claude mark. Stroked, not filled.
+struct ClaudeBurst: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let s = min(rect.width, rect.height) / 24
+        let cx = rect.midX, cy = rect.midY
+        let n = 12
+        let inner: CGFloat = 2.6
+        for i in 0..<n {
+            let a = (CGFloat(i) / CGFloat(n)) * (.pi * 2) - .pi / 2
+            let outer: CGFloat = 11.2 - (i % 2 == 1 ? 2.1 : 0)
+            p.move(to: CGPoint(x: cx + cos(a) * inner * s, y: cy + sin(a) * inner * s))
+            p.addLine(to: CGPoint(x: cx + cos(a) * outer * s, y: cy + sin(a) * outer * s))
+        }
+        return p
+    }
+}
+
+// MARK: - VectorLogo
+//
+// Renders an SVG path (24×24 viewBox) scaled + centered into the frame. Filled.
+struct VectorLogo: Shape {
+    let pathData: String
+
+    func path(in rect: CGRect) -> Path {
+        let cg = SVGPath.cgPath(from: pathData)
+        let s = min(rect.width, rect.height) / 24
+        let tx = rect.minX + (rect.width - 24 * s) / 2
+        let ty = rect.minY + (rect.height - 24 * s) / 2
+        var t = CGAffineTransform(scaleX: s, y: s)
+            .concatenating(CGAffineTransform(translationX: tx, y: ty))
+        if let scaled = cg.copy(using: &t) { return Path(scaled) }
+        return Path(cg)
+    }
+}
+
+// MARK: - Brand path data
+//
+// Verbatim from the design preview (and upstream simple-icons) so the native
+// gauge and the HTML mock render the identical mark.
+enum BrandPaths {
+    // OpenAI / Codex — simple-icons "openai" knot.
+    static let openai = "M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.1419.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"
+
+    // Gemini — four-point spark.
+    static let gemini = "M12 0C12 6.6 6.6 12 0 12C6.6 12 12 17.4 12 24C12 17.4 17.4 12 24 12C17.4 12 12 6.6 12 0Z"
+}

--- a/Sources/KajiGauge/Providers.swift
+++ b/Sources/KajiGauge/Providers.swift
@@ -6,11 +6,9 @@ import Foundation
 // for real brand marks later. This map is the single place to add/remove a
 // provider's display config; the data layer surfaces whatever quota.py emits.
 enum Providers {
-    /// Glyph marks shown in the ring center, tinted to the ring color. These are
-    /// Unicode placeholders chosen to hint each brand. Official brand vector
-    /// logos (Claude burst / OpenAI knot / Gemini spark) are a TODO — bundle
-    /// them as assets; the design preview has accurate SVGs to convert.
-    /// (No emoji marks — the crab is gone.)
+    /// Unicode FALLBACK marks. claude / codex / gemini now render real vector
+    /// logos via `ProviderLogo` (Claude burst / OpenAI knot / Gemini spark);
+    /// these marks are only used for providers without a vector logo.
     static let marks: [String: String] = [
         "claude": "\u{2733}",   // ✳ burst — hints Claude's radial mark
         "codex":  "\u{273B}",   // ✻ six-petalled florette — hints OpenAI knot
@@ -31,6 +29,11 @@ enum Providers {
     /// Preferred left-to-right display order. Providers not listed here are
     /// appended afterward in alphabetical order.
     static let order: [String] = ["claude", "codex", "gemini", "kiro", "opencode"]
+
+    /// Providers we currently surface as rings. gemini / kiro / opencode are
+    /// intentionally hidden for now — focus on claude + codex.
+    static let visible: Set<String> = ["claude", "codex"]
+    static func isVisible(_ key: String) -> Bool { visible.contains(key) }
 
     static func mark(for key: String) -> String {
         marks[key] ?? "\u{2022}" // • bullet fallback

--- a/Sources/KajiGauge/QuotaStore.swift
+++ b/Sources/KajiGauge/QuotaStore.swift
@@ -41,8 +41,8 @@ struct ProviderView: Identifiable, Equatable {
         return min(max(p / 100.0, 0), 1)
     }
 
-    /// Near-limit alert state — the >=80% threshold drives the SUN color + glow
-    /// + non-color emphasis (thicker cap / alert tick).
+    /// Near-limit alert state — the >=80% threshold deepens the ring to AMBER
+    /// (same warm family, no glow) plus non-color emphasis (thicker cap / tick).
     var isNearLimit: Bool {
         (fiveHourPercent ?? 0) >= 80
     }
@@ -71,6 +71,13 @@ final class QuotaStore: ObservableObject {
 
     init() {
         loadHistory()
+    }
+
+    /// Seed a store with fixed data for previews / offscreen snapshots. Does not
+    /// start the poll timer or touch UserDefaults.
+    init(previewProviders: [ProviderView], updated: Date? = nil) {
+        self.providers = previewProviders
+        self.lastUpdated = updated
     }
 
     var scriptPath: String {
@@ -167,7 +174,9 @@ final class QuotaStore: ObservableObject {
         // Only show providers that have a `limits` block (a quota to gauge).
         // Providers like kiro/opencode with no limits are skipped from the
         // rings — there is nothing to ring-gauge.
-        let keys = Providers.sorted(snap.keys.filter { snap[$0]?.limits != nil })
+        let keys = Providers.sorted(snap.keys.filter {
+            snap[$0]?.limits != nil && Providers.isVisible($0)
+        })
 
         var views: [ProviderView] = []
         for key in keys {

--- a/Sources/KajiGauge/RingGauge.swift
+++ b/Sources/KajiGauge/RingGauge.swift
@@ -3,31 +3,30 @@ import SwiftUI
 // MARK: - Sparkline
 //
 // A thin polyline of the rolling 24h-ish history of 5h used% samples.
-// (See QuotaStore — there is no real 24h series; this is a rolling buffer.)
+// quota.py exposes NO real time series — this is a buffer the gauge fills as it
+// polls (persisted in UserDefaults). 5h used% barely moves over minutes, so we
+// only draw it once there is genuine movement (see RingGauge.showSpark); a flat
+// line is worse than none. Auto-ranged to the data so real variation is visible
+// rather than squashed against a 0–100 axis.
 private struct Sparkline: View {
-    let values: [Double]   // 0...100 used%
+    let values: [Double]
     let color: Color
 
     var body: some View {
         GeometryReader { geo in
             Path { path in
                 guard values.count >= 2 else { return }
-                let w = geo.size.width
-                let h = geo.size.height
-                // Normalize to 0...100 so the line height reflects absolute use.
-                let maxV = 100.0
-                let minV = 0.0
-                let span = max(maxV - minV, 1)
+                let w = geo.size.width, h = geo.size.height
+                let minV = values.min() ?? 0
+                let maxV = values.max() ?? 100
+                let span = max(maxV - minV, 1)         // auto-range
                 let step = w / CGFloat(values.count - 1)
                 for (i, v) in values.enumerated() {
                     let x = CGFloat(i) * step
                     let norm = (v - minV) / span
                     let y = h - CGFloat(norm) * h
-                    if i == 0 {
-                        path.move(to: CGPoint(x: x, y: y))
-                    } else {
-                        path.addLine(to: CGPoint(x: x, y: y))
-                    }
+                    if i == 0 { path.move(to: CGPoint(x: x, y: y)) }
+                    else { path.addLine(to: CGPoint(x: x, y: y)) }
                 }
             }
             .stroke(color.opacity(0.85),
@@ -38,100 +37,105 @@ private struct Sparkline: View {
 
 // MARK: - RingGauge
 //
-// The product's signature visual. Per provider: a single 5-hour ring.
-//   - Background track circle (#3A3026 @ 50%, lineWidth 12, rounded caps).
-//   - Value arc trimmed to usedFraction, rotated to start at 12 o'clock.
-//   - Warm gold normally; same-family deeper AMBER when used% >= 80 (the
-//     "near limit" alert). No neon orange, no glow — restrained / 淡雅.
-//   - Color is NOT the only signal at >=80%: the cap thickens AND a small
-//     alert tick is drawn at the arc head, so it reads without color.
-//   - Center: provider mark glyph, big used% number, then a sparkline below.
-//   - Below the ring: muted caption "周 {week}% · resets {reset}".
+// The product's signature visual. Per provider, a single 5-hour ring:
+//   - Background track circle; a value arc trimmed to usedFraction from 12 o'clock.
+//   - Warm gold normally; same-family deeper AMBER at >= 80% (the "near limit"
+//     alert) with a thicker arc + a color-independent alert tick. No glow.
+//   - Center: the real provider logo (tinted to the arc), the big used-% number,
+//     and — only when there's genuine movement — a thin sparkline.
+//   - Below the ring: the provider NAME (kills logo ambiguity) + a clear
+//     "周 {week}% · resets {reset}" caption.
 struct RingGauge: View {
     let provider: ProviderView
 
-    // Geometry.
-    private let ringSize: CGFloat = 96
-    private let baseLineWidth: CGFloat = 12
+    @Environment(\.colorScheme) private var scheme
+    private var t: KajiTheme { .resolve(scheme) }
 
-    private var arcColor: Color {
-        provider.isNearLimit ? Palette.amber : Palette.gold
-    }
+    // Geometry — compact for a desktop HUD (was 96/12, felt oversized).
+    private let ringSize: CGFloat = 84
+    private let baseLineWidth: CGFloat = 10
 
-    // Thicken the value arc when near limit (non-color emphasis).
+    private var arcColor: Color { provider.isNearLimit ? t.amber : t.gold }
+
     private var valueLineWidth: CGFloat {
         provider.isNearLimit ? baseLineWidth + 3 : baseLineWidth
     }
 
     private var percentText: String {
-        guard let p = provider.fiveHourPercent else { return "\u{2014}" } // —
+        guard let p = provider.fiveHourPercent else { return "\u{2014}" }
         return "\(Int(p.rounded()))"
     }
 
-    private var numberColor: Color {
-        provider.isNearLimit ? Palette.amber : Palette.cream
+    private var numberColor: Color { provider.isNearLimit ? t.amber : t.cream }
+
+    // Only draw the sparkline when there are enough real samples AND they
+    // actually move — otherwise it's a misleading flat line.
+    private var showSpark: Bool {
+        let h = provider.history
+        guard h.count >= 4, let lo = h.min(), let hi = h.max() else { return false }
+        return (hi - lo) >= 1.0
     }
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 7) {
             ZStack {
-                // Background track.
                 Circle()
-                    .stroke(Palette.track.opacity(0.5),
+                    .stroke(t.track.opacity(0.5),
                             style: StrokeStyle(lineWidth: baseLineWidth, lineCap: .round))
 
-                // Value arc.
                 Circle()
                     .trim(from: 0, to: provider.usedFraction)
                     .stroke(arcColor,
                             style: StrokeStyle(lineWidth: valueLineWidth, lineCap: .round))
-                    .rotationEffect(.degrees(-90)) // start at 12 o'clock
-                    // No glow — alert reads via deeper amber + thicker cap + AlertTick.
+                    .rotationEffect(.degrees(-90))
 
-                // Non-color alert tick at the arc head when near limit.
                 if provider.isNearLimit && provider.usedFraction > 0 {
                     AlertTick(fraction: provider.usedFraction,
-                              ringSize: ringSize,
-                              lineWidth: valueLineWidth)
-                        .stroke(Palette.cream,
+                              ringSize: ringSize, lineWidth: valueLineWidth)
+                        .stroke(t.cream,
                                 style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 }
 
-                // Center stack: mark, big number, sparkline.
-                VStack(spacing: 2) {
-                    Text(provider.mark)
-                        .font(.system(size: 19))
-                        .foregroundColor(arcColor)
+                VStack(spacing: 1) {
+                    ProviderLogo(key: provider.id, color: arcColor, size: 17)
 
                     Text(percentText)
-                        .font(.system(size: 27, weight: .semibold, design: .rounded))
+                        .font(.system(size: 23, weight: .semibold, design: .rounded))
                         .foregroundColor(numberColor)
                         .monospacedDigit()
 
-                    Sparkline(values: provider.history, color: arcColor)
-                        .frame(width: 34, height: 10)
+                    if showSpark {
+                        Sparkline(values: provider.history, color: arcColor)
+                            .frame(width: 30, height: 8)
+                    }
                 }
             }
             .frame(width: ringSize, height: ringSize)
 
-            caption
+            label
         }
     }
 
-    private var caption: some View {
+    private var label: some View {
         let week = provider.weekPercent.map { "\(Int($0.rounded()))%" } ?? "\u{2014}"
         let reset = ResetFormat.short(provider.resetDate)
-        return Text("\u{5468} \(week) \u{00B7} resets \(reset)") // 周 {week} · resets {reset}
-            .font(.system(size: 10))
-            .foregroundColor(Palette.mute)
-            .lineLimit(1)
+        return VStack(spacing: 2) {
+            Text(provider.displayName)
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundColor(t.cream)
+            // 周 {week} · resets {reset} — reset in gold for a touch of warmth.
+            (Text("\u{5468} \(week) \u{00B7} resets ").foregroundColor(t.mute)
+                + Text(reset).foregroundColor(t.gold))
+                .font(.system(size: 11))
+                .lineLimit(1)
+        }
     }
 }
 
 // MARK: - AlertTick
 //
-// A short radial line drawn at the arc head (12 o'clock + usedFraction). A
-// second, color-independent signal that the ring is in alert state.
+// A short radial line at the arc head — a color-independent second signal that
+// the ring is in alert state.
 private struct AlertTick: Shape {
     let fraction: Double
     let ringSize: CGFloat
@@ -141,24 +145,20 @@ private struct AlertTick: Shape {
         var p = Path()
         let center = CGPoint(x: rect.midX, y: rect.midY)
         let radius = min(rect.width, rect.height) / 2
-        // Angle of the arc head: -90° (12 o'clock) + fraction of full turn.
         let angle = Angle.degrees(-90 + fraction * 360).radians
         let inner = radius - lineWidth / 2 - 3
         let outer = radius + lineWidth / 2 + 3
-        let start = CGPoint(x: center.x + CGFloat(cos(angle)) * inner,
-                            y: center.y + CGFloat(sin(angle)) * inner)
-        let end = CGPoint(x: center.x + CGFloat(cos(angle)) * outer,
-                          y: center.y + CGFloat(sin(angle)) * outer)
-        p.move(to: start)
-        p.addLine(to: end)
+        p.move(to: CGPoint(x: center.x + CGFloat(cos(angle)) * inner,
+                           y: center.y + CGFloat(sin(angle)) * inner))
+        p.addLine(to: CGPoint(x: center.x + CGFloat(cos(angle)) * outer,
+                              y: center.y + CGFloat(sin(angle)) * outer))
         return p
     }
 }
 
 // MARK: - Reset formatting
 enum ResetFormat {
-    /// "—" when no date; "2h 14m" style countdown for the future; "now" when
-    /// already past (data is stale or window just rolled).
+    /// "—" when no date; "2h 14m" countdown for the future; "now" when past.
     static func short(_ date: Date?) -> String {
         guard let date = date else { return "\u{2014}" }
         let delta = date.timeIntervalSinceNow
@@ -166,8 +166,7 @@ enum ResetFormat {
         let hours = Int(delta) / 3600
         let mins = (Int(delta) % 3600) / 60
         if hours >= 24 {
-            let days = hours / 24
-            let rem = hours % 24
+            let days = hours / 24, rem = hours % 24
             return "\(days)d \(rem)h"
         }
         if hours > 0 { return "\(hours)h \(mins)m" }

--- a/Sources/KajiGauge/SVGPath.swift
+++ b/Sources/KajiGauge/SVGPath.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+import CoreGraphics
+
+// MARK: - SVGPath
+//
+// A minimal SVG path-data ("d" attribute) parser that builds a CGPath. Just
+// enough to render the brand logos we ship (OpenAI / Gemini) from the exact
+// same path strings the design preview uses — so the gauge and the HTML mock
+// stay pixel-faithful.
+//
+// Supports: M m  L l  H h  V v  C c  S s  Q q  T t  A a  Z z
+// Arcs (A/a) are converted to cubic Béziers (the OpenAI mark needs them).
+// All logos author in a 24×24 viewBox; `path(in:)` consumers scale to fit.
+enum SVGPath {
+    /// Parse SVG path data into a CGPath in the path's own coordinate space
+    /// (here, a 24×24 box). Unknown/garbage input yields an empty path rather
+    /// than crashing.
+    static func cgPath(from d: String) -> CGPath {
+        let path = CGMutablePath()
+        var t = Scanner(d)
+
+        var cur = CGPoint.zero          // current point
+        var startPt = CGPoint.zero      // subpath start (for Z)
+        var prevCtrl: CGPoint? = nil    // last cubic/quad control (for S/T)
+        var prevCmd: Character = " "
+
+        func n() -> CGFloat { CGFloat(t.number() ?? 0) }
+        func flag() -> Bool { (t.number() ?? 0) != 0 }
+
+        while let cmd = t.command() {
+            let rel = cmd.isLowercase
+            switch cmd {
+            case "M", "m":
+                var p = CGPoint(x: n(), y: n())
+                if rel { p.x += cur.x; p.y += cur.y }
+                path.move(to: p); cur = p; startPt = p
+                // Extra coordinate pairs after a moveto are implicit linetos.
+                while t.peekIsNumber() {
+                    var q = CGPoint(x: n(), y: n())
+                    if rel { q.x += cur.x; q.y += cur.y }
+                    path.addLine(to: q); cur = q
+                }
+            case "L", "l":
+                while t.peekIsNumber() {
+                    var p = CGPoint(x: n(), y: n())
+                    if rel { p.x += cur.x; p.y += cur.y }
+                    path.addLine(to: p); cur = p
+                }
+            case "H", "h":
+                while t.peekIsNumber() {
+                    var x = n(); if rel { x += cur.x }
+                    cur.x = x; path.addLine(to: cur)
+                }
+            case "V", "v":
+                while t.peekIsNumber() {
+                    var y = n(); if rel { y += cur.y }
+                    cur.y = y; path.addLine(to: cur)
+                }
+            case "C", "c":
+                while t.peekIsNumber() {
+                    var c1 = CGPoint(x: n(), y: n())
+                    var c2 = CGPoint(x: n(), y: n())
+                    var p  = CGPoint(x: n(), y: n())
+                    if rel {
+                        c1.x += cur.x; c1.y += cur.y
+                        c2.x += cur.x; c2.y += cur.y
+                        p.x  += cur.x; p.y  += cur.y
+                    }
+                    path.addCurve(to: p, control1: c1, control2: c2)
+                    prevCtrl = c2; cur = p
+                }
+            case "S", "s":
+                while t.peekIsNumber() {
+                    var c2 = CGPoint(x: n(), y: n())
+                    var p  = CGPoint(x: n(), y: n())
+                    if rel { c2.x += cur.x; c2.y += cur.y; p.x += cur.x; p.y += cur.y }
+                    let c1: CGPoint
+                    if "CcSs".contains(prevCmd), let pc = prevCtrl {
+                        c1 = CGPoint(x: 2 * cur.x - pc.x, y: 2 * cur.y - pc.y) // reflect
+                    } else { c1 = cur }
+                    path.addCurve(to: p, control1: c1, control2: c2)
+                    prevCtrl = c2; cur = p
+                }
+            case "Q", "q":
+                while t.peekIsNumber() {
+                    var c = CGPoint(x: n(), y: n())
+                    var p = CGPoint(x: n(), y: n())
+                    if rel { c.x += cur.x; c.y += cur.y; p.x += cur.x; p.y += cur.y }
+                    path.addQuadCurve(to: p, control: c)
+                    prevCtrl = c; cur = p
+                }
+            case "T", "t":
+                while t.peekIsNumber() {
+                    var p = CGPoint(x: n(), y: n())
+                    if rel { p.x += cur.x; p.y += cur.y }
+                    let c: CGPoint
+                    if "QqTt".contains(prevCmd), let pc = prevCtrl {
+                        c = CGPoint(x: 2 * cur.x - pc.x, y: 2 * cur.y - pc.y)
+                    } else { c = cur }
+                    path.addQuadCurve(to: p, control: c)
+                    prevCtrl = c; cur = p
+                }
+            case "A", "a":
+                while t.peekIsNumber() {
+                    let rx = n(), ry = n(), rot = n()
+                    let large = flag(), sweep = flag()
+                    var p = CGPoint(x: n(), y: n())
+                    if rel { p.x += cur.x; p.y += cur.y }
+                    appendArc(to: path, from: cur, to: p, rx: rx, ry: ry,
+                              xRotDeg: rot, largeArc: large, sweep: sweep)
+                    cur = p; prevCtrl = nil
+                }
+            case "Z", "z":
+                path.closeSubpath(); cur = startPt; prevCtrl = nil
+            default:
+                break
+            }
+            prevCmd = cmd
+        }
+        return path
+    }
+
+    // MARK: Arc → cubic Béziers (endpoint to center parameterization, W3C impl notes)
+    private static func appendArc(to path: CGMutablePath, from p0: CGPoint, to p1: CGPoint,
+                                  rx rxIn: CGFloat, ry ryIn: CGFloat, xRotDeg: CGFloat,
+                                  largeArc: Bool, sweep: Bool) {
+        if p0 == p1 { return }
+        var rx = abs(rxIn), ry = abs(ryIn)
+        if rx == 0 || ry == 0 { path.addLine(to: p1); return }
+
+        let phi = xRotDeg * .pi / 180
+        let cosPhi = cos(phi), sinPhi = sin(phi)
+
+        // Step 1: compute (x1', y1')
+        let dx = (p0.x - p1.x) / 2, dy = (p0.y - p1.y) / 2
+        let x1p =  cosPhi * dx + sinPhi * dy
+        let y1p = -sinPhi * dx + cosPhi * dy
+
+        // Correct out-of-range radii.
+        let lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+        if lambda > 1 { let s = sqrt(lambda); rx *= s; ry *= s }
+
+        // Step 2: compute center (cx', cy')
+        let rx2 = rx * rx, ry2 = ry * ry, x1p2 = x1p * x1p, y1p2 = y1p * y1p
+        var num = rx2 * ry2 - rx2 * y1p2 - ry2 * x1p2
+        let den = rx2 * y1p2 + ry2 * x1p2
+        if num < 0 { num = 0 }
+        var coef = den == 0 ? 0 : sqrt(num / den)
+        if largeArc == sweep { coef = -coef }
+        let cxp =  coef * rx * y1p / ry
+        let cyp = -coef * ry * x1p / rx
+
+        // Step 3: center (cx, cy)
+        let cx = cosPhi * cxp - sinPhi * cyp + (p0.x + p1.x) / 2
+        let cy = sinPhi * cxp + cosPhi * cyp + (p0.y + p1.y) / 2
+
+        // Step 4: angles
+        func angle(_ ux: CGFloat, _ uy: CGFloat, _ vx: CGFloat, _ vy: CGFloat) -> CGFloat {
+            let dot = ux * vx + uy * vy
+            let len = sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy))
+            var a = acos(min(max(dot / len, -1), 1))
+            if ux * vy - uy * vx < 0 { a = -a }
+            return a
+        }
+        let ux = (x1p - cxp) / rx, uy = (y1p - cyp) / ry
+        let vx = (-x1p - cxp) / rx, vy = (-y1p - cyp) / ry
+        let theta1 = angle(1, 0, ux, uy)
+        var dTheta = angle(ux, uy, vx, vy)
+        if !sweep && dTheta > 0 { dTheta -= 2 * .pi }
+        if sweep && dTheta < 0 { dTheta += 2 * .pi }
+
+        // Split into segments of <= 90°, each a cubic Bézier.
+        let segs = max(1, Int(ceil(abs(dTheta) / (.pi / 2))))
+        let delta = dTheta / CGFloat(segs)
+        let tParam = 4.0 / 3.0 * tan(delta / 4)
+        var ang = theta1
+        for _ in 0..<segs {
+            let cosA = cos(ang), sinA = sin(ang)
+            let cosB = cos(ang + delta), sinB = sin(ang + delta)
+            // Points on the unit-ish ellipse, then rotate + translate.
+            func pt(_ ca: CGFloat, _ sa: CGFloat) -> CGPoint {
+                let ex = rx * ca, ey = ry * sa
+                return CGPoint(x: cosPhi * ex - sinPhi * ey + cx,
+                               y: sinPhi * ex + cosPhi * ey + cy)
+            }
+            func deriv(_ ca: CGFloat, _ sa: CGFloat) -> CGPoint {
+                let ex = -rx * sa, ey = ry * ca
+                return CGPoint(x: cosPhi * ex - sinPhi * ey,
+                               y: sinPhi * ex + cosPhi * ey)
+            }
+            let e1 = pt(cosA, sinA), e2 = pt(cosB, sinB)
+            let d1 = deriv(cosA, sinA), d2 = deriv(cosB, sinB)
+            let c1 = CGPoint(x: e1.x + tParam * d1.x, y: e1.y + tParam * d1.y)
+            let c2 = CGPoint(x: e2.x - tParam * d2.x, y: e2.y - tParam * d2.y)
+            path.addCurve(to: e2, control1: c1, control2: c2)
+            ang += delta
+        }
+    }
+
+    // MARK: - Number/command scanner
+    private struct Scanner {
+        private let chars: [Character]
+        private var i = 0
+        init(_ s: String) { chars = Array(s) }
+
+        private mutating func skipSep() {
+            while i < chars.count {
+                let c = chars[i]
+                if c == " " || c == "," || c == "\n" || c == "\t" || c == "\r" { i += 1 }
+                else { break }
+            }
+        }
+
+        private static let cmds = Set("MmLlHhVvCcSsQqTtAaZz")
+
+        mutating func command() -> Character? {
+            skipSep()
+            guard i < chars.count else { return nil }
+            let c = chars[i]
+            if Scanner.cmds.contains(c) { i += 1; return c }
+            return nil // a number where a command is expected -> caller loop handled it
+        }
+
+        mutating func peekIsNumber() -> Bool {
+            skipSep()
+            guard i < chars.count else { return false }
+            let c = chars[i]
+            return c.isNumber || c == "-" || c == "+" || c == "."
+        }
+
+        /// Scan one SVG number (sign, int/frac, exponent). Stops at a second '.'
+        /// or a '-'/'+' that begins the next number.
+        mutating func number() -> Double? {
+            skipSep()
+            guard i < chars.count else { return nil }
+            let start = i
+            var seenDot = false
+            var seenDigit = false
+            if chars[i] == "-" || chars[i] == "+" { i += 1 }
+            while i < chars.count {
+                let c = chars[i]
+                if c.isNumber { seenDigit = true; i += 1 }
+                else if c == "." {
+                    if seenDot { break }
+                    seenDot = true; i += 1
+                }
+                else if (c == "e" || c == "E"), seenDigit {
+                    i += 1
+                    if i < chars.count, chars[i] == "-" || chars[i] == "+" { i += 1 }
+                }
+                else { break }
+            }
+            guard i > start else { return nil }
+            return Double(String(chars[start..<i]))
+        }
+    }
+}

--- a/Sources/KajiGauge/StatusItemView.swift
+++ b/Sources/KajiGauge/StatusItemView.swift
@@ -8,19 +8,22 @@ import SwiftUI
 struct StatusItemView: View {
     let provider: ProviderView?
 
+    @Environment(\.colorScheme) private var scheme
+    private var t: KajiTheme { .resolve(scheme) }
+
     private var percent: Int? {
         provider?.fiveHourPercent.map { Int($0.rounded()) }
     }
 
     private var nearLimit: Bool { provider?.isNearLimit ?? false }
 
-    private var tint: Color { nearLimit ? Palette.amber : Palette.gold }
+    private var tint: Color { nearLimit ? t.amber : t.gold }
 
     var body: some View {
         HStack(spacing: 3) {
             ZStack {
                 Circle()
-                    .stroke(Palette.track.opacity(0.6),
+                    .stroke(t.track.opacity(0.6),
                             style: StrokeStyle(lineWidth: 2.4, lineCap: .round))
                 Circle()
                     .trim(from: 0, to: provider?.usedFraction ?? 0)
@@ -33,11 +36,11 @@ struct StatusItemView: View {
                 Text("\(p)%")
                     .font(.system(size: 11, weight: .medium, design: .rounded))
                     .monospacedDigit()
-                    .foregroundColor(nearLimit ? Palette.amber : Palette.cream)
+                    .foregroundColor(nearLimit ? t.amber : t.cream)
             } else {
                 Text("\u{2014}") // —
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(Palette.mute)
+                    .foregroundColor(t.mute)
             }
         }
         .padding(.horizontal, 2)


### PR DESCRIPTION
Reworks the ring gauge per design review:

- Real vector provider logos (Claude radial burst, OpenAI knot) via a small
  SVG path parser (SVGPath) with arc->bezier — distinct marks instead of
  near-identical Unicode asterisks. ProviderLogo dispatches per provider.
- Auto light/dark: KajiTheme replaces the static palette and is selected from
  the SwiftUI \.colorScheme environment — Kaji Ember (dark) / Kaji Sun (light),
  flips with the system appearance. Drops dynamic-NSColor resolution quirks.
- Compact, adaptive layout: smaller rings (84/10), no fixed 360pt width so the
  panel/popover hug N rings (no dead space). Warm gradient background.
- Provider name below each ring; larger, clearer caption.
- Sparkline only drawn when there's genuine movement (quota.py exposes no real
  history) — a flat line is worse than none.
- Removed the "updated Ns ago" footer; only a small stale flag on fetch error.
- Persimmon SUN brand dot in the header.
- Surface Claude + Codex only for now (Providers.visible); Gemini/others hidden.
- Drop .hudWindow from the floating panel so its material doesn't force dark.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
