### PR TITLE
feat: curved dock handle + used/remaining toggle

### DIFF
--- a/Sources/KajiGauge/AppDelegate.swift
+++ b/Sources/KajiGauge/AppDelegate.swift
@@ -166,6 +166,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         styleItem.submenu = styleMenu
         menu.addItem(styleItem)
 
+        // Usage submenu (Used / Remaining), radio-checked. Mirrors the popover
+        // footer segment so the same mode can be flipped without opening the
+        // popover (right-clicking the menubar glyph is faster).
+        let usageItem = NSMenuItem(title: L10n.t(.usage, lang), action: nil, keyEquivalent: "")
+        let usageMenu = NSMenu()
+        let usedItem = NSMenuItem(title: L10n.t(.showUsed, lang),
+                                  action: #selector(setShowUsed), keyEquivalent: "")
+        usedItem.target = self
+        usedItem.state = prefs.showRemaining ? .off : .on
+        usageMenu.addItem(usedItem)
+        let remItem = NSMenuItem(title: L10n.t(.showRemaining, lang),
+                                 action: #selector(setShowRemaining), keyEquivalent: "")
+        remItem.target = self
+        remItem.state = prefs.showRemaining ? .on : .off
+        usageMenu.addItem(remItem)
+        usageItem.submenu = usageMenu
+        menu.addItem(usageItem)
+
         // Language toggle — shows the OTHER language as the action label.
         let langItem = NSMenuItem(title: "\(L10n.t(.language, lang)): \(lang.toggled.label)",
                                   action: #selector(toggleLanguage),
@@ -219,6 +237,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func setMenubarColor() {
         prefs.menubarStyle = .color
+    }
+
+    @objc private func setShowUsed() {
+        prefs.showRemaining = false
+    }
+
+    @objc private func setShowRemaining() {
+        prefs.showRemaining = true
     }
 
     @objc private func toggleLanguage() {

--- a/Sources/KajiGauge/DockStripView.swift
+++ b/Sources/KajiGauge/DockStripView.swift
@@ -3,16 +3,17 @@ import SwiftUI
 // MARK: - DockStripView
 //
 // The visual shown when the floating HUD is `.docked` against a screen edge.
-// A 36pt thin strip with the mostConstrained provider's logo + 5h percentage
-// + reset countdown, so the user keeps an at-a-glance read of their tightest
-// quota even with the panel collapsed out of the way.
+// A 36pt thin strip hosting:
+//   - the mostConstrained provider's logo + 5h % + reset countdown, on the
+//     SCREEN-edge side of the strip.
+//   - a curved handle ("ear") on the PANEL-facing side, with a chevron
+//     pointing the way the panel will unfold. Click handle (or anywhere on
+//     the strip) → `onExpand()`.
 //
-// The strip rotates the content 90° on left/right docks so reading flows
-// top→bottom (matches QQ-style edge docks). On top/bottom the strip is short
-// + wide and reads horizontally (no rotation).
-//
-// Tap or hover the strip → `onExpand()` fires; the controller animates the
-// panel back to its saved expanded frame.
+// Layout is done natively via HStack / VStack — no rotation. The strip's
+// long axis (height for left/right docks, width for top/bottom docks) is laid
+// out the way the eye reads it, so the chevron + percent text never need
+// a transform.
 struct DockStripView: View {
     @ObservedObject var store: QuotaStore
     @ObservedObject var prefs: Prefs
@@ -30,47 +31,59 @@ struct DockStripView: View {
     }
 
     var body: some View {
-        // The frame is set by the controller (panel width/height after snap).
-        // Content is rotated on left/right edges so the strip reads top-down.
-        ZStack {
-            background
-            content
-                .rotationEffect(rotation, anchor: .center)
+        // Handle sits on the PANEL-facing side, content on the SCREEN-edge
+        // side. No rotation — the long axis is laid out natively.
+        Group {
+            switch edge {
+            case .left:
+                HStack(spacing: 0) { handle; content }
+            case .right:
+                HStack(spacing: 0) { content; handle }
+            case .top:
+                VStack(spacing: 0) { handle; content }
+            case .bottom:
+                VStack(spacing: 0) { content; handle }
+            }
         }
-        .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .background(stripBg)
+        .overlay(stripOutline)
+        .clipShape(stripShape)
+        .contentShape(stripShape)
         .onTapGesture(perform: onExpand)
     }
 
-    // MARK: Background chrome
+    // MARK: Background + shape
 
-    private var background: some View {
-        ZStack {
-            // Same warm paper/ink gradient as the full HUD so the docked
-            // strip doesn't look like a foreign object on the desktop.
-            LinearGradient(
-                colors: [t.bgTop, t.bg],
-                startPoint: .topTrailing, endPoint: .bottomLeading
-            )
-            // 1pt gold outline — matches the HUD's accent ring so docked
-            // mode reads as a continuation, not a separate widget.
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(t.gold.opacity(0.55), lineWidth: 1)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    private var stripBg: some View {
+        // Same warm paper/ink gradient as the full HUD so the docked strip
+        // doesn't look like a foreign object on the desktop.
+        LinearGradient(
+            colors: [t.bgTop, t.bg],
+            startPoint: .topTrailing, endPoint: .bottomLeading
+        )
     }
 
-    // MARK: Content
+    private var stripOutline: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .stroke(t.gold.opacity(0.55), lineWidth: 1)
+    }
+
+    /// Capsule on both ends — the panel-facing edge already curves gracefully,
+    /// and the dedicated handle View on top of it pops as the affordance.
+    private var stripShape: some Shape {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+    }
+
+    // MARK: Content (logo + % + countdown)
 
     private var content: some View {
-        // VStack along the strip's long axis (will be rotated for left/right).
-        // Spacing is tight — the strip is 36pt wide so we have ~30pt usable.
         VStack(spacing: 3) {
             logo
             percentLabel
             countdownLabel
         }
-        .padding(.horizontal, 4)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 8)
     }
 
     @ViewBuilder
@@ -85,8 +98,9 @@ struct DockStripView: View {
 
     private var percentLabel: some View {
         let text: String = {
-            guard let p = provider, let pct = p.fiveHourPercent else { return "—" }
-            return "\(Int(pct.rounded()))%"
+            guard let p = provider, let raw = p.fiveHourPercent else { return "—" }
+            let shown = prefs.showRemaining ? (100 - raw) : raw
+            return "\(Int(shown.rounded()))%"
         }()
         return Text(text)
             .font(.system(size: 12.5, weight: .semibold, design: .rounded))
@@ -104,7 +118,7 @@ struct DockStripView: View {
     }
 
     /// "5h12m" or "12m" or "" when no data. Matches the menubar's compact
-    /// style — short enough to fit a rotated 36pt strip without truncation.
+    /// style — short enough to fit a 36pt strip without truncation.
     private var countdownText: String {
         guard let p = provider, let reset = p.resetDate else { return "·" }
         let secs = max(0, Int(reset.timeIntervalSinceNow))
@@ -114,15 +128,47 @@ struct DockStripView: View {
         return h > 0 ? "\(h)h\(m)m" : "\(m)m"
     }
 
-    // MARK: Rotation
+    // MARK: Handle (panel-facing side)
 
-    /// Left/right docks rotate content 90° so the strip reads top→bottom;
-    /// top/bottom docks keep horizontal reading.
-    private var rotation: Angle {
+    /// Curved pill on the inner side of the strip. The chevron points the
+    /// way the panel will unfold. Has its own gold-tinted backdrop so it
+    /// visually pops as "this is the button" against the warm-paper strip.
+    /// The whole strip is also tappable as a fallback.
+    private var handle: some View {
+        ZStack {
+            Capsule(style: .continuous)
+                .fill(t.gold.opacity(0.18))
+                .overlay(Capsule(style: .continuous)
+                    .stroke(t.gold.opacity(0.7), lineWidth: 1))
+            Image(systemName: chevronName)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(t.gold)
+        }
+        .frame(width: handleSize.width, height: handleSize.height)
+        .padding(3)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onExpand)
+    }
+
+    /// Tall thin pill on left/right docks, short wide pill on top/bottom.
+    /// Sized so it reads as a "tab" inside the strip without competing with
+    /// the logo / percentage content.
+    private var handleSize: CGSize {
         switch edge {
-        case .left:   return .degrees(90)
-        case .right:  return .degrees(-90)
-        case .top, .bottom: return .degrees(0)
+        case .left, .right:
+            return CGSize(width: 14, height: 44)
+        case .top, .bottom:
+            return CGSize(width: 44, height: 14)
+        }
+    }
+
+    /// Chevron points WHERE the panel will unfold toward when the user clicks.
+    private var chevronName: String {
+        switch edge {
+        case .left:   return "chevron.right"   // panel unrolls to the right
+        case .right:  return "chevron.left"    // panel unrolls to the left
+        case .top:    return "chevron.down"    // panel unrolls down
+        case .bottom: return "chevron.up"      // panel unrolls up
         }
     }
 }

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -170,10 +170,11 @@ final class DraggablePanel: NSPanel {
 // MARK: - ResizeHandle
 //
 // An NSView that owns one of the eight panel edges/corners. The hit zone is
-// 16pt wide; visually we draw a 1.5pt track line on the INNER edge (toward
-// the panel center) so the user can see "here is the grab zone" without the
-// chrome competing with the SwiftUI content. On hover the track thickens to
-// 2.5pt and switches to the Kaji gold so the affordance is unmistakable.
+// 16pt wide. Cursor changes on enter so the user reads the affordance from
+// the cursor shape alone — we deliberately paint NOTHING here, so the chrome
+// stays out of the way of the SwiftUI content. Earlier iterations drew a 1.5pt
+// track + a gold hover line; both were dropped after user feedback said they
+// felt more like glitches than affordances.
 final class ResizeHandle: NSView {
     enum Kind {
         case topLeft, topRight, bottomLeft, bottomRight
@@ -185,33 +186,13 @@ final class ResizeHandle: NSView {
     private var startSize: NSSize = .zero
     private var startFrame: NSRect = .zero
 
-    /// Hover state — set by the tracking area, read by draw(_:). The view
-    /// repaints on every change so the line thickens + recolors smoothly.
-    private var hovered = false
-
-    /// Idle track + hover gold, resolved once per scheme. We keep both modes
-    /// (light + dark) so theme switches in macOS Auto just trigger a redraw.
-    private static let trackDark  = NSColor(srgbRed: 0x3A/255, green: 0x30/255, blue: 0x26/255, alpha: 0.60)
-    private static let trackLight = NSColor(srgbRed: 0xE2/255, green: 0xD8/255, blue: 0xC6/255, alpha: 0.70)
-    private static let goldDark   = NSColor(srgbRed: 0xD8/255, green: 0xA6/255, blue: 0x57/255, alpha: 1.0)
-    private static let goldLight  = NSColor(srgbRed: 0xF2/255, green: 0x5C/255, blue: 0x05/255, alpha: 1.0)
-
     init(kind: Kind, panel: NSPanel) {
         self.kind = kind
         self.panel = panel
         super.init(frame: .zero)
-        // Transparent base — the visual is purely the inner-edge track line.
+        // Transparent — cursor change is the only affordance.
         wantsLayer = true
         layer?.backgroundColor = .clear
-        // Add the tracking area so mouseEntered/Exited fire while we're in
-        // the key window. The handle sits above the SwiftUI host so we own
-        // the hover events; the rest of the panel doesn't trigger us.
-        addTrackingArea(NSTrackingArea(
-            rect: bounds,
-            options: [.activeInKeyWindow, .mouseEnteredAndExited, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        ))
     }
     required init?(coder: NSCoder) { fatalError() }
 
@@ -227,68 +208,8 @@ final class ResizeHandle: NSView {
         addCursorRect(bounds, cursor: cursor())
     }
 
-    override func mouseEntered(with event: NSEvent) {
-        hovered = true
-        needsDisplay = true
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        hovered = false
-        needsDisplay = true
-    }
-
     override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let color: NSColor
-        if hovered {
-            color = isDark ? Self.goldDark : Self.goldLight
-        } else {
-            color = isDark ? Self.trackDark : Self.trackLight
-        }
-        let lineWidth: CGFloat = hovered ? 2.5 : 1.5
-        let path = NSBezierPath()
-        path.lineWidth = lineWidth
-        path.lineCapStyle = .round
-
-        // Inset the line by half the stroke so it stays inside our bounds;
-        // the cursor rect covers the full 16pt zone regardless.
-        let inset: CGFloat = lineWidth / 2
-        let b = bounds
-        switch kind {
-        case .top:
-            // Horizontal line near the bottom of the top handle (= inner edge).
-            path.move(to: NSPoint(x: inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
-        case .bottom:
-            path.move(to: NSPoint(x: inset, y: b.maxY - inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
-        case .left:
-            path.move(to: NSPoint(x: inset, y: inset))
-            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
-        case .right:
-            path.move(to: NSPoint(x: b.maxX - inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
-        case .topLeft:
-            // L-shape: vertical leg (inner edge) + horizontal leg (inner edge).
-            path.move(to: NSPoint(x: inset, y: b.maxY - inset))
-            path.line(to: NSPoint(x: inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
-        case .topRight:
-            path.move(to: NSPoint(x: inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
-        case .bottomLeft:
-            path.move(to: NSPoint(x: inset, y: inset))
-            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
-        case .bottomRight:
-            path.move(to: NSPoint(x: b.maxX - inset, y: inset))
-            path.line(to: NSPoint(x: b.maxX - inset, y: b.maxY - inset))
-            path.line(to: NSPoint(x: inset, y: b.maxY - inset))
-        }
-        color.setStroke()
-        path.stroke()
+        // Intentional no-op — see file header.
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -114,6 +114,7 @@ struct GaugeRowView: View {
                         LazyVStack(alignment: .leading, spacing: 10) {
                             ForEach(shown) { provider in
                                 RingGauge(provider: provider, lang: prefs.language,
+                                          showRemaining: prefs.showRemaining,
                                           ringSize: size)
                             }
                         }
@@ -122,6 +123,7 @@ struct GaugeRowView: View {
                         HStack(alignment: .top, spacing: 16) {
                             ForEach(shown) { provider in
                                 RingGauge(provider: provider, lang: prefs.language,
+                                          showRemaining: prefs.showRemaining,
                                           ringSize: size)
                             }
                         }
@@ -133,6 +135,7 @@ struct GaugeRowView: View {
             HStack(alignment: .top, spacing: 16) {
                 ForEach(shown) { provider in
                     RingGauge(provider: provider, lang: prefs.language,
+                              showRemaining: prefs.showRemaining,
                               ringSize: defaultRing)
                 }
             }
@@ -176,6 +179,22 @@ struct GaugeRowView: View {
                 }
                 segment(L10n.t(.styleColor, prefs.language), on: prefs.menubarStyle == .color) {
                     prefs.menubarStyle = .color
+                }
+            }
+
+            // Usage row: show 5h as USED vs REMAINING. Defaults to USED, which
+            // matches the historical ring direction; REMAINING reads "0% means
+            // full" with a reversed trim. The dock strip + menubar follow along.
+            HStack(spacing: 7) {
+                Text(L10n.t(.usage, prefs.language))
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundColor(t.mute)
+                Spacer(minLength: 8)
+                segment(L10n.t(.showUsed, prefs.language), on: !prefs.showRemaining) {
+                    prefs.showRemaining = false
+                }
+                segment(L10n.t(.showRemaining, prefs.language), on: prefs.showRemaining) {
+                    prefs.showRemaining = true
                 }
             }
 

--- a/Sources/KajiGauge/Prefs.swift
+++ b/Sources/KajiGauge/Prefs.swift
@@ -28,12 +28,19 @@ final class Prefs: ObservableObject {
     @Published var dockEdge: DockEdge? {
         didSet { UserDefaults.standard.set(dockEdge?.rawValue, forKey: Key.dockEdge) }
     }
+    /// Show the 5h percentage as USED (default, "100% means full") vs
+    /// REMAINING ("0% means full"). Persisted; the toggle lives in both the
+    /// popover footer segment and the right-click menu on the status item.
+    @Published var showRemaining: Bool {
+        didSet { UserDefaults.standard.set(showRemaining, forKey: Key.showRemaining) }
+    }
 
     enum Key {
         static let visibleProviders = "visibleProviders"
         static let language = "language"
         static let menubarStyle = "menubarStyle"
         static let dockEdge = "panelDockEdge"
+        static let showRemaining = "showRemaining"
     }
 
     init() {
@@ -59,6 +66,13 @@ final class Prefs: ObservableObject {
             dockEdge = e
         } else {
             dockEdge = nil
+        }
+        // Default to showing USED — matches what the rings always did and
+        // avoids surprising existing users on first launch after upgrade.
+        if d.object(forKey: Key.showRemaining) != nil {
+            showRemaining = d.bool(forKey: Key.showRemaining)
+        } else {
+            showRemaining = false
         }
     }
 
@@ -121,6 +135,7 @@ enum L10n {
         case refreshNow, quitApp, language, providers, show
         case menubar, styleMono, styleColor
         case dockExpand, dockHint
+        case usage, showUsed, showRemaining
     }
 
     private static let table: [K: (en: String, zh: String)] = [
@@ -142,6 +157,9 @@ enum L10n {
         .styleColor:   ("Color",              "\u{5F69}\u{8272}"),                         // 彩色
         .dockExpand:   ("tap to expand",      "\u{70B9}\u{51FB}\u{5C55}\u{5F00}"),         // 点击展开
         .dockHint:     ("drag to undock",     "\u{62D6}\u{52A8}\u{5C55}\u{5F00}"),         // 拖动展开
+        .usage:        ("Usage",              "\u{7528}\u{91CF}"),                         // 用量
+        .showUsed:     ("Used",               "\u{5DF2}\u{7528}"),                         // 已用
+        .showRemaining:("Remaining",          "\u{5269}\u{4F59}"),                         // 剩余
     ]
 
     static func t(_ k: K, _ lang: Lang) -> String {

--- a/Sources/KajiGauge/QuotaStore.swift
+++ b/Sources/KajiGauge/QuotaStore.swift
@@ -7,7 +7,7 @@ enum Config {
     /// shipped .app uses the self-contained copy bundled in Contents/Resources
     /// (see `QuotaStore.scriptPath`); end users never need this path.
     static let defaultQuotaScriptPath =
-        "/Users/tangyinghao/workspace/helm-terminal/tools/helm-quota/quota.py"
+        "/Users/tangyinghao/workspace/kaji/tools/helm-quota/quota.py"
 
     /// python3 interpreter. We rely on PATH resolution via /usr/bin/env.
     static let pythonInterpreter = "python3"

--- a/Sources/KajiGauge/RingGauge.swift
+++ b/Sources/KajiGauge/RingGauge.swift
@@ -9,9 +9,16 @@ import SwiftUI
 //   - Below: the provider NAME, then two captions — the 5h reset countdown and
 //     "7d {week}% · {reset}" — so "how long until reset" is answered for BOTH
 //     windows right here in the popover. Localized EN / 中文.
+//
+// `showRemaining` flips BOTH the ring trim direction (1-usedFraction) and the
+// center % text (100-used) — "0% means full" instead of "100% means full".
+// The "near limit" threshold is ALWAYS based on USED, so an empty (remaining
+// 100%) ring never reads as amber; a low-remaining ring always does.
 struct RingGauge: View {
     let provider: ProviderView
     var lang: Lang = .en
+    /// When true, the ring + % read as REMAINING (100% used → empty ring + 0%).
+    var showRemaining: Bool = false
 
     /// Outer ring diameter. Scales the ring + the logo + the big % together so
     /// the visual mass stays proportional when the floating HUD is resized.
@@ -28,6 +35,9 @@ struct RingGauge: View {
     private var logoSize: CGFloat      { ringSize * (16.0 / 84.0) }
     private var percentFont: CGFloat   { ringSize * (22.0 / 84.0) }
 
+    /// "Near limit" is always USED-based regardless of display direction —
+    /// we don't want the ring color to flip just because the user toggled
+    /// between used/remaining. (>=80% used = amber in both modes.)
     private var arcColor: Color { provider.isNearLimit ? t.amber : t.gold }
     private var weekColor: Color { provider.weekNearLimit ? t.amber : t.gold.opacity(0.55) }
 
@@ -35,9 +45,21 @@ struct RingGauge: View {
         provider.isNearLimit ? baseLineWidth + (ringSize * (3.0 / 84.0)) : baseLineWidth
     }
 
+    /// Fraction of the ring's TRIM, given the current display direction.
+    private var trimFraction: Double {
+        showRemaining ? 1.0 - provider.usedFraction : provider.usedFraction
+    }
+
+    /// 7-day inner ring, also direction-flipped for symmetry.
+    private var weekTrimFraction: Double {
+        showRemaining ? 1.0 - provider.weekFraction : provider.weekFraction
+    }
+
+    /// Center % text — shown as USED or REMAINING per the toggle.
     private var percentText: String {
         guard let p = provider.fiveHourPercent else { return "\u{2014}" }
-        return "\(Int(p.rounded()))"
+        let shown = showRemaining ? (100.0 - p) : p
+        return "\(Int(shown.rounded()))"
     }
 
     private var numberColor: Color { provider.isNearLimit ? t.amber : t.cream }
@@ -50,7 +72,7 @@ struct RingGauge: View {
                     .stroke(t.track.opacity(0.5),
                             style: StrokeStyle(lineWidth: baseLineWidth, lineCap: .round))
                 Circle()
-                    .trim(from: 0, to: provider.usedFraction)
+                    .trim(from: 0, to: trimFraction)
                     .stroke(arcColor,
                             style: StrokeStyle(lineWidth: valueLineWidth, lineCap: .round))
                     .rotationEffect(.degrees(-90))
@@ -61,7 +83,7 @@ struct RingGauge: View {
                             style: StrokeStyle(lineWidth: innerLineWidth, lineCap: .round))
                     .padding(innerInset)
                 Circle()
-                    .trim(from: 0, to: provider.weekFraction)
+                    .trim(from: 0, to: weekTrimFraction)
                     .stroke(weekColor,
                             style: StrokeStyle(lineWidth: innerLineWidth, lineCap: .round))
                     .rotationEffect(.degrees(-90))
@@ -82,7 +104,9 @@ struct RingGauge: View {
     }
 
     private var label: some View {
-        let week = provider.weekPercent.map { "\(Int($0.rounded()))%" } ?? "\u{2014}"
+        let weekRaw = provider.weekPercent
+        let weekDisplayed = weekRaw.map { showRemaining ? (100 - $0) : $0 }
+        let week = weekDisplayed.map { "\(Int($0.rounded()))%" } ?? "\u{2014}"
         let fiveReset = ResetFormat.phrase(provider.resetDate, lang)
         let weekReset = ResetFormat.phrase(provider.weekResetDate, lang)
         // When the ring is small, drop the "5h · " and "周 {n}% · " prefixes.


### PR DESCRIPTION
Four HUD polish items from user feedback:

- **Resize edge**: drop the always-visible track + gold hover line. User
  said both felt "more like glitches than affordances." Cursor change
  alone is the cue now; `ResizeHandle.draw(_:)` is an intentional no-op.

- **Dock strip**: rewrite `DockStripView` with a curved Capsule handle
  on the panel-facing side (gold tint, SF Symbol chevron pointing the
  unfold direction). Native HStack/VStack layout per edge — no
  rotation, chevron + % always read right-way-up. Handle + whole strip
  tappable → `onExpand()`.

- **Used / Remaining toggle**: new `Prefs.showRemaining` (persisted,
  default false = USED, backward compat). `RingGauge` flips outer +
  inner trim direction AND center % text when on. "Near limit" amber
  stays USED-based, so an empty (remaining 100%) ring never reads
  amber. Surfaces: dock-strip label, popover footer segment row,
  right-click "Usage" submenu. L10n: usage / showUsed / showRemaining.

- **Quota script path**: `Config.defaultQuotaScriptPath` updated
  `helm-terminal/tools/helm-quota/` → `kaji/tools/helm-quota/`. The
  bundled `Resources/quota.py` was already correct; the dev fallback
  path now resolves too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)