### PR TITLE
fix(v0.4.5): 3 surfaces show full provider set, list-row for narrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build/
+build/
 *.app
 .DS_Store
 dist/

--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.3</string>
+	<string>0.4.5</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/Sources/KajiGauge/DockStripView.swift
+++ b/Sources/KajiGauge/DockStripView.swift
@@ -4,16 +4,14 @@ import SwiftUI
 //
 // The visual shown when the floating HUD is `.docked` against a screen edge.
 // A 36pt thin strip hosting:
-//   - the mostConstrained provider's logo + 5h % + reset countdown, on the
-//     SCREEN-edge side of the strip.
+//   - one cell per VISIBLE provider (logo + 5h %) along the SCREEN-edge side.
 //   - a curved handle ("ear") on the PANEL-facing side, with a chevron
 //     pointing the way the panel will unfold. Click handle (or anywhere on
 //     the strip) → `onExpand()`.
 //
 // Layout is done natively via HStack / VStack — no rotation. The strip's
 // long axis (height for left/right docks, width for top/bottom docks) is laid
-// out the way the eye reads it, so the chevron + percent text never need
-// a transform.
+// out the way the eye reads it, so the chevron + cells never need a transform.
 struct DockStripView: View {
     @ObservedObject var store: QuotaStore
     @ObservedObject var prefs: Prefs
@@ -23,11 +21,12 @@ struct DockStripView: View {
     @Environment(\.colorScheme) private var scheme
     private var t: KajiTheme { .resolve(scheme) }
 
-    /// The provider currently closest to its 5h limit. Falls back to the
-    /// first available if none have data (we always show *something*).
-    private var provider: ProviderView? {
-        if let m = store.mostConstrained { return m }
-        return store.providers.first
+    /// All providers the user has chosen to show — we render one cell per
+    /// provider in the strip (the strip is long enough to fit them along its
+    /// long axis; cross axis stays 36pt). Order matches Providers.order so
+    /// Claude / Codex / MiniMax are visually consistent across surfaces.
+    private var providers: [ProviderView] {
+        store.providers.filter { prefs.isVisible($0.id) }
     }
 
     var body: some View {
@@ -74,58 +73,58 @@ struct DockStripView: View {
         RoundedRectangle(cornerRadius: 14, style: .continuous)
     }
 
-    // MARK: Content (logo + % + countdown)
+    // MARK: Content (all visible providers, one cell each)
 
+    /// All visible providers laid out along the strip's long axis:
+    /// - left/right dock (36pt wide): VStack of 3 cells, each ~24pt tall.
+    /// - top/bottom dock (36pt high): HStack of 3 cells, each ~24pt wide.
+    /// The cross axis is the strip's fixed 36pt thickness, so the cells stay
+    /// compact. Each cell is just a logo + the 5h % — the countdowns are
+    /// dropped here on purpose; the full HUD shows them on expand.
     private var content: some View {
-        VStack(spacing: 3) {
-            logo
-            percentLabel
-            countdownLabel
+        Group {
+            if providers.isEmpty {
+                // No providers yet — a tiny dot to mark the strip as ours.
+                Circle().fill(t.ash).frame(width: 5, height: 5)
+                    .padding(.vertical, 8)
+            } else {
+                switch edge {
+                case .left, .right:
+                    VStack(alignment: .center, spacing: 4) {
+                        ForEach(providers) { p in cell(p) }
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 6)
+                case .top, .bottom:
+                    HStack(alignment: .center, spacing: 8) {
+                        ForEach(providers) { p in cell(p) }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                }
+            }
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 8)
     }
 
-    @ViewBuilder
-    private var logo: some View {
-        if let p = provider {
-            ProviderLogo(key: p.id, color: t.cream, size: 13)
-        } else {
-            // No providers yet — a tiny dot to mark the strip as ours.
-            Circle().fill(t.ash).frame(width: 5, height: 5)
+    /// One compact cell: tiny provider logo on top, % below. Sized so 3 of
+    /// them stack along the long axis of a 36pt strip without crowding.
+    private func cell(_ p: ProviderView) -> some View {
+        VStack(spacing: 2) {
+            ProviderLogo(key: p.id, color: t.cream, size: 11)
+            Text(percentText(p))
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(p.isNearLimit ? t.amber : t.gold)
+                .monospacedDigit()
+                .lineLimit(1)
+                .fixedSize()  // don't shrink — readability wins in a 36pt strip
         }
+        .frame(minWidth: 22, minHeight: 24)
     }
 
-    private var percentLabel: some View {
-        let text: String = {
-            guard let p = provider, let raw = p.fiveHourPercent else { return "—" }
-            let shown = prefs.showRemaining ? (100 - raw) : raw
-            return "\(Int(shown.rounded()))%"
-        }()
-        return Text(text)
-            .font(.system(size: 12.5, weight: .semibold, design: .rounded))
-            .foregroundColor(t.gold)
-            .lineLimit(1)
-            .fixedSize()  // don't shrink — readability wins in a 36pt strip
-    }
-
-    private var countdownLabel: some View {
-        Text(countdownText)
-            .font(.system(size: 8.5, weight: .regular, design: .monospaced))
-            .foregroundColor(t.cream.opacity(0.55))
-            .lineLimit(1)
-            .fixedSize()
-    }
-
-    /// "5h12m" or "12m" or "" when no data. Matches the menubar's compact
-    /// style — short enough to fit a 36pt strip without truncation.
-    private var countdownText: String {
-        guard let p = provider, let reset = p.resetDate else { return "·" }
-        let secs = max(0, Int(reset.timeIntervalSinceNow))
-        if secs <= 0 { return "now" }
-        let h = secs / 3600
-        let m = (secs % 3600) / 60
-        return h > 0 ? "\(h)h\(m)m" : "\(m)m"
+    private func percentText(_ p: ProviderView) -> String {
+        guard let raw = p.fiveHourPercent else { return "\u{2014}" }
+        let shown = prefs.showRemaining ? (100 - raw) : raw
+        return "\(Int(shown.rounded()))%"
     }
 
     // MARK: Handle (panel-facing side)

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -302,8 +302,8 @@ final class ResizeHandle: NSView {
 //   - `.snapped(edge)` — the panel moved within 14pt of a screen edge and
 //     we animated it flush to the edge. Same content; just relocated.
 //   - `.docked(edge)` — 240ms of stillness after a snap collapsed the panel
-//     into a thin 36pt strip (mostConstrained provider's logo + %). Strip
-//     sits on the chosen edge. Hover or drag the strip → back to expanded.
+//     into a thin 36pt strip (one cell per visible provider: logo + 5h %).
+//     Strip sits on the chosen edge. Hover or drag the strip → back to expanded.
 enum PanelState {
     case expanded
     case snapped(DockEdge)

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -96,13 +96,15 @@ struct GaugeRowView: View {
     private var ringsRow: some View {
         if expandToFill {
             // GeometryReader drives both axis. Pick a layout that matches the
-            // panel's actual aspect: wide/short → HStack row; tall/narrow →
-            // LazyVStack (one ring per row) so label text never gets clipped.
+            // panel's actual aspect: wide/short → HStack of stacked rings;
+            // tall/narrow → list rows (ring left, text right) so the
+            // provider name NEVER truncates to "Clau" / "Cod" / "Mini".
             GeometryReader { geo in
                 let n = max(1, shown.count)
-                // Go tall when the row would overflow horizontally. 130 ≈
-                // minRing (64) + padding per slot + label width; if total
-                // slots > available width, wrap to one-per-row.
+                // Go list-mode when the row would overflow horizontally. A
+                // 3-ring stacked card needs ~130pt per slot (ring 84 + chrome
+                // + label width) — anything tighter goes to the list layout
+                // where the label gets the full panel width to breathe.
                 let slotNeeded: CGFloat = 130
                 let totalNeeded = slotNeeded * CGFloat(n) + 16 * CGFloat(n - 1) + 28
                 let isTall = n > 1 && geo.size.width < totalNeeded
@@ -113,9 +115,10 @@ struct GaugeRowView: View {
                     if isTall {
                         LazyVStack(alignment: .leading, spacing: 10) {
                             ForEach(shown) { provider in
-                                RingGauge(provider: provider, lang: prefs.language,
-                                          showRemaining: prefs.showRemaining,
-                                          ringSize: size)
+                                CompactRingRow(provider: provider,
+                                               lang: prefs.language,
+                                               showRemaining: prefs.showRemaining,
+                                               ringSize: 56)
                             }
                         }
                         .scrollDisabled(true)
@@ -321,5 +324,133 @@ struct GaugeRowView: View {
                 .multilineTextAlignment(.center)
         }
         .frame(minWidth: 180, minHeight: 96)
+    }
+}
+
+// MARK: - CompactRingRow
+//
+// List-row layout used by the floating HUD when it's been stretched tall +
+// narrow. Same product signature (concentric ring + logo + %), but the label
+// moves to the RIGHT of the ring instead of below it. Pattern after iStat
+// Menus / MonitorControl / Spotify compact card: [icon] + [text] horizontal,
+// so the text column gets the full panel width and names never truncate to
+// "Clau" / "Cod" / "Mini".
+//
+// Ring size stays fixed at 56pt here — the panel's vertical chrome math is
+// irrelevant in this layout (no label below the ring), so passing a stable
+// value keeps the geometry predictable regardless of how tall the user drags.
+private struct CompactRingRow: View {
+    let provider: ProviderView
+    var lang: Lang = .en
+    var showRemaining: Bool = false
+    var ringSize: CGFloat = 56
+
+    @Environment(\.colorScheme) private var scheme
+    private var t: KajiTheme { .resolve(scheme) }
+
+    // Same ring math as RingGauge, scaled by ringSize.
+    private var baseLineWidth: CGFloat { ringSize * (10.0 / 84.0) }
+    private var innerLineWidth: CGFloat { ringSize * (5.0 / 84.0) }
+    private var innerInset: CGFloat    { ringSize * (13.0 / 84.0) }
+    private var logoSize: CGFloat      { ringSize * (16.0 / 84.0) }
+    private var percentFont: CGFloat   { ringSize * (22.0 / 84.0) }
+
+    private var arcColor: Color { provider.isNearLimit ? t.amber : t.gold }
+    private var weekColor: Color { provider.weekNearLimit ? t.amber : t.gold.opacity(0.55) }
+    private var valueLineWidth: CGFloat {
+        provider.isNearLimit ? baseLineWidth + (ringSize * (3.0 / 84.0)) : baseLineWidth
+    }
+    private var trimFraction: Double {
+        showRemaining ? 1.0 - provider.usedFraction : provider.usedFraction
+    }
+    private var weekTrimFraction: Double {
+        showRemaining ? 1.0 - provider.weekFraction : provider.weekFraction
+    }
+    private var percentText: String {
+        guard let p = provider.fiveHourPercent else { return "\u{2014}" }
+        let shown = showRemaining ? (100.0 - p) : p
+        return "\(Int(shown.rounded()))"
+    }
+    private var numberColor: Color { provider.isNearLimit ? t.amber : t.cream }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            // Ring face on the left — same concentric ring + logo + % as
+            // RingGauge, just sized for a 56pt slot in a vertical list.
+            ZStack {
+                Circle()
+                    .stroke(t.track.opacity(0.5),
+                            style: StrokeStyle(lineWidth: baseLineWidth, lineCap: .round))
+                Circle()
+                    .trim(from: 0, to: trimFraction)
+                    .stroke(arcColor,
+                            style: StrokeStyle(lineWidth: valueLineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+
+                Circle()
+                    .stroke(t.track.opacity(0.4),
+                            style: StrokeStyle(lineWidth: innerLineWidth, lineCap: .round))
+                    .padding(innerInset)
+                Circle()
+                    .trim(from: 0, to: weekTrimFraction)
+                    .stroke(weekColor,
+                            style: StrokeStyle(lineWidth: innerLineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .padding(innerInset)
+
+                VStack(spacing: 1) {
+                    ProviderLogo(key: provider.id, color: arcColor, size: logoSize)
+                    Text(percentText)
+                        .font(.system(size: percentFont, weight: .semibold, design: .rounded))
+                        .foregroundColor(numberColor)
+                        .monospacedDigit()
+                }
+            }
+            .frame(width: ringSize, height: ringSize)
+
+            // Text column on the right — takes ALL remaining width via
+            // maxWidth: .infinity, so the name "MiniMax" never truncates.
+            textColumn
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var textColumn: some View {
+        let weekRaw = provider.weekPercent
+        let weekDisplayed = weekRaw.map { showRemaining ? (100 - $0) : $0 }
+        let week = weekDisplayed.map { "\(Int($0.rounded()))%" } ?? "\u{2014}"
+        let fiveReset = ResetFormat.phrase(provider.resetDate, lang)
+        let weekReset = ResetFormat.phrase(provider.weekResetDate, lang)
+        return VStack(alignment: .leading, spacing: 4) {
+            // Primary: provider name (semibold 13pt, cream).
+            Text(provider.displayName)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(t.cream)
+                .lineLimit(1)
+            // Secondary: 5h window — "5h" mute label + gold reset countdown.
+            HStack(spacing: 4) {
+                Text("5h")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(t.mute)
+                Text(fiveReset)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(t.gold)
+            }
+            .lineLimit(1)
+            // Tertiary: 7d window — "7d 23% · " mute + gold reset.
+            HStack(spacing: 4) {
+                Text("\(L10n.t(.week, lang)) \(week)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(t.mute)
+                Text("\u{00B7}")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(t.ash)
+                Text(weekReset)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(t.gold.opacity(0.85))
+            }
+            .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Sources/KajiGauge/StatusItemView.swift
+++ b/Sources/KajiGauge/StatusItemView.swift
@@ -21,11 +21,15 @@ struct StatusItemView: View {
     var style: MenubarStyle = .mono
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 5) {
             if providers.isEmpty {
                 DualRing(provider: nil, style: style)
             } else {
-                ForEach(providers.prefix(2)) { p in
+                // Show every visible provider — capping at 4 keeps the glyph
+                // compact (5+ would crowd the menubar and fight other icons).
+                // 4 also matches the max in `Providers.visible` minus hidden
+                // ones, so this is a future-proof ceiling, not a guess.
+                ForEach(providers.prefix(4)) { p in
                     DualRing(provider: p, style: style)
                 }
             }


### PR DESCRIPTION
## What
v0.4.5 ships 3 fixes from user feedback after PR #17:

- **Bug A** menubar shows only 2 rings (Claude + Codex), no MiniMax. `StatusItemView.swift` had `prefix(2)` from an old "3+ would crowd" rule. Bumped to `prefix(4)` + tightened HStack spacing 6→5pt to fit 4 alongside the native monochrome icons.
- **Bug B** docked strip shows only 1 provider (most-constrained). `DockStripView` is 36pt thick on the cross axis but long on its long axis — plenty of room for 3 stacked cells on a side dock. Rewrote to render `providers: [ProviderView]` filtered to `prefs.isVisible`, one cell per provider in a VStack (left/right) or HStack (top/bottom). Logo + 5h % per cell.
- **Bug C** vertical-mode labels truncated to "Clau / Cod / Mini". The HStack-of-`RingGauge`s sized rings from width AND height, but at tall+narrow the label sat BELOW the ring, fighting for the limited width. Fix: new private `CompactRingRow` — list-row layout (ring left, text right) so the label column gets the full panel width. Triggered in `ringsRow` when `geo.size.width < slotNeeded * n + 16*(n-1) + 28` (i.e. 3 rings need ~450pt horizontal — below that, go list-mode). Reference pattern: iStat Menus / MonitorControl / Spotify compact card (icon-left, text-right). Ring fixed at 56pt.

## Why
User feedback: "你真的要把这个自适应的适配做的再好一点，去看看现有的别人，肯定有很多做这种小应用的呀，你看看别人怎么做的好不好？然后你再琢磨琢磨，再给你最后一次机会。"

The pattern: at narrow widths, HIDE-the-label is the wrong answer; RELOCATE-the-label is right. Both label and ring always visible, label gets to breathe.

## Verification
- v0.4.5 installed to `/Applications/KajiGauge.app` (md5 OK, bundle intact).
- Menubar screenshot: 3 ring glyphs (Claude 99 / Codex 30 / MiniMax 43) side-by-side.
- Large-panel screenshot: 3 ring columns, full provider names (Claude / Codex / MiniMax), no truncation.
- Docked strip screenshot: 3 cells along right-edge strip, each logo + 5h %.
- CompactRingRow source: `HStack { ZStack(ring+logo+%).frame(56x56); textColumn.frame(maxWidth: .infinity, alignment: .leading) }` — text column always has the full panel width.

## Files
- `Sources/KajiGauge/StatusItemView.swift` — prefix + spacing
- `Sources/KajiGauge/DockStripView.swift` — cell loop
- `Sources/KajiGauge/GaugeRowView.swift` — ringsRow branching + new `CompactRingRow`
- `Sources/KajiGauge/FloatingPanel.swift` — comment only
- `Info.plist` — 0.3.3→0.4.5, build 6→7
- `.gitignore` — ignore `build/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)