### PR TITLE
Light theme: persimmon ring instead of ochre

### DIFF
--- a/Sources/KajiGauge/Palette.swift
+++ b/Sources/KajiGauge/Palette.swift
@@ -48,8 +48,8 @@ struct KajiTheme {
         mute:  Color(hex: 0x8A8174),
         ash:   Color(hex: 0xB5AB9C),
         track: Color(hex: 0xE2D8C6),
-        gold:  Color(hex: 0xA16207),
-        amber: Color(hex: 0xB45309),
+        gold:  Color(hex: 0xF25C05), // Kaji persimmon — the ring on paper (ochre felt off)
+        amber: Color(hex: 0xC2410C), // >=80%: deeper persimmon, same family
         sun:   Color(hex: 0xF25C05)
     )
 }


### PR DESCRIPTION
The ochre (#a16207) ring read as muddy on the warm paper background. Switch
the light Kaji Sun ring to the Kaji brand persimmon (#f25c05, matching the
header brand dot); >=80% deepens to #c2410c. Dark Ember keeps its subtler
ember gold.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
