### PR TITLE
feat: live MiniMax quota (mmx) + M monogram + resizable HUD

### DIFF
--- a/Resources/quota.py
+++ b/Resources/quota.py
@@ -442,14 +442,62 @@ def fmt_last(ts):
     return ago(ts)
 
 
-def minimax():
-    """MiniMax: API-key based, no local session files at the moment.
+def _fetch_minimax_limits():
+    """MiniMax Token Plan usage via the `mmx` CLI.
 
-    Returns (sessions_today=0, tokens_today=None, last_active_ts=None). The
-    ring renders an empty arc with the brand mark + "—" until a live quota
-    source lands (account-level windows need a MiniMax endpoint we don't
-    have yet). Keeping the slot in `collect()` so the SwiftUI side can show
-    it as a third ring out of the box.
+    `mmx quota show --output json` returns a per-model `model_remains[]` array.
+    We pick the "general" model (text quota) and read:
+      - 5h window:  used% = 100 - current_interval_remaining_percent
+      - 7d window:  used% = 100 - current_weekly_remaining_percent
+      - resets:     end_time / weekly_end_time (ms unix epoch → seconds float,
+                    the ResetTimestamp decoder on the Swift side accepts both)
+
+    On auth failure (no `mmx` creds), unrecognised response, or any subprocess
+    error we return None and the store shows the MiniMax ring empty. Same
+    stale-cache behavior as the other providers.
+    """
+    try:
+        proc = subprocess.run(
+            ["mmx", "quota", "show", "--output", "json", "--quiet"],
+            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        d = json.loads(proc.stdout)
+    except Exception:
+        return None
+    out = {}
+    for entry in (d.get("model_remains") or []):
+        if not isinstance(entry, dict) or entry.get("model_name") != "general":
+            continue
+        iv_remaining = entry.get("current_interval_remaining_percent")
+        wk_remaining = entry.get("current_weekly_remaining_percent")
+        if iv_remaining is not None:
+            out["five_hour_used_percent"] = max(0.0, 100.0 - float(iv_remaining))
+            end_ms = entry.get("end_time")
+            if isinstance(end_ms, (int, float)):
+                out["five_hour_resets_at"] = float(end_ms) / 1000.0
+        if wk_remaining is not None:
+            out["seven_day_used_percent"] = max(0.0, 100.0 - float(wk_remaining))
+            wk_end_ms = entry.get("weekly_end_time")
+            if isinstance(wk_end_ms, (int, float)):
+                out["seven_day_resets_at"] = float(wk_end_ms) / 1000.0
+        break
+    return out or None
+
+
+def minimax_limits():
+    return _limits_cached("minimax-limits-cache.json", _fetch_minimax_limits)
+
+
+def minimax():
+    """MiniMax: no local session files; quota lives server-side (mmx CLI).
+
+    Returns (sessions_today=0, tokens_today=None, last_active_ts=None) — the
+    ring's `limits` block is filled by `minimax_limits()` (cached) which the
+    Swift side surfaces as the 5h/7d percentages.
     """
     return 0, None, None
 
@@ -458,9 +506,9 @@ def collect():
     """Per-harness tuples (name, sessions, tokens, last, limits|None, by_project).
 
     Limits: live account windows (five_hour/seven_day used_percent) — claude
-    via the oauth usage endpoint, codex via app-server; codex falls back to
-    the freshest session file when the live call fails. MiniMax is reserved
-    with no limits yet (placeholder — see `minimax()`).
+    via the oauth usage endpoint, codex via app-server (or freshest session
+    file fallback), minimax via the `mmx` CLI; all cached on disk with the
+    same TTL.
     """
     c_sess, c_tok, c_last, c_proj, c_ctx = claude_code()
     x_sess, x_tok, x_last, x_file_limits, x_proj, x_ctx = codex()
@@ -470,7 +518,7 @@ def collect():
         ("kiro",    *kiro(), None, {}, {}),
         ("opencode", *opencode(), None, {}, {}),
         ("codex",   x_sess, x_tok, x_last, codex_limits() or x_file_limits, x_proj, x_ctx),
-        ("minimax", m_sess, m_tok, m_last, None, {}, {}),
+        ("minimax", m_sess, m_tok, m_last, minimax_limits(), {}, {}),
     ]
 
 

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -12,7 +12,9 @@ final class DraggablePanel: NSPanel {
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
             // No .hudWindow — its material forces a dark vibrancy that fights the
             // light "Kaji Sun" theme. We paint our own warm gradient instead.
-            styleMask: [.borderless, .nonactivatingPanel],
+            // .resizable so the user can drag the edges/corners to scale the
+            // HUD; we paint our own shadow (no native chrome).
+            styleMask: [.borderless, .nonactivatingPanel, .resizable],
             backing: .buffered,
             defer: false
         )
@@ -33,6 +35,18 @@ final class DraggablePanel: NSPanel {
         if let fitting = content.fittingSize as NSSize?, fitting.width > 0 {
             setContentSize(fitting)
         }
+
+        // Allow the user to shrink toward the content's natural size and grow
+        // comfortably up to ~3 rings at max ring size. Below the minimum the
+        // SwiftUI content would clip; above the max, the rings stop scaling.
+        let minW: CGFloat = 220
+        let minH: CGFloat = 140
+        let maxW: CGFloat = 720
+        let maxH: CGFloat = 360
+        minSize = NSSize(width: minW, height: minH)
+        maxSize = NSSize(width: maxW, height: maxH)
+        contentMinSize = NSSize(width: minW, height: minH)
+        contentMaxSize = NSSize(width: maxW, height: maxH)
     }
 
     // Borderless windows can't become key by default; allow it so SwiftUI
@@ -72,13 +86,16 @@ final class FloatingPanelController {
 
     func show() {
         if panel == nil {
-            // No fixed width — GaugeRowView paints its own warm gradient and
-            // hugs its content, so the panel fits N rings without dead space.
-            let root = GaugeRowView(store: store, prefs: prefs)
+            // Resizable HUD: GaugeRowView runs in `expandToFill` mode so the
+            // SwiftUI view tracks the panel's width and rings scale together.
+            let root = GaugeRowView(store: store, prefs: prefs, expandToFill: true)
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             let hosting = NSHostingView(rootView: root)
             hosting.layer?.cornerRadius = 14
             hosting.frame = NSRect(origin: .zero, size: hosting.fittingSize)
+            // Track the panel's content size on resize (width + height), so
+            // the SwiftUI view reflows instead of staying anchored top-left.
+            hosting.autoresizingMask = [.width, .height]
             let p = DraggablePanel(content: hosting)
             // Place near the top-right of the main screen on first show.
             if let screen = NSScreen.main {

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -15,6 +15,20 @@ struct GaugeRowView: View {
 
     var controls: Controls? = nil
 
+    /// When true the view expands to fill its container (used by the resizable
+    /// floating HUD — rings scale up with the panel width). Popover leaves
+    /// this false so the view still hugs its content and the popover stays
+    /// tight around its rings.
+    var expandToFill: Bool = false
+
+    /// Minimum / maximum ring diameter when scaling with the panel. Keeps the
+    /// gauge readable at small widths and prevents over-stretch at large ones.
+    private let minRing: CGFloat = 64
+    private let maxRing: CGFloat = 160
+    /// Default ring size when the view is hugging its content (popover, or a
+    /// panel that's at its natural fitting size).
+    private let defaultRing: CGFloat = 84
+
     struct Controls {
         let panelVisible: Bool
         let onTogglePanel: () -> Void
@@ -31,6 +45,18 @@ struct GaugeRowView: View {
         store.providers.filter { prefs.isVisible($0.id) }
     }
 
+    /// Pick a ring diameter that distributes the available width evenly across
+    /// the visible rings (minus the HStack spacing). Clamped so small widths
+    /// still read and large widths don't bloat the ring into a coin.
+    private func ringSize(forAvailable width: CGFloat) -> CGFloat {
+        let n = max(1, CGFloat(shown.count))
+        let spacing: CGFloat = 16
+        let padding: CGFloat = 28   // 14 on each side
+        let usable = max(0, width - padding - spacing * (n - 1))
+        let raw = usable / n
+        return min(max(raw, minRing), maxRing)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             header
@@ -38,18 +64,48 @@ struct GaugeRowView: View {
             if shown.isEmpty {
                 emptyState
             } else {
-                HStack(alignment: .top, spacing: 16) {
-                    ForEach(shown) { provider in
-                        RingGauge(provider: provider, lang: prefs.language)
-                    }
-                }
+                ringsRow
             }
 
             if let controls { footer(controls) }
         }
         .padding(14)
         .background(background)
-        .fixedSize()
+        .modifier(FitOrFill(expand: expandToFill))
+    }
+
+    @ViewBuilder
+    private var ringsRow: some View {
+        if expandToFill {
+            // GeometryReader detects the panel width; rings scale together.
+            GeometryReader { geo in
+                let size = ringSize(forAvailable: geo.size.width)
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(shown) { provider in
+                        RingGauge(provider: provider, lang: prefs.language,
+                                  ringSize: size)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: ringSize(forAvailable: maxRing * CGFloat(shown.count)) + 32)
+        } else {
+            HStack(alignment: .top, spacing: 16) {
+                ForEach(shown) { provider in
+                    RingGauge(provider: provider, lang: prefs.language,
+                              ringSize: defaultRing)
+                }
+            }
+        }
+    }
+
+    /// `.fixedSize()` for the popover (hugs content) → removed when the panel
+    /// mode is on (fills the panel, rings scale with width).
+    private struct FitOrFill: ViewModifier {
+        let expand: Bool
+        func body(content: Content) -> some View {
+            if expand { content } else { content.fixedSize() }
+        }
     }
 
     // MARK: Footer (settings — popover only)

--- a/Sources/KajiGauge/ProviderLogo.swift
+++ b/Sources/KajiGauge/ProviderLogo.swift
@@ -7,6 +7,9 @@ import SwiftUI
 //   - Claude  → a radial burst of tapered lines (stroked).
 //   - OpenAI  → the official simple-icons knot (filled path, needs SVG arcs).
 //   - Gemini  → the four-point spark (filled path).
+//   - MiniMax → geometric M monogram (filled path). MiniMax has no published
+//     icon — wordmark only — so we draw a sans-serif M in the same visual
+//     weight as the OpenAI / Gemini marks.
 // Anything else falls back to its Unicode mark from `Providers`.
 //
 // All paths author in a 24×24 box; the shapes scale to whatever frame we give.
@@ -26,6 +29,8 @@ struct ProviderLogo: View {
                 VectorLogo(pathData: BrandPaths.openai).fill(color)
             case "gemini":
                 VectorLogo(pathData: BrandPaths.gemini).fill(color)
+            case "minimax":
+                VectorLogo(pathData: BrandPaths.minimax).fill(color)
             default:
                 Text(Providers.mark(for: key))
                     .font(.system(size: size))
@@ -85,4 +90,8 @@ enum BrandPaths {
 
     // Gemini — four-point spark.
     static let gemini = "M12 0C12 6.6 6.6 12 0 12C6.6 12 12 17.4 12 24C12 17.4 17.4 12 24 12C17.4 12 12 6.6 12 0Z"
+
+    // MiniMax — geometric M monogram (sans-serif, V cut from top, flat bottom).
+    // Authored in 24×24; two stems (4u wide), central V peak at (12,12).
+    static let minimax = "M3,3 H8 L12,12 L16,3 H21 V21 H3 Z"
 }

--- a/Sources/KajiGauge/Providers.swift
+++ b/Sources/KajiGauge/Providers.swift
@@ -6,13 +6,14 @@ import Foundation
 // for real brand marks later. This map is the single place to add/remove a
 // provider's display config; the data layer surfaces whatever quota.py emits.
 enum Providers {
-    /// Unicode FALLBACK marks. claude / codex / gemini now render real vector
-    /// logos via `ProviderLogo` (Claude burst / OpenAI knot / Gemini spark);
-    /// these marks are only used for providers without a vector logo.
+    /// Unicode FALLBACK marks. claude / codex / gemini / minimax render real
+    /// vector logos via `ProviderLogo` (Claude burst / OpenAI knot / Gemini
+    /// spark / MiniMax M monogram); these marks are only used for providers
+    /// without a vector logo.
     static let marks: [String: String] = [
         "claude":  "\u{2733}",   // ✳ burst — hints Claude's radial mark
         "codex":   "\u{273B}",   // ✻ six-petalled florette — hints OpenAI knot
-        "minimax": "\u{272A}",   // ✪ circled white star — MiniMax mark
+        "minimax": "\u{272A}",   // ✪ circled white star — kept as fallback
         "gemini":  "\u{2726}",   // ✦ four-point spark — hints Gemini
         "kiro":    "\u{25C9}",   // ◉
         "opencode": "\u{25B3}",  // △
@@ -34,9 +35,8 @@ enum Providers {
 
     /// Providers we currently surface as rings. gemini / kiro / opencode are
     /// intentionally hidden for now — focus on claude + codex + minimax.
-    /// MiniMax has no live local quota yet (no per-session files / quota API
-    /// wired), so it renders an empty ring with the brand mark — the slot is
-    /// reserved for when the API integration lands.
+    /// MiniMax quota is wired through the `mmx` CLI (see `quota.py`'s
+    /// `_fetch_minimax_limits`).
     static let visible: Set<String> = ["claude", "codex", "minimax"]
     static func isVisible(_ key: String) -> Bool { visible.contains(key) }
 

--- a/Sources/KajiGauge/RingGauge.swift
+++ b/Sources/KajiGauge/RingGauge.swift
@@ -13,20 +13,26 @@ struct RingGauge: View {
     let provider: ProviderView
     var lang: Lang = .en
 
+    /// Outer ring diameter. Scales the ring + the logo + the big % together so
+    /// the visual mass stays proportional when the floating HUD is resized.
+    /// 84 = the legacy fixed size used by the popover + first-launch HUD.
+    var ringSize: CGFloat = 84
+
     @Environment(\.colorScheme) private var scheme
     private var t: KajiTheme { .resolve(scheme) }
 
-    // Geometry — compact for a desktop HUD.
-    private let ringSize: CGFloat = 84
-    private let baseLineWidth: CGFloat = 10
-    private let innerLineWidth: CGFloat = 5
-    private let innerInset: CGFloat = 13   // pulls the 7d ring inside the 5h ring
+    // All ring geometry is derived from ringSize so the gauge scales as a unit.
+    private var baseLineWidth: CGFloat { ringSize * (10.0 / 84.0) }
+    private var innerLineWidth: CGFloat { ringSize * (5.0 / 84.0) }
+    private var innerInset: CGFloat    { ringSize * (13.0 / 84.0) }
+    private var logoSize: CGFloat      { ringSize * (16.0 / 84.0) }
+    private var percentFont: CGFloat   { ringSize * (22.0 / 84.0) }
 
     private var arcColor: Color { provider.isNearLimit ? t.amber : t.gold }
     private var weekColor: Color { provider.weekNearLimit ? t.amber : t.gold.opacity(0.55) }
 
     private var valueLineWidth: CGFloat {
-        provider.isNearLimit ? baseLineWidth + 3 : baseLineWidth
+        provider.isNearLimit ? baseLineWidth + (ringSize * (3.0 / 84.0)) : baseLineWidth
     }
 
     private var percentText: String {
@@ -62,9 +68,9 @@ struct RingGauge: View {
                     .padding(innerInset)
 
                 VStack(spacing: 1) {
-                    ProviderLogo(key: provider.id, color: arcColor, size: 16)
+                    ProviderLogo(key: provider.id, color: arcColor, size: logoSize)
                     Text(percentText)
-                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .font(.system(size: percentFont, weight: .semibold, design: .rounded))
                         .foregroundColor(numberColor)
                         .monospacedDigit()
                 }


### PR DESCRIPTION
## What

Three follow-ups to the MiniMax provider slot:

1. **Live quota** — `Resources/quota.py` shells out to `mmx quota show --output json --quiet`, parses `model_remains[]` filtering `model_name == "general"`, returns 5h/7d used% + ms-epoch resets (converted to seconds float for the existing `ResetTimestamp` decoder). Same `_limits_cached` TTL as claude/codex; falls back to `None` (empty ring) on auth/parse errors.
2. **Brand mark** — `ProviderLogo` gains a `case "minimax"` rendering a vector M monogram (filled path, 24×24, two stems + V cut from top + flat bottom — same visual weight as the OpenAI knot / Gemini spark). MiniMax is wordmark-only with no published icon, so author a sans-serif M to match.
3. **Resizable HUD** — `FloatingPanel` adds `.resizable` to its `styleMask` + `minSize`/`maxSize` bounds; `GaugeRowView` gains an `expandToFill` mode that drops `.fixedSize()` and uses `GeometryReader` to scale ring diameter (clamped 64–160pt) with the panel width. `RingGauge` derives its ring, inner ring, logo, and big % from `ringSize` so the whole gauge scales as one unit. Popover still hugs content (no change).

## Verify

- bundled quota.py: `claude {5h:100, 7d:22}`, `codex {5h:7, 7d:56}`, `minimax {5h:15, 7d:2}` — all three populate.
- screenshot at default size + after resize to 480×240 — all three rings (Claude burst / OpenAI knot / MiniMax M) render with real percentages, fully visible after resize.

## Files

- `Resources/quota.py`
- `Sources/KajiGauge/ProviderLogo.swift`
- `Sources/KajiGauge/Providers.swift` (comment only)
- `Sources/KajiGauge/FloatingPanel.swift`
- `Sources/KajiGauge/GaugeRowView.swift`
- `Sources/KajiGauge/RingGauge.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)