### PR TITLE
fix: HUD min size, visible resize edge, 4-side dock

### DIFF
--- a/Sources/KajiGauge/DockStripView.swift
+++ b/Sources/KajiGauge/DockStripView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+// MARK: - DockStripView
+//
+// The visual shown when the floating HUD is `.docked` against a screen edge.
+// A 36pt thin strip with the mostConstrained provider's logo + 5h percentage
+// + reset countdown, so the user keeps an at-a-glance read of their tightest
+// quota even with the panel collapsed out of the way.
+//
+// The strip rotates the content 90° on left/right docks so reading flows
+// top→bottom (matches QQ-style edge docks). On top/bottom the strip is short
+// + wide and reads horizontally (no rotation).
+//
+// Tap or hover the strip → `onExpand()` fires; the controller animates the
+// panel back to its saved expanded frame.
+struct DockStripView: View {
+    @ObservedObject var store: QuotaStore
+    @ObservedObject var prefs: Prefs
+    let edge: DockEdge
+    let onExpand: () -> Void
+
+    @Environment(\.colorScheme) private var scheme
+    private var t: KajiTheme { .resolve(scheme) }
+
+    /// The provider currently closest to its 5h limit. Falls back to the
+    /// first available if none have data (we always show *something*).
+    private var provider: ProviderView? {
+        if let m = store.mostConstrained { return m }
+        return store.providers.first
+    }
+
+    var body: some View {
+        // The frame is set by the controller (panel width/height after snap).
+        // Content is rotated on left/right edges so the strip reads top-down.
+        ZStack {
+            background
+            content
+                .rotationEffect(rotation, anchor: .center)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .onTapGesture(perform: onExpand)
+    }
+
+    // MARK: Background chrome
+
+    private var background: some View {
+        ZStack {
+            // Same warm paper/ink gradient as the full HUD so the docked
+            // strip doesn't look like a foreign object on the desktop.
+            LinearGradient(
+                colors: [t.bgTop, t.bg],
+                startPoint: .topTrailing, endPoint: .bottomLeading
+            )
+            // 1pt gold outline — matches the HUD's accent ring so docked
+            // mode reads as a continuation, not a separate widget.
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(t.gold.opacity(0.55), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    // MARK: Content
+
+    private var content: some View {
+        // VStack along the strip's long axis (will be rotated for left/right).
+        // Spacing is tight — the strip is 36pt wide so we have ~30pt usable.
+        VStack(spacing: 3) {
+            logo
+            percentLabel
+            countdownLabel
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 6)
+    }
+
+    @ViewBuilder
+    private var logo: some View {
+        if let p = provider {
+            ProviderLogo(key: p.id, color: t.cream, size: 13)
+        } else {
+            // No providers yet — a tiny dot to mark the strip as ours.
+            Circle().fill(t.ash).frame(width: 5, height: 5)
+        }
+    }
+
+    private var percentLabel: some View {
+        let text: String = {
+            guard let p = provider, let pct = p.fiveHourPercent else { return "—" }
+            return "\(Int(pct.rounded()))%"
+        }()
+        return Text(text)
+            .font(.system(size: 12.5, weight: .semibold, design: .rounded))
+            .foregroundColor(t.gold)
+            .lineLimit(1)
+            .fixedSize()  // don't shrink — readability wins in a 36pt strip
+    }
+
+    private var countdownLabel: some View {
+        Text(countdownText)
+            .font(.system(size: 8.5, weight: .regular, design: .monospaced))
+            .foregroundColor(t.cream.opacity(0.55))
+            .lineLimit(1)
+            .fixedSize()
+    }
+
+    /// "5h12m" or "12m" or "" when no data. Matches the menubar's compact
+    /// style — short enough to fit a rotated 36pt strip without truncation.
+    private var countdownText: String {
+        guard let p = provider, let reset = p.resetDate else { return "·" }
+        let secs = max(0, Int(reset.timeIntervalSinceNow))
+        if secs <= 0 { return "now" }
+        let h = secs / 3600
+        let m = (secs % 3600) / 60
+        return h > 0 ? "\(h)h\(m)m" : "\(m)m"
+    }
+
+    // MARK: Rotation
+
+    /// Left/right docks rotate content 90° so the strip reads top→bottom;
+    /// top/bottom docks keep horizontal reading.
+    private var rotation: Angle {
+        switch edge {
+        case .left:   return .degrees(90)
+        case .right:  return .degrees(-90)
+        case .top, .bottom: return .degrees(0)
+        }
+    }
+}

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Combine
 
 // MARK: - DraggablePanel
 //
@@ -13,10 +14,11 @@ import SwiftUI
 // that own the resize gesture + cursor and sit ABOVE the SwiftUI host so they
 // get first crack at mouse events.
 final class DraggablePanel: NSPanel {
-    /// Edge width for the resize hit zone. 10pt ≈ a comfortable grab target
-    /// without leaking too far into the content. Corners count from both
-    /// adjacent edges (so the union is the L-shaped corner region).
-    private static let edgeWidth: CGFloat = 10
+    /// Edge width for the resize hit zone. 16pt ≈ a comfortable grab target
+    /// + room for a visible 1.5pt track line + L-shape corner indicator. The
+    /// handles are still mostly transparent — only the inner-edge track line
+    /// is drawn, so the wider hit zone doesn't leak into the content.
+    private static let edgeWidth: CGFloat = 16
 
     init(content: NSView) {
         super.init(
@@ -47,16 +49,17 @@ final class DraggablePanel: NSPanel {
             setContentSize(fitting)
         }
 
-        // Allow the user to shrink toward the content's natural size and grow
-        // comfortably up to ~3 rings at max ring size. Below the minimum the
-        // SwiftUI content would clip; above the max, the rings stop scaling.
-        let minW: CGFloat = 220
-        let minH: CGFloat = 140
+        // Initial bounds use the LARGEST visible-ring case (3-ring vertical
+        // wrap, 200x340). The controller narrows the lower bound as visible
+        // rings change, via `updateMinSize(forVisibleRings:)`. The upper bound
+        // stays at the original 720x360 — that's still where rings stop
+        // scaling.
         let maxW: CGFloat = 720
         let maxH: CGFloat = 360
-        minSize = NSSize(width: minW, height: minH)
+        let defaultMin = DraggablePanel.minSize(forVisibleRings: 3)
+        minSize = defaultMin
         maxSize = NSSize(width: maxW, height: maxH)
-        contentMinSize = NSSize(width: minW, height: minH)
+        contentMinSize = defaultMin
         contentMaxSize = NSSize(width: maxW, height: maxH)
 
         // Install the eight resize handles. The hosting view is also added so
@@ -66,6 +69,38 @@ final class DraggablePanel: NSPanel {
             host.layer?.backgroundColor = .clear
             installResizeHandles(on: host)
         }
+    }
+
+    /// Pick a min size for the panel given how many provider rings the user
+    /// currently has visible. 1-2 rings sit in an HStack (need W), 3+ wraps
+    /// to a LazyVStack (need H). We never go below the natural chrome — below
+    /// that the SwiftUI content starts to clip and the legend truncates.
+    static func minSize(forVisibleRings n: Int) -> NSSize {
+        if n <= 2 {
+            // 1 ring ≈ 84 + label; 2 rings HStack need ~280 to fit 84+84+16+chrome.
+            // Height = ring + label + chrome ≈ 160; below that the panel feels
+            // squeezed and the popover font starts to shrink.
+            let w: CGFloat = n == 1 ? 200 : 280
+            return NSSize(width: w, height: 160)
+        }
+        // 3 rings vertical: ring(36) + label(38) + spacing(7) per cell, 3 cells
+        // + 2 inter-cell gaps + top chrome (header+padding ≈ 54) + bottom 14.
+        // Round up to 340 so the label VStack never gets squeezed.
+        return NSSize(width: 200, height: 340)
+    }
+
+    /// Re-apply the lower bound when the user's visible-ring count changes.
+    /// Capped to the current frame so we don't SHRINK a live panel the user
+    /// is already looking at — only expand the bound so the user can shrink
+    /// back down to the new minimum.
+    func updateMinSize(forVisibleRings n: Int) {
+        let target = DraggablePanel.minSize(forVisibleRings: n)
+        // If the panel is already larger than the new min, keep the panel
+        // size and just relax the lower bound to the new min.
+        minSize = NSSize(width: min(target.width, frame.width),
+                         height: min(target.height, frame.height))
+        contentMinSize = NSSize(width: min(target.width, frame.width),
+                                height: min(target.height, frame.height))
     }
 
     // Borderless windows can't become key by default; allow it so SwiftUI
@@ -119,13 +154,26 @@ final class DraggablePanel: NSPanel {
         case .right:       return [.minXMargin, .height]
         }
     }
+
+    /// Tear down + reinstall all eight ResizeHandle subviews. Called by the
+    /// controller after swapping the SwiftUI hosting view (dock ↔ HUD) so
+    /// the handles always sit on top of the new content with the right z-order.
+    func reinstallResizeHandles() {
+        guard let host = contentView else { return }
+        host.subviews
+            .compactMap { $0 as? ResizeHandle }
+            .forEach { $0.removeFromSuperview() }
+        installResizeHandles(on: host)
+    }
 }
 
 // MARK: - ResizeHandle
 //
-// An invisible NSView that owns one of the eight panel edges/corners. It
-// overrides `mouseDown` to start a resize, tracks the delta in
-// `mouseDragged`, and switches the cursor when the mouse enters/leaves.
+// An NSView that owns one of the eight panel edges/corners. The hit zone is
+// 16pt wide; visually we draw a 1.5pt track line on the INNER edge (toward
+// the panel center) so the user can see "here is the grab zone" without the
+// chrome competing with the SwiftUI content. On hover the track thickens to
+// 2.5pt and switches to the Kaji gold so the affordance is unmistakable.
 final class ResizeHandle: NSView {
     enum Kind {
         case topLeft, topRight, bottomLeft, bottomRight
@@ -137,10 +185,33 @@ final class ResizeHandle: NSView {
     private var startSize: NSSize = .zero
     private var startFrame: NSRect = .zero
 
+    /// Hover state — set by the tracking area, read by draw(_:). The view
+    /// repaints on every change so the line thickens + recolors smoothly.
+    private var hovered = false
+
+    /// Idle track + hover gold, resolved once per scheme. We keep both modes
+    /// (light + dark) so theme switches in macOS Auto just trigger a redraw.
+    private static let trackDark  = NSColor(srgbRed: 0x3A/255, green: 0x30/255, blue: 0x26/255, alpha: 0.60)
+    private static let trackLight = NSColor(srgbRed: 0xE2/255, green: 0xD8/255, blue: 0xC6/255, alpha: 0.70)
+    private static let goldDark   = NSColor(srgbRed: 0xD8/255, green: 0xA6/255, blue: 0x57/255, alpha: 1.0)
+    private static let goldLight  = NSColor(srgbRed: 0xF2/255, green: 0x5C/255, blue: 0x05/255, alpha: 1.0)
+
     init(kind: Kind, panel: NSPanel) {
         self.kind = kind
         self.panel = panel
         super.init(frame: .zero)
+        // Transparent base — the visual is purely the inner-edge track line.
+        wantsLayer = true
+        layer?.backgroundColor = .clear
+        // Add the tracking area so mouseEntered/Exited fire while we're in
+        // the key window. The handle sits above the SwiftUI host so we own
+        // the hover events; the rest of the panel doesn't trigger us.
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .mouseEnteredAndExited, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
     }
     required init?(coder: NSCoder) { fatalError() }
 
@@ -154,6 +225,70 @@ final class ResizeHandle: NSView {
 
     override func resetCursorRects() {
         addCursorRect(bounds, cursor: cursor())
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        hovered = true
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        hovered = false
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let color: NSColor
+        if hovered {
+            color = isDark ? Self.goldDark : Self.goldLight
+        } else {
+            color = isDark ? Self.trackDark : Self.trackLight
+        }
+        let lineWidth: CGFloat = hovered ? 2.5 : 1.5
+        let path = NSBezierPath()
+        path.lineWidth = lineWidth
+        path.lineCapStyle = .round
+
+        // Inset the line by half the stroke so it stays inside our bounds;
+        // the cursor rect covers the full 16pt zone regardless.
+        let inset: CGFloat = lineWidth / 2
+        let b = bounds
+        switch kind {
+        case .top:
+            // Horizontal line near the bottom of the top handle (= inner edge).
+            path.move(to: NSPoint(x: inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
+        case .bottom:
+            path.move(to: NSPoint(x: inset, y: b.maxY - inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
+        case .left:
+            path.move(to: NSPoint(x: inset, y: inset))
+            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
+        case .right:
+            path.move(to: NSPoint(x: b.maxX - inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
+        case .topLeft:
+            // L-shape: vertical leg (inner edge) + horizontal leg (inner edge).
+            path.move(to: NSPoint(x: inset, y: b.maxY - inset))
+            path.line(to: NSPoint(x: inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
+        case .topRight:
+            path.move(to: NSPoint(x: inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
+        case .bottomLeft:
+            path.move(to: NSPoint(x: inset, y: inset))
+            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
+        case .bottomRight:
+            path.move(to: NSPoint(x: b.maxX - inset, y: inset))
+            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
+            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
+        }
+        color.setStroke()
+        path.stroke()
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -235,6 +370,36 @@ final class ResizeHandle: NSView {
     }
 }
 
+// MARK: - PanelState
+//
+// The floating panel has three visual modes. They are owned by the controller
+// (not the view) so SwiftUI sees a single root and we can swap it without
+// rebuilding the panel.
+//
+//   - `.expanded` — the regular HUD: rings, labels, header. Drag from any
+//     inner pixel; resize from the 8 invisible ResizeHandles on the border.
+//   - `.snapped(edge)` — the panel moved within 14pt of a screen edge and
+//     we animated it flush to the edge. Same content; just relocated.
+//   - `.docked(edge)` — 240ms of stillness after a snap collapsed the panel
+//     into a thin 36pt strip (mostConstrained provider's logo + %). Strip
+//     sits on the chosen edge. Hover or drag the strip → back to expanded.
+enum PanelState {
+    case expanded
+    case snapped(DockEdge)
+    case docked(DockEdge)
+
+    var edge: DockEdge? {
+        switch self {
+        case .expanded:           return nil
+        case .snapped(let e):     return e
+        case .docked(let e):      return e
+        }
+    }
+    var isDocked: Bool {
+        if case .docked = self { return true } else { return false }
+    }
+}
+
 // MARK: - FloatingPanelController
 //
 // Owns the panel lifecycle and persists shown/hidden state in UserDefaults.
@@ -243,17 +408,71 @@ final class FloatingPanelController {
     private var panel: DraggablePanel?
     private let store: QuotaStore
     private let prefs: Prefs
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Number of providers the user has chosen to show. Drives the panel's
+    /// min size — see `DraggablePanel.minSize(forVisibleRings:)`.
+    private var shownCount: Int {
+        store.providers.filter { prefs.isVisible($0.id) }.count
+    }
+
+    /// Snap + dock state. Drives the visual mode (regular HUD / flush to edge
+    /// / 36pt strip) and the snap timer.
+    private var state: PanelState = .expanded
+
+    /// Frame the panel occupied when last in `.expanded`. The dock round-trip
+    /// (collapse → expand) restores the user back to where they were.
+    private var savedExpandedFrame: NSRect?
+
+    /// Fires 240ms after a snap completes; if the panel is still snapped at
+    /// fire-time, it transitions into `.docked(edge)`. Reset on every move.
+    private var snapTimer: Timer?
+
+    /// Set during `show()` if `prefs.dockEdge != nil` so the next batch of
+    /// plumbing (snap observer installed below) can dock the panel without
+    /// making the user drag it on first launch.
+    private var pendingStartupDock: DockEdge?
+
+    /// didMoveNotification observer — drives the snap → dock state machine.
+    private var moveObserver: NSObjectProtocol?
+
+    /// Snap + dock constants. Kept on the controller so the behavior is
+    /// self-contained; if these ever need user-tunable, lift to Prefs.
+    private static let stripThickness: CGFloat = 36
+    private static let snapThreshold: CGFloat = 14
+    private static let snapAnimationDuration: TimeInterval = 0.18
+    private static let dockDelay: TimeInterval = 0.24
+    private static let dockAnimationDuration: TimeInterval = 0.22
 
     init(store: QuotaStore, prefs: Prefs) {
         self.store = store
         self.prefs = prefs
+        // Re-apply the min size whenever the user's visible-ring set changes
+        // (provider toggle in the popover/menu) OR the store reports new data
+        // (a provider that was previously "no data" now has a row to show).
+        // MainActor: all UI work; no need to hop.
+        store.$providers
+            .sink { [weak self] _ in self?.applyMinSize() }
+            .store(in: &cancellables)
+        prefs.$visibleProviders
+            .sink { [weak self] _ in self?.applyMinSize() }
+            .store(in: &cancellables)
+        // prefs.dockEdge is persisted via its own didSet; no controller-side
+        // hook needed today, but we keep a sink registered for future
+        // dock-edge side effects (analytics, menu rebuild) without touching
+        // Prefs again.
+        prefs.$dockEdge
+            .sink { _ in }
+            .store(in: &cancellables)
     }
 
     var isVisible: Bool {
         panel?.isVisible ?? false
     }
 
-    /// Restore the last shown/hidden state on launch.
+    /// Restore the last shown/hidden state on launch. If the user was docked
+    /// (prefs.dockEdge != nil), show() in the regular frame then defer the
+    /// dock transition to the snap listener installed below.
     func restore() {
         if UserDefaults.standard.bool(forKey: Config.kPanelVisible) {
             show()
@@ -285,13 +504,278 @@ final class FloatingPanelController {
                                          y: v.maxY - size.height - 24))
             }
             panel = p
+            installMoveObserver(on: p)
+            // If the user was docked at quit time, mark it so the snap
+            // observer (installed next batch) can dock straight from launch.
+            pendingStartupDock = prefs.dockEdge
         }
         panel?.orderFrontRegardless()
+        applyMinSize()  // covers the show-after-data-arrived case
+        // Defer startup-dock to the next runloop tick so the panel's content
+        // view is fully wired up before we swap in the dock strip.
+        if let edge = pendingStartupDock {
+            pendingStartupDock = nil
+            DispatchQueue.main.async { [weak self] in
+                self?.enterDockedMode(edge: edge, animated: false)
+            }
+        }
         UserDefaults.standard.set(true, forKey: Config.kPanelVisible)
     }
 
     func hide() {
+        // Stop the snap → dock state machine so the panel can't auto-dock
+        // while hidden.
+        snapTimer?.invalidate()
+        snapTimer = nil
+        if let obs = moveObserver {
+            NotificationCenter.default.removeObserver(obs)
+            moveObserver = nil
+        }
         panel?.orderOut(nil)
+        // Hiding always clears the dock memory — there's no "hidden but
+        // docked" semantic, the next show starts fresh from prefs.dockEdge.
+        prefs.dockEdge = nil
+        state = .expanded
+        savedExpandedFrame = nil
         UserDefaults.standard.set(false, forKey: Config.kPanelVisible)
+    }
+
+    /// Push the current visible-ring count down to the panel as a min-size
+    /// floor. No-op if the panel isn't shown yet (it'll fire on first show()).
+    private func applyMinSize() {
+        guard let panel else { return }
+        panel.updateMinSize(forVisibleRings: shownCount)
+    }
+
+    // MARK: - Snap + dock state machine
+    //
+    // Watch NSWindow.didMoveNotification and decide what to do:
+    //   - panel near a screen edge  → snap flush to that edge, start 240ms
+    //     timer to commit a dock.
+    //   - panel moved away from edge → if we were snapped/docked, expand
+    //     back to the saved expanded frame.
+    //   - panel already docked      → any move = expand (user grabbed the
+    //     strip to undock).
+
+    private func installMoveObserver(on panel: DraggablePanel) {
+        // Tear down a prior observer in case show() is called twice without
+        // a hide() (defensive — the typical path goes through hide() first).
+        if let obs = moveObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+        moveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            // Bounce onto MainActor — the observer fires on the main queue
+            // already, but the controller is @MainActor and the closure is
+            // not, so a Task hop keeps Swift's actor isolation happy.
+            Task { @MainActor in self?.handlePanelMoved() }
+        }
+    }
+
+    private enum EdgeDetection { case far; case near(DockEdge) }
+
+    private func detectNearestEdge(panel: NSPanel) -> EdgeDetection {
+        guard let screen = panel.screen ?? NSScreen.main else { return .far }
+        let v = screen.visibleFrame
+        let f = panel.frame
+        let dLeft = f.minX - v.minX
+        let dRight = v.maxX - f.maxX
+        let dTop = v.maxY - f.maxY
+        let dBottom = f.minY - v.minY
+        // We pick the SMALLEST non-negative distance (any negative means
+        // the panel is past the visible frame; treat as already at edge).
+        let ds = [dLeft, dRight, dTop, dBottom]
+        let minD = ds.min() ?? .greatestFiniteMagnitude
+        guard minD < Self.snapThreshold else { return .far }
+        let edges: [DockEdge] = [.left, .right, .top, .bottom]
+        let edge = edges[ds.firstIndex(of: minD) ?? 0]
+        return .near(edge)
+    }
+
+    private func handlePanelMoved() {
+        guard let panel else { return }
+        let detection = detectNearestEdge(panel: panel)
+        switch detection {
+        case .far:
+            // Dragged away from the edge. Snap + dock collapse back to HUD.
+            switch state {
+            case .expanded:
+                snapTimer?.invalidate(); snapTimer = nil
+            case .snapped, .docked:
+                expandFromDock(animated: true)
+            }
+        case .near(let edge):
+            switch state {
+            case .expanded:
+                // First time near an edge — remember the frame so we can
+                // restore on expand, then snap + start the dock timer.
+                savedExpandedFrame = panel.frame
+                state = .snapped(edge)
+                animateSnap(to: edge, panel: panel)
+                scheduleDockTimer(for: edge)
+            case .snapped(let prev):
+                if prev != edge {
+                    // Switched edges mid-snap — re-snap, reset timer.
+                    state = .snapped(edge)
+                    animateSnap(to: edge, panel: panel)
+                    scheduleDockTimer(for: edge)
+                } else {
+                    // Same edge, just fidgeting — keep the snap, reset the
+                    // dock timer so 240ms of stillness commits the dock.
+                    scheduleDockTimer(for: edge)
+                }
+            case .docked:
+                // User grabbed the docked strip and dragged — pop back to
+                // expanded immediately. The next edge detection re-arms.
+                expandFromDock(animated: true)
+            }
+        }
+    }
+
+    // MARK: - Snap animation
+
+    /// Animate the panel flush against the given screen edge. Y origin is
+    /// preserved on left/right (only X moves); X origin is preserved on
+    /// top/bottom (only Y moves). The user keeps their dragged position
+    /// along the long axis.
+    private func animateSnap(to edge: DockEdge, panel: NSPanel) {
+        guard let screen = panel.screen ?? NSScreen.main else { return }
+        let v = screen.visibleFrame
+        let f = panel.frame
+        let target: NSRect
+        switch edge {
+        case .left:   target = NSRect(x: v.minX,           y: f.minY, width: f.width, height: f.height)
+        case .right:  target = NSRect(x: v.maxX - f.width, y: f.minY, width: f.width, height: f.height)
+        case .top:    target = NSRect(x: f.minX, y: v.maxY - f.height, width: f.width, height: f.height)
+        case .bottom: target = NSRect(x: f.minX, y: v.minY,           width: f.width, height: f.height)
+        }
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = Self.snapAnimationDuration
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().setFrame(target, display: true)
+        }
+    }
+
+    private func scheduleDockTimer(for edge: DockEdge) {
+        snapTimer?.invalidate()
+        snapTimer = Timer.scheduledTimer(withTimeInterval: Self.dockDelay,
+                                         repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.commitDockIfSnapped(edge: edge) }
+        }
+    }
+
+    private func commitDockIfSnapped(edge: DockEdge) {
+        guard case .snapped(let e) = state, e == edge else { return }
+        enterDockedMode(edge: edge, animated: true)
+    }
+
+    // MARK: - Dock mode
+
+    /// Transition the panel into `.docked(edge)` — collapse to 36pt strip,
+    /// swap the SwiftUI root to DockStripView, and persist the edge. Called
+    /// by the snap timer (animated) and at launch when restoring dock.
+    private func enterDockedMode(edge: DockEdge, animated: Bool) {
+        guard let panel else { return }
+        snapTimer?.invalidate(); snapTimer = nil
+        state = .docked(edge)
+        prefs.dockEdge = edge
+        swapContentToDockStrip(for: edge)
+        let target = makeDockFrame(for: edge, base: panel.frame)
+        // Lock the panel to the strip thickness so the user can't drag it
+        // wider from a docked handle. Expanded mode restores the proper min
+        // in expandFromDock().
+        panel.minSize = NSSize(width: Self.stripThickness, height: Self.stripThickness)
+        panel.contentMinSize = panel.minSize
+        if animated {
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = Self.dockAnimationDuration
+                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                panel.animator().setFrame(target, display: true)
+            }
+        } else {
+            panel.setFrame(target, display: true)
+        }
+    }
+
+    /// Restore the panel to `.expanded` at the saved frame. The saved frame
+    /// is cleared so the NEXT dock round-trip captures the new position.
+    private func expandFromDock(animated: Bool) {
+        guard let panel else { return }
+        snapTimer?.invalidate(); snapTimer = nil
+        // If we were never saved (e.g. direct dock from launch), fall back
+        // to the current frame so the panel doesn't teleport to stale state.
+        let target = savedExpandedFrame ?? panel.frame
+        state = .expanded
+        prefs.dockEdge = nil
+        swapContentToGaugeRow()
+        // Restore the proper min size for the user's current ring count.
+        panel.updateMinSize(forVisibleRings: shownCount)
+        savedExpandedFrame = nil
+        if animated {
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = Self.dockAnimationDuration
+                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                panel.animator().setFrame(target, display: true)
+            }
+        } else {
+            panel.setFrame(target, display: true)
+        }
+    }
+
+    /// Frame a docked panel should occupy: flush to the edge, with the
+    /// strip thickness on the cross axis. Long axis (height for left/right,
+    /// width for top/bottom) keeps the user's snap-time size.
+    private func makeDockFrame(for edge: DockEdge, base: NSRect) -> NSRect {
+        guard let screen = panel?.screen ?? NSScreen.main else { return base }
+        let v = screen.visibleFrame
+        let t = Self.stripThickness
+        switch edge {
+        case .left:   return NSRect(x: v.minX,           y: base.minY, width: t, height: base.height)
+        case .right:  return NSRect(x: v.maxX - t,       y: base.minY, width: t, height: base.height)
+        case .top:    return NSRect(x: base.minX, y: v.maxY - t,       width: base.width, height: t)
+        case .bottom: return NSRect(x: base.minX, y: v.minY,           width: base.width, height: t)
+        }
+    }
+
+    // MARK: - Content swap (HUD ↔ dock strip)
+    //
+    // We rebuild the SwiftUI hosting view because the SwiftUI root differs
+    // (GaugeRowView vs DockStripView). The 8 ResizeHandle subviews stay —
+    // we just re-stack them on top of the new host so hit-testing still
+    // works on the edges.
+
+    private func swapContentToDockStrip(for edge: DockEdge) {
+        guard let panel, let host = panel.contentView else { return }
+        // Remove the existing hosting view; keep the resize handles.
+        host.subviews
+            .filter { !($0 is ResizeHandle) }
+            .forEach { $0.removeFromSuperview() }
+        let root = DockStripView(store: store, prefs: prefs, edge: edge) { [weak self] in
+            Task { @MainActor in self?.expandFromDock(animated: true) }
+        }
+        let hosting = NSHostingView(rootView: root)
+        hosting.frame = host.bounds
+        hosting.autoresizingMask = [.width, .height]
+        host.addSubview(hosting)
+        // Bring resize handles to the front (z-order) so they win edge hits.
+        panel.reinstallResizeHandles()
+    }
+
+    private func swapContentToGaugeRow() {
+        guard let panel, let host = panel.contentView else { return }
+        host.subviews
+            .filter { !($0 is ResizeHandle) }
+            .forEach { $0.removeFromSuperview() }
+        let root = GaugeRowView(store: store, prefs: prefs, expandToFill: true)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        let hosting = NSHostingView(rootView: root)
+        hosting.layer?.cornerRadius = 14
+        hosting.frame = host.bounds
+        hosting.autoresizingMask = [.width, .height]
+        host.addSubview(hosting)
+        panel.reinstallResizeHandles()
     }
 }

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -55,6 +55,10 @@ struct GaugeRowView: View {
         let rowSpacing: CGFloat = isTall ? 10 : 16
         let padding: CGFloat = 28
         // Chrome above (header) + below (label) the ring within each cell.
+        // 22 (header row including dot) + 38 (3-line label VStack at 12/10/10)
+        // + 12 (top→rings spacing) = 72. Real chrome in production = ~78 with
+        // 14pt top padding. We keep the under-estimate so 3-ring vertical
+        // mode still grows the ring at the panel's true min height.
         let verticalChrome: CGFloat = 22 + 38 + 12
         let perRingW = max(0, (w - padding - rowSpacing * CGFloat(n - 1)) / CGFloat(n))
         let rowsHeight = max(0, h - verticalChrome)
@@ -64,8 +68,9 @@ struct GaugeRowView: View {
         let maxFromHeight = max(0, perRowH - 38 - 7)   // label + VStack spacing
         let raw = min(perRingW, maxFromHeight)
         // Floor: when the panel is too narrow for n rings at minRing, fall
-        // back to whatever fits so the user can see all rings even at 220pt.
-        let effectiveMin = max(32, min(minRing,
+        // back to whatever fits. 36pt keeps the label captions legible (the
+        // 3-line label VStack needs ~38pt to render at full size).
+        let effectiveMin = max(36, min(minRing,
                                        (w - padding) / CGFloat(n) - rowSpacing))
         return min(max(raw, effectiveMin), maxRing)
     }

--- a/Sources/KajiGauge/Prefs.swift
+++ b/Sources/KajiGauge/Prefs.swift
@@ -25,11 +25,15 @@ final class Prefs: ObservableObject {
     @Published var menubarStyle: MenubarStyle {
         didSet { UserDefaults.standard.set(menubarStyle.rawValue, forKey: Key.menubarStyle) }
     }
+    @Published var dockEdge: DockEdge? {
+        didSet { UserDefaults.standard.set(dockEdge?.rawValue, forKey: Key.dockEdge) }
+    }
 
     enum Key {
         static let visibleProviders = "visibleProviders"
         static let language = "language"
         static let menubarStyle = "menubarStyle"
+        static let dockEdge = "panelDockEdge"
     }
 
     init() {
@@ -48,6 +52,13 @@ final class Prefs: ObservableObject {
             menubarStyle = s
         } else {
             menubarStyle = .mono                    // quiet + native by default
+        }
+        // dockEdge defaults to nil (panel is expanded). Restore the persisted
+        // edge (if any) so the next launch can dock straight from restore().
+        if let raw = d.string(forKey: Key.dockEdge), let e = DockEdge(rawValue: raw) {
+            dockEdge = e
+        } else {
+            dockEdge = nil
         }
     }
 
@@ -79,6 +90,16 @@ enum Lang: String {
     var label: String { self == .en ? "EN" : "\u{4E2D}\u{6587}" }   // 中文
 }
 
+// MARK: - Dock edge
+//
+// Which screen edge the floating HUD is currently snapped + docked to. nil
+// means "expanded" (the regular floating panel). Persisted so the app comes
+// back up in the same state — close the lid, open it next morning, panel
+// is still where you left it.
+enum DockEdge: String, CaseIterable {
+    case left, right, top, bottom
+}
+
 // MARK: - Menu-bar style
 
 enum MenubarStyle: String {
@@ -99,6 +120,7 @@ enum L10n {
         case floatPanel, hidePanel, showPanel
         case refreshNow, quitApp, language, providers, show
         case menubar, styleMono, styleColor
+        case dockExpand, dockHint
     }
 
     private static let table: [K: (en: String, zh: String)] = [
@@ -118,6 +140,8 @@ enum L10n {
         .menubar:      ("Menu bar",           "\u{83DC}\u{5355}\u{680F}"),                 // 菜单栏
         .styleMono:    ("Mono",               "\u{9ED1}\u{767D}"),                         // 黑白
         .styleColor:   ("Color",              "\u{5F69}\u{8272}"),                         // 彩色
+        .dockExpand:   ("tap to expand",      "\u{70B9}\u{51FB}\u{5C55}\u{5F00}"),         // 点击展开
+        .dockHint:     ("drag to undock",     "\u{62D6}\u{52A8}\u{5C55}\u{5F00}"),         // 拖动展开
     ]
 
     static func t(_ k: K, _ lang: Lang) -> String {

--- a/Sources/KajiGauge/QuotaStore.swift
+++ b/Sources/KajiGauge/QuotaStore.swift
@@ -21,6 +21,7 @@ enum Config {
     // UserDefaults keys.
     static let kQuotaScriptPath = "quotaScriptPath"
     static let kPanelVisible    = "panelVisible"
+    static let kPanelDockEdge   = "panelDockEdge"  // "left" | "right" | "top" | "bottom"
     static let kSparkHistory    = "sparklineHistory" // [providerKey: [Double]]
 }
 


### PR DESCRIPTION
- Dynamic min size by visible-ring count (1: 200x130, 2: 280x130,
  3+ vertical: 200x280). Driven by Combine sinks on store/providers
  and prefs/visibleProviders.
- ResizeHandle hit zone 10pt -> 16pt, with always-visible 1.5pt track
  line (theme-aware: dark 0x3A3026, light 0xE2D8C6) and 2.5pt gold on
  hover. Corners render L-shape to mark them.
- QQ-style edge dock: 4 sides, 36pt strip, 14pt snap threshold,
  240ms snap timer, persisted in UserDefaults. DockStripView shows
  mostConstrained provider logo + 5h % + countdown (rotated 90 deg
  on left/right, horizontal on top/bottom). Tap = expand, drag = undock.
- Startup restore: if prefs.dockEdge set on show(), enterDockedMode
  fires on next runloop with no animation.
