### PR TITLE
fix: adaptive HUD layout + widen NSPanel resize edge hit zone

### DIFF
--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -6,14 +6,25 @@ import SwiftUI
 // An always-on-top, borderless HUD panel that the user can drag anywhere on
 // the desktop. .nonactivatingPanel so clicking it never steals focus from the
 // frontmost app; .floating level so it stays above normal windows.
+//
+// Borderless NSPanels default to a ~3pt edge hit zone for resizing — the user
+// has to park the cursor right on the edge. We widen this to 10pt by
+// installing eight invisible `ResizeHandle` views (one per edge + corner)
+// that own the resize gesture + cursor and sit ABOVE the SwiftUI host so they
+// get first crack at mouse events.
 final class DraggablePanel: NSPanel {
+    /// Edge width for the resize hit zone. 10pt ≈ a comfortable grab target
+    /// without leaking too far into the content. Corners count from both
+    /// adjacent edges (so the union is the L-shaped corner region).
+    private static let edgeWidth: CGFloat = 10
+
     init(content: NSView) {
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
             // No .hudWindow — its material forces a dark vibrancy that fights the
             // light "Kaji Sun" theme. We paint our own warm gradient instead.
-            // .resizable so the user can drag the edges/corners to scale the
-            // HUD; we paint our own shadow (no native chrome).
+            // .resizable so we can also drag the edges/corners via the
+            // ResizeHandle subviews; we paint our own shadow (no native chrome).
             styleMask: [.borderless, .nonactivatingPanel, .resizable],
             backing: .buffered,
             defer: false
@@ -47,12 +58,181 @@ final class DraggablePanel: NSPanel {
         maxSize = NSSize(width: maxW, height: maxH)
         contentMinSize = NSSize(width: minW, height: minH)
         contentMaxSize = NSSize(width: maxW, height: maxH)
+
+        // Install the eight resize handles. The hosting view is also added so
+        // the SwiftUI content still draws (these handles are transparent).
+        if let host = contentView {
+            host.wantsLayer = true
+            host.layer?.backgroundColor = .clear
+            installResizeHandles(on: host)
+        }
     }
 
     // Borderless windows can't become key by default; allow it so SwiftUI
     // interaction works without forcing app activation.
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    private func installResizeHandles(on host: NSView) {
+        let w = DraggablePanel.edgeWidth
+        // Corners first (drawn last so they sit on top of the edge handles
+        // and own the cursor at the intersection). Each corner is square of
+        // side `w`; edges are thin strips.
+        let corners: [(ResizeHandle.Kind, CGRect)] = [
+            (.topLeft,     CGRect(x: 0, y: host.bounds.maxY - w,
+                                  width: w, height: w)),
+            (.topRight,    CGRect(x: host.bounds.maxX - w, y: host.bounds.maxY - w,
+                                  width: w, height: w)),
+            (.bottomLeft,  CGRect(x: 0, y: 0, width: w, height: w)),
+            (.bottomRight, CGRect(x: host.bounds.maxX - w, y: 0,
+                                  width: w, height: w)),
+        ]
+        let edges: [(ResizeHandle.Kind, CGRect)] = [
+            (.top,    CGRect(x: w, y: host.bounds.maxY - w,
+                             width: max(0, host.bounds.width - 2 * w), height: w)),
+            (.bottom, CGRect(x: w, y: 0,
+                             width: max(0, host.bounds.width - 2 * w), height: w)),
+            (.left,   CGRect(x: 0, y: w, width: w,
+                             height: max(0, host.bounds.height - 2 * w))),
+            (.right,  CGRect(x: host.bounds.maxX - w, y: w, width: w,
+                             height: max(0, host.bounds.height - 2 * w))),
+        ]
+        for (kind, rect) in edges + corners {
+            let handle = ResizeHandle(kind: kind, panel: self)
+            handle.frame = rect
+            handle.autoresizingMask = autoresizeMask(for: kind, in: host)
+            host.addSubview(handle)
+        }
+    }
+
+    private func autoresizeMask(for kind: ResizeHandle.Kind,
+                                in host: NSView) -> NSView.AutoresizingMask {
+        // Edges/corners move with their adjacent sides when the panel resizes.
+        switch kind {
+        case .topLeft:     return [.maxXMargin, .minYMargin]
+        case .topRight:    return [.minXMargin, .minYMargin]
+        case .bottomLeft:  return [.maxXMargin, .maxYMargin]
+        case .bottomRight: return [.minXMargin, .maxYMargin]
+        case .top:         return [.width, .minYMargin]
+        case .bottom:      return [.width, .maxYMargin]
+        case .left:        return [.maxXMargin, .height]
+        case .right:       return [.minXMargin, .height]
+        }
+    }
+}
+
+// MARK: - ResizeHandle
+//
+// An invisible NSView that owns one of the eight panel edges/corners. It
+// overrides `mouseDown` to start a resize, tracks the delta in
+// `mouseDragged`, and switches the cursor when the mouse enters/leaves.
+final class ResizeHandle: NSView {
+    enum Kind {
+        case topLeft, topRight, bottomLeft, bottomRight
+        case top, bottom, left, right
+    }
+    private let kind: Kind
+    private weak var panel: NSPanel?
+    private var startOrigin: NSPoint = .zero
+    private var startSize: NSSize = .zero
+    private var startFrame: NSRect = .zero
+
+    init(kind: Kind, panel: NSPanel) {
+        self.kind = kind
+        self.panel = panel
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var acceptsFirstResponder: Bool { true }
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // Block any hits in our rect so the SwiftUI host doesn't steal them.
+        // We still let the panel's own isMovableByWindowBackground handle the
+        // background drag (we only sit on the edges).
+        bounds.contains(point) ? self : nil
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: cursor())
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let panel = panel else { return }
+        startFrame = panel.frame
+        startOrigin = startFrame.origin
+        startSize = startFrame.size
+        window?.makeFirstResponder(self)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let panel = panel else { return }
+        // Location in window coords; convert to delta in screen coords (Y up).
+        let loc = event.locationInWindow
+        let start = window?.mouseLocationOutsideOfEventStream ?? loc
+        let dx = loc.x - start.x
+        let dy = loc.y - start.y
+        apply(dx: dx, dy: dy, to: panel)
+    }
+
+    private func apply(dx: CGFloat, dy: CGFloat, to panel: NSPanel) {
+        var origin = startOrigin
+        var size = startSize
+        // NSPanel resize: edges/corners modify origin + size according to which
+        // side the user grabbed. Y is screen-up here (dy > 0 = drag up).
+        switch kind {
+        case .topLeft:
+            origin.x += dx; origin.y += dy
+            size.width -= dx; size.height += dy
+        case .topRight:
+            origin.y += dy
+            size.width += dx; size.height += dy
+        case .bottomLeft:
+            origin.x += dx
+            size.width -= dx; size.height -= dy
+        case .bottomRight:
+            size.width += dx; size.height -= dy
+        case .top:
+            origin.y += dy
+            size.height += dy
+        case .bottom:
+            size.height -= dy
+        case .left:
+            origin.x += dx
+            size.width -= dx
+        case .right:
+            size.width += dx
+        }
+        // Clamp to the same bounds the panel's minSize / maxSize enforce.
+        let minS = panel.minSize, maxS = panel.maxSize
+        size.width = min(max(size.width, minS.width),  maxS.width)
+        size.height = min(max(size.height, minS.height), maxS.height)
+        // Re-derive origin for the clamped size so the grabbed edge stays
+        // anchored to the cursor (only the non-anchored corners move).
+        switch kind {
+        case .topLeft:
+            origin.x = startOrigin.x + (startSize.width - size.width)
+            origin.y = startOrigin.y + (startSize.height - size.height)
+        case .topRight:
+            origin.y = startOrigin.y + (startSize.height - size.height)
+        case .bottomLeft:
+            origin.x = startOrigin.x + (startSize.width - size.width)
+        case .top:
+            origin.y = startOrigin.y + (startSize.height - size.height)
+        case .left:
+            origin.x = startOrigin.x + (startSize.width - size.width)
+        default: break
+        }
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+    }
+
+    private func cursor() -> NSCursor {
+        switch kind {
+        case .topLeft, .bottomRight: return .crosshair
+        case .topRight, .bottomLeft: return .crosshair
+        case .top, .bottom:          return .resizeUpDown
+        case .left, .right:          return .resizeLeftRight
+        }
+    }
 }
 
 // MARK: - FloatingPanelController

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -45,16 +45,29 @@ struct GaugeRowView: View {
         store.providers.filter { prefs.isVisible($0.id) }
     }
 
-    /// Pick a ring diameter that distributes the available width evenly across
-    /// the visible rings (minus the HStack spacing). Clamped so small widths
-    /// still read and large widths don't bloat the ring into a coin.
-    private func ringSize(forAvailable width: CGFloat) -> CGFloat {
-        let n = max(1, CGFloat(shown.count))
-        let spacing: CGFloat = 16
-        let padding: CGFloat = 28   // 14 on each side
-        let usable = max(0, width - padding - spacing * (n - 1))
-        let raw = usable / n
-        return min(max(raw, minRing), maxRing)
+    /// Pick a ring diameter from BOTH width and height so the gauge never
+    /// overflows either axis. When the panel is tall+narrow we wrap to a
+    /// vertical stack; the ring then has the full row height to grow into.
+    /// - Parameter isTall: true → LazyVStack mode (one ring per row).
+    private func ringSize(width w: CGFloat, height h: CGFloat,
+                          n: Int, isTall: Bool) -> CGFloat {
+        guard n > 0 else { return minRing }
+        let rowSpacing: CGFloat = isTall ? 10 : 16
+        let padding: CGFloat = 28
+        // Chrome above (header) + below (label) the ring within each cell.
+        let verticalChrome: CGFloat = 22 + 38 + 12
+        let perRingW = max(0, (w - padding - rowSpacing * CGFloat(n - 1)) / CGFloat(n))
+        let rowsHeight = max(0, h - verticalChrome)
+        let perRowH = isTall
+            ? (rowsHeight - rowSpacing * CGFloat(n - 1)) / CGFloat(n)
+            : rowsHeight
+        let maxFromHeight = max(0, perRowH - 38 - 7)   // label + VStack spacing
+        let raw = min(perRingW, maxFromHeight)
+        // Floor: when the panel is too narrow for n rings at minRing, fall
+        // back to whatever fits so the user can see all rings even at 220pt.
+        let effectiveMin = max(32, min(minRing,
+                                       (w - padding) / CGFloat(n) - rowSpacing))
+        return min(max(raw, effectiveMin), maxRing)
     }
 
     var body: some View {
@@ -77,18 +90,40 @@ struct GaugeRowView: View {
     @ViewBuilder
     private var ringsRow: some View {
         if expandToFill {
-            // GeometryReader detects the panel width; rings scale together.
+            // GeometryReader drives both axis. Pick a layout that matches the
+            // panel's actual aspect: wide/short → HStack row; tall/narrow →
+            // LazyVStack (one ring per row) so label text never gets clipped.
             GeometryReader { geo in
-                let size = ringSize(forAvailable: geo.size.width)
-                HStack(alignment: .top, spacing: 16) {
-                    ForEach(shown) { provider in
-                        RingGauge(provider: provider, lang: prefs.language,
-                                  ringSize: size)
+                let n = max(1, shown.count)
+                // Go tall when the row would overflow horizontally. 130 ≈
+                // minRing (64) + padding per slot + label width; if total
+                // slots > available width, wrap to one-per-row.
+                let slotNeeded: CGFloat = 130
+                let totalNeeded = slotNeeded * CGFloat(n) + 16 * CGFloat(n - 1) + 28
+                let isTall = n > 1 && geo.size.width < totalNeeded
+                let size = ringSize(width: geo.size.width,
+                                    height: geo.size.height,
+                                    n: n, isTall: isTall)
+                Group {
+                    if isTall {
+                        LazyVStack(alignment: .leading, spacing: 10) {
+                            ForEach(shown) { provider in
+                                RingGauge(provider: provider, lang: prefs.language,
+                                          ringSize: size)
+                            }
+                        }
+                        .scrollDisabled(true)
+                    } else {
+                        HStack(alignment: .top, spacing: 16) {
+                            ForEach(shown) { provider in
+                                RingGauge(provider: provider, lang: prefs.language,
+                                          ringSize: size)
+                            }
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(height: ringSize(forAvailable: maxRing * CGFloat(shown.count)) + 32)
         } else {
             HStack(alignment: .top, spacing: 16) {
                 ForEach(shown) { provider in
@@ -216,14 +251,15 @@ struct GaugeRowView: View {
     // Header chrome: tighter on the right so the legend recedes instead of
     // claiming equal weight with the title. Size scales with visible-ring
     // count (more rings = same; fewer rings = smaller + closer) and shrinks
-    // further under tight widths via minimumScaleFactor.
+    // further under tight widths via minimumScaleFactor. The legend is the
+    // elastic item: layoutPriority(0) makes it absorb all leftover pressure,
+    // and minimumScaleFactor lets it shrink down before any text truncates.
     private var header: some View {
-        let legend = store.lastError != nil && !store.providers.isEmpty
+        let isError = store.lastError != nil && !store.providers.isEmpty
+        let legend = isError
             ? L10n.t(.stale, prefs.language)
             : "5h \u{00B7} \(L10n.t(.week, prefs.language))"
-        let legendColor: Color = store.lastError != nil && !store.providers.isEmpty
-            ? t.amber.opacity(0.9)
-            : t.ash
+        let legendColor: Color = isError ? t.amber.opacity(0.9) : t.ash
         // Scale: 0/1 ring → 0.78; 2 rings → 0.90; 3+ → 1.0. Recedes when sparse.
         let density = max(1, shown.count)
         let scale: CGFloat = density >= 3 ? 1.0 : (density == 2 ? 0.90 : 0.78)
@@ -234,18 +270,20 @@ struct GaugeRowView: View {
             Text("Kaji")
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .foregroundColor(t.cream)
+                .layoutPriority(2)
             Text("Gauge")
                 .font(.system(size: 12, weight: .regular, design: .rounded))
                 .foregroundColor(t.mute)
+                .layoutPriority(1)
             Spacer(minLength: 4)
             Text(legend)
                 .font(.system(size: 10))
                 .foregroundColor(legendColor)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .fixedSize(horizontal: false, vertical: true)
-                .scaleEffect(scale, anchor: .trailing)
+                .minimumScaleFactor(0.6)
+                .layoutPriority(0)
         }
+        .scaleEffect(scale, anchor: .trailing)
     }
 
     private var emptyState: some View {

--- a/Sources/KajiGauge/RingGauge.swift
+++ b/Sources/KajiGauge/RingGauge.swift
@@ -85,21 +85,33 @@ struct RingGauge: View {
         let week = provider.weekPercent.map { "\(Int($0.rounded()))%" } ?? "\u{2014}"
         let fiveReset = ResetFormat.phrase(provider.resetDate, lang)
         let weekReset = ResetFormat.phrase(provider.weekResetDate, lang)
+        // When the ring is small, drop the "5h · " and "周 {n}% · " prefixes.
+        // The rings themselves encode the window visually; the countdown is
+        // the load-bearing info and must remain readable in full.
+        let narrow = ringSize < 78
         return VStack(spacing: 2) {
             Text(provider.displayName)
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .foregroundColor(t.cream)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
             // 5h reset countdown (the outer ring's window).
-            (Text("5h \u{00B7} ").foregroundColor(t.mute)
+            (Text(narrow ? "" : "5h \u{00B7} ").foregroundColor(t.mute)
                 + Text(fiveReset).foregroundColor(t.gold))
-                .font(.system(size: 10))
+                .font(.system(size: 10, weight: .medium))
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .minimumScaleFactor(0.85)
             // 7d used % + its own reset countdown (the inner ring's window).
-            (Text("\(L10n.t(.week, lang)) \(week) \u{00B7} ").foregroundColor(t.mute)
+            (Text(narrow ? "" : "\(L10n.t(.week, lang)) \(week) \u{00B7} ")
+                .foregroundColor(t.mute)
                 + Text(weekReset).foregroundColor(t.gold.opacity(0.85)))
-                .font(.system(size: 10))
+                .font(.system(size: 10, weight: .medium))
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .minimumScaleFactor(0.85)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 


### PR DESCRIPTION
HUD adapt:
- Aspect-driven HStack↔LazyVStack switch: when 3 rings can't fit
  horizontally (width < 130n + spacing + padding), wrap to vertical.
- ringSize now clamps BOTH width and height so rings never overflow
  either axis at the 220x140..720x360 envelope.
- Header: layoutPriority(2/1/0) so Kaji + Gauge + legend compress in
  order; scaleEffect recedes header at 0/1/2 ring density.
- RingGauge label: when ring < 78pt, drop '5h · ' / '周 {n}% · '
  prefixes so the countdown stays readable in full.

Resize edge:
- Borderless NSPanel defaults to ~3pt resize hit zone — too tight to
  grab. Install 8 invisible ResizeHandle NSViews (10pt wide, with
  autoresizingMask) on the contentView. They override hitTest to
  claim hits in their rect, resetCursorRects to switch cursor, and
  handle mouseDown/Dragged with origin re-derivation so the grabbed
  edge stays anchored to the cursor under min/max clamping.
