### PR TITLE
Refine floating dock behavior

### DIFF
--- a/Sources/KajiGauge/AppDelegate.swift
+++ b/Sources/KajiGauge/AppDelegate.swift
@@ -69,6 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let view = StatusItemView(providers: visibleProviders,
                                   style: prefs.menubarStyle)
         hostingView = NSHostingView(rootView: view)
+        hostingView.configureKajiHost()
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         button.addSubview(hostingView)
         NSLayoutConstraint.activate([
@@ -86,6 +87,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func updateStatusItem() {
         hostingView?.rootView = StatusItemView(providers: visibleProviders,
                                                style: prefs.menubarStyle)
+        statusItem.length = statusItemLength
+    }
+
+    private var statusItemLength: CGFloat {
+        let count = max(1, min(4, visibleProviders.count))
+        return CGFloat(count) * 26 + 6
     }
 
     @objc private func statusButtonClicked(_ sender: NSStatusBarButton) {
@@ -122,7 +129,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onQuit: { NSApp.terminate(nil) }
         )
         let content = GaugeRowView(store: store, prefs: prefs, controls: controls)
-        popover.contentViewController = NSHostingController(rootView: content)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        let controller = NSHostingController(rootView: content)
+        controller.view.configureKajiHost(cornerRadius: 14)
+        let fitting = controller.view.fittingSize
+        controller.view.frame = NSRect(origin: .zero, size: fitting)
+        controller.preferredContentSize = fitting
+        popover.contentSize = fitting
+        popover.contentViewController = controller
         popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
         popover.contentViewController?.view.window?.makeKey()
     }
@@ -183,6 +197,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         usageMenu.addItem(remItem)
         usageItem.submenu = usageMenu
         menu.addItem(usageItem)
+
+        let sizeItem = NSMenuItem(title: L10n.t(.panelSize, lang), action: nil, keyEquivalent: "")
+        let sizeMenu = NSMenu()
+        for size in PanelSize.allCases {
+            let item = NSMenuItem(title: sizeTitle(size, lang),
+                                  action: #selector(setPanelSize(_:)),
+                                  keyEquivalent: "")
+            item.target = self
+            item.representedObject = size.rawValue
+            item.state = prefs.panelSize == size ? .on : .off
+            sizeMenu.addItem(item)
+        }
+        sizeItem.submenu = sizeMenu
+        menu.addItem(sizeItem)
 
         // Language toggle — shows the OTHER language as the action label.
         let langItem = NSMenuItem(title: "\(L10n.t(.language, lang)): \(lang.toggled.label)",
@@ -247,7 +275,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         prefs.showRemaining = true
     }
 
+    @objc private func setPanelSize(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String,
+              let size = PanelSize(rawValue: raw) else { return }
+        prefs.panelSize = size
+    }
+
     @objc private func toggleLanguage() {
         prefs.language = prefs.language.toggled
+    }
+
+    private func sizeTitle(_ size: PanelSize, _ lang: Lang) -> String {
+        switch size {
+        case .small:  return L10n.t(.sizeSmall, lang)
+        case .medium: return L10n.t(.sizeMedium, lang)
+        case .large:  return L10n.t(.sizeLarge, lang)
+        }
     }
 }

--- a/Sources/KajiGauge/DockStripView.swift
+++ b/Sources/KajiGauge/DockStripView.swift
@@ -3,11 +3,9 @@ import SwiftUI
 // MARK: - DockStripView
 //
 // The visual shown when the floating HUD is `.docked` against a screen edge.
-// A 36pt thin strip hosting:
+// A fixed side tab hosting:
 //   - one cell per VISIBLE provider (logo + 5h %) along the SCREEN-edge side.
-//   - a curved handle ("ear") on the PANEL-facing side, with a chevron
-//     pointing the way the panel will unfold. Click handle (or anywhere on
-//     the strip) → `onExpand()`.
+//   - a curved handle on the panel-facing side. Click arrow → `onExpand()`.
 //
 // Layout is done natively via HStack / VStack — no rotation. The strip's
 // long axis (height for left/right docks, width for top/bottom docks) is laid
@@ -35,20 +33,19 @@ struct DockStripView: View {
         Group {
             switch edge {
             case .left:
-                HStack(spacing: 0) { handle; content }
-            case .right:
                 HStack(spacing: 0) { content; handle }
+            case .right:
+                HStack(spacing: 0) { handle; content }
             case .top:
-                VStack(spacing: 0) { handle; content }
-            case .bottom:
                 VStack(spacing: 0) { content; handle }
+            case .bottom:
+                VStack(spacing: 0) { handle; content }
             }
         }
         .background(stripBg)
         .overlay(stripOutline)
         .clipShape(stripShape)
         .contentShape(stripShape)
-        .onTapGesture(perform: onExpand)
     }
 
     // MARK: Background + shape
@@ -63,14 +60,12 @@ struct DockStripView: View {
     }
 
     private var stripOutline: some View {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .stroke(t.gold.opacity(0.55), lineWidth: 1)
+        DockTabShape(edge: edge, radius: 22)
+            .stroke(t.gold.opacity(0.46), lineWidth: 1)
     }
 
-    /// Capsule on both ends — the panel-facing edge already curves gracefully,
-    /// and the dedicated handle View on top of it pops as the affordance.
     private var stripShape: some Shape {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
+        DockTabShape(edge: edge, radius: 22)
     }
 
     // MARK: Content (all visible providers, one cell each)
@@ -90,17 +85,17 @@ struct DockStripView: View {
             } else {
                 switch edge {
                 case .left, .right:
-                    VStack(alignment: .center, spacing: 4) {
+                    VStack(alignment: .center, spacing: 7) {
                         ForEach(providers) { p in cell(p) }
                     }
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 6)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 4)
                 case .top, .bottom:
                     HStack(alignment: .center, spacing: 8) {
                         ForEach(providers) { p in cell(p) }
                     }
                     .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
+                    .padding(.vertical, 4)
                 }
             }
         }
@@ -112,13 +107,13 @@ struct DockStripView: View {
         VStack(spacing: 2) {
             ProviderLogo(key: p.id, color: t.cream, size: 11)
             Text(percentText(p))
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
                 .foregroundColor(p.isNearLimit ? t.amber : t.gold)
                 .monospacedDigit()
                 .lineLimit(1)
-                .fixedSize()  // don't shrink — readability wins in a 36pt strip
+                .minimumScaleFactor(0.78)
         }
-        .frame(minWidth: 22, minHeight: 24)
+        .frame(width: 36, height: 35)
     }
 
     private func percentText(_ p: ProviderView) -> String {
@@ -135,18 +130,36 @@ struct DockStripView: View {
     /// The whole strip is also tappable as a fallback.
     private var handle: some View {
         ZStack {
-            Capsule(style: .continuous)
-                .fill(t.gold.opacity(0.18))
-                .overlay(Capsule(style: .continuous)
-                    .stroke(t.gold.opacity(0.7), lineWidth: 1))
-            Image(systemName: chevronName)
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(t.gold)
+            Button(action: onExpand) {
+                ZStack {
+                    Capsule(style: .continuous)
+                        .fill(t.gold.opacity(0.10))
+                        .overlay(Capsule(style: .continuous)
+                            .stroke(t.gold.opacity(0.52), lineWidth: 1))
+                    Image(systemName: chevronName)
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(t.gold)
+                }
+                .frame(width: edge == .left || edge == .right ? 18 : 34,
+                       height: edge == .left || edge == .right ? 52 : 18)
+            }
+            .buttonStyle(.plain)
+
+            if edge == .left || edge == .right {
+                Capsule(style: .continuous)
+                    .fill(t.gold.opacity(0.18))
+                    .frame(width: 1.5, height: 50)
+                    .offset(x: edge == .left ? 13 : -13)
+                    .allowsHitTesting(false)
+            } else {
+                Capsule(style: .continuous)
+                    .fill(t.gold.opacity(0.18))
+                    .frame(width: 50, height: 1.5)
+                    .offset(y: edge == .top ? -13 : 13)
+                    .allowsHitTesting(false)
+            }
         }
         .frame(width: handleSize.width, height: handleSize.height)
-        .padding(3)
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onExpand)
     }
 
     /// Tall thin pill on left/right docks, short wide pill on top/bottom.
@@ -155,9 +168,9 @@ struct DockStripView: View {
     private var handleSize: CGSize {
         switch edge {
         case .left, .right:
-            return CGSize(width: 14, height: 44)
+            return CGSize(width: 22, height: 78)
         case .top, .bottom:
-            return CGSize(width: 44, height: 14)
+            return CGSize(width: 78, height: 22)
         }
     }
 
@@ -169,5 +182,55 @@ struct DockStripView: View {
         case .top:    return "chevron.down"    // panel unrolls down
         case .bottom: return "chevron.up"      // panel unrolls up
         }
+    }
+}
+
+private struct DockTabShape: Shape {
+    let edge: DockEdge
+    let radius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let r = min(radius, rect.width / 2, rect.height / 2)
+        var p = Path()
+        switch edge {
+        case .left:
+            p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX - r, y: rect.minY))
+            p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.minY + r),
+                           control: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - r))
+            p.addQuadCurve(to: CGPoint(x: rect.maxX - r, y: rect.maxY),
+                           control: CGPoint(x: rect.maxX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        case .right:
+            p.move(to: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX + r, y: rect.minY))
+            p.addQuadCurve(to: CGPoint(x: rect.minX, y: rect.minY + r),
+                           control: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - r))
+            p.addQuadCurve(to: CGPoint(x: rect.minX + r, y: rect.maxY),
+                           control: CGPoint(x: rect.minX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        case .top:
+            p.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.minY + r))
+            p.addQuadCurve(to: CGPoint(x: rect.minX + r, y: rect.minY),
+                           control: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX - r, y: rect.minY))
+            p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.minY + r),
+                           control: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        case .bottom:
+            p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - r))
+            p.addQuadCurve(to: CGPoint(x: rect.minX + r, y: rect.maxY),
+                           control: CGPoint(x: rect.minX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.maxX - r, y: rect.maxY))
+            p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.maxY - r),
+                           control: CGPoint(x: rect.maxX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        }
+        p.closeSubpath()
+        return p
     }
 }

--- a/Sources/KajiGauge/FloatingPanel.swift
+++ b/Sources/KajiGauge/FloatingPanel.swift
@@ -3,31 +3,22 @@ import SwiftUI
 import Combine
 
 // MARK: - DraggablePanel
-//
-// An always-on-top, borderless HUD panel that the user can drag anywhere on
-// the desktop. .nonactivatingPanel so clicking it never steals focus from the
-// frontmost app; .floating level so it stays above normal windows.
-//
-// Borderless NSPanels default to a ~3pt edge hit zone for resizing — the user
-// has to park the cursor right on the edge. We widen this to 10pt by
-// installing eight invisible `ResizeHandle` views (one per edge + corner)
-// that own the resize gesture + cursor and sit ABOVE the SwiftUI host so they
-// get first crack at mouse events.
 final class DraggablePanel: NSPanel {
-    /// Edge width for the resize hit zone. 16pt ≈ a comfortable grab target
-    /// + room for a visible 1.5pt track line + L-shape corner indicator. The
-    /// handles are still mostly transparent — only the inner-edge track line
-    /// is drawn, so the wider hit zone doesn't leak into the content.
-    private static let edgeWidth: CGFloat = 16
-
     init(content: NSView) {
+        let fitting = content.fittingSize
+        let initialSize = NSSize(
+            width: max(1, fitting.width),
+            height: max(1, fitting.height)
+        )
+        let container = NSView(frame: NSRect(origin: .zero, size: initialSize))
+        container.configureKajiHost()
+        content.frame = container.bounds
+        content.autoresizingMask = [.width, .height]
+        container.addSubview(content)
+
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
-            // No .hudWindow — its material forces a dark vibrancy that fights the
-            // light "Kaji Sun" theme. We paint our own warm gradient instead.
-            // .resizable so we can also drag the edges/corners via the
-            // ResizeHandle subviews; we paint our own shadow (no native chrome).
-            styleMask: [.borderless, .nonactivatingPanel, .resizable],
+            contentRect: NSRect(origin: .zero, size: initialSize),
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -43,64 +34,13 @@ final class DraggablePanel: NSPanel {
         hasShadow = true
         hidesOnDeactivate = false
 
-        contentView = content
+        contentView = container
         // Size to fit the SwiftUI content.
-        if let fitting = content.fittingSize as NSSize?, fitting.width > 0 {
+        if fitting.width > 0 {
             setContentSize(fitting)
         }
 
-        // Initial bounds use the LARGEST visible-ring case (3-ring vertical
-        // wrap, 200x340). The controller narrows the lower bound as visible
-        // rings change, via `updateMinSize(forVisibleRings:)`. The upper bound
-        // stays at the original 720x360 — that's still where rings stop
-        // scaling.
-        let maxW: CGFloat = 720
-        let maxH: CGFloat = 360
-        let defaultMin = DraggablePanel.minSize(forVisibleRings: 3)
-        minSize = defaultMin
-        maxSize = NSSize(width: maxW, height: maxH)
-        contentMinSize = defaultMin
-        contentMaxSize = NSSize(width: maxW, height: maxH)
-
-        // Install the eight resize handles. The hosting view is also added so
-        // the SwiftUI content still draws (these handles are transparent).
-        if let host = contentView {
-            host.wantsLayer = true
-            host.layer?.backgroundColor = .clear
-            installResizeHandles(on: host)
-        }
-    }
-
-    /// Pick a min size for the panel given how many provider rings the user
-    /// currently has visible. 1-2 rings sit in an HStack (need W), 3+ wraps
-    /// to a LazyVStack (need H). We never go below the natural chrome — below
-    /// that the SwiftUI content starts to clip and the legend truncates.
-    static func minSize(forVisibleRings n: Int) -> NSSize {
-        if n <= 2 {
-            // 1 ring ≈ 84 + label; 2 rings HStack need ~280 to fit 84+84+16+chrome.
-            // Height = ring + label + chrome ≈ 160; below that the panel feels
-            // squeezed and the popover font starts to shrink.
-            let w: CGFloat = n == 1 ? 200 : 280
-            return NSSize(width: w, height: 160)
-        }
-        // 3 rings vertical: ring(36) + label(38) + spacing(7) per cell, 3 cells
-        // + 2 inter-cell gaps + top chrome (header+padding ≈ 54) + bottom 14.
-        // Round up to 340 so the label VStack never gets squeezed.
-        return NSSize(width: 200, height: 340)
-    }
-
-    /// Re-apply the lower bound when the user's visible-ring count changes.
-    /// Capped to the current frame so we don't SHRINK a live panel the user
-    /// is already looking at — only expand the bound so the user can shrink
-    /// back down to the new minimum.
-    func updateMinSize(forVisibleRings n: Int) {
-        let target = DraggablePanel.minSize(forVisibleRings: n)
-        // If the panel is already larger than the new min, keep the panel
-        // size and just relax the lower bound to the new min.
-        minSize = NSSize(width: min(target.width, frame.width),
-                         height: min(target.height, frame.height))
-        contentMinSize = NSSize(width: min(target.width, frame.width),
-                                height: min(target.height, frame.height))
+        setFixedContentSize(initialSize)
     }
 
     // Borderless windows can't become key by default; allow it so SwiftUI
@@ -108,186 +48,11 @@ final class DraggablePanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 
-    private func installResizeHandles(on host: NSView) {
-        let w = DraggablePanel.edgeWidth
-        // Corners first (drawn last so they sit on top of the edge handles
-        // and own the cursor at the intersection). Each corner is square of
-        // side `w`; edges are thin strips.
-        let corners: [(ResizeHandle.Kind, CGRect)] = [
-            (.topLeft,     CGRect(x: 0, y: host.bounds.maxY - w,
-                                  width: w, height: w)),
-            (.topRight,    CGRect(x: host.bounds.maxX - w, y: host.bounds.maxY - w,
-                                  width: w, height: w)),
-            (.bottomLeft,  CGRect(x: 0, y: 0, width: w, height: w)),
-            (.bottomRight, CGRect(x: host.bounds.maxX - w, y: 0,
-                                  width: w, height: w)),
-        ]
-        let edges: [(ResizeHandle.Kind, CGRect)] = [
-            (.top,    CGRect(x: w, y: host.bounds.maxY - w,
-                             width: max(0, host.bounds.width - 2 * w), height: w)),
-            (.bottom, CGRect(x: w, y: 0,
-                             width: max(0, host.bounds.width - 2 * w), height: w)),
-            (.left,   CGRect(x: 0, y: w, width: w,
-                             height: max(0, host.bounds.height - 2 * w))),
-            (.right,  CGRect(x: host.bounds.maxX - w, y: w, width: w,
-                             height: max(0, host.bounds.height - 2 * w))),
-        ]
-        for (kind, rect) in edges + corners {
-            let handle = ResizeHandle(kind: kind, panel: self)
-            handle.frame = rect
-            handle.autoresizingMask = autoresizeMask(for: kind, in: host)
-            host.addSubview(handle)
-        }
-    }
-
-    private func autoresizeMask(for kind: ResizeHandle.Kind,
-                                in host: NSView) -> NSView.AutoresizingMask {
-        // Edges/corners move with their adjacent sides when the panel resizes.
-        switch kind {
-        case .topLeft:     return [.maxXMargin, .minYMargin]
-        case .topRight:    return [.minXMargin, .minYMargin]
-        case .bottomLeft:  return [.maxXMargin, .maxYMargin]
-        case .bottomRight: return [.minXMargin, .maxYMargin]
-        case .top:         return [.width, .minYMargin]
-        case .bottom:      return [.width, .maxYMargin]
-        case .left:        return [.maxXMargin, .height]
-        case .right:       return [.minXMargin, .height]
-        }
-    }
-
-    /// Tear down + reinstall all eight ResizeHandle subviews. Called by the
-    /// controller after swapping the SwiftUI hosting view (dock ↔ HUD) so
-    /// the handles always sit on top of the new content with the right z-order.
-    func reinstallResizeHandles() {
-        guard let host = contentView else { return }
-        host.subviews
-            .compactMap { $0 as? ResizeHandle }
-            .forEach { $0.removeFromSuperview() }
-        installResizeHandles(on: host)
-    }
-}
-
-// MARK: - ResizeHandle
-//
-// An NSView that owns one of the eight panel edges/corners. The hit zone is
-// 16pt wide. Cursor changes on enter so the user reads the affordance from
-// the cursor shape alone — we deliberately paint NOTHING here, so the chrome
-// stays out of the way of the SwiftUI content. Earlier iterations drew a 1.5pt
-// track + a gold hover line; both were dropped after user feedback said they
-// felt more like glitches than affordances.
-final class ResizeHandle: NSView {
-    enum Kind {
-        case topLeft, topRight, bottomLeft, bottomRight
-        case top, bottom, left, right
-    }
-    private let kind: Kind
-    private weak var panel: NSPanel?
-    private var startOrigin: NSPoint = .zero
-    private var startSize: NSSize = .zero
-    private var startFrame: NSRect = .zero
-
-    init(kind: Kind, panel: NSPanel) {
-        self.kind = kind
-        self.panel = panel
-        super.init(frame: .zero)
-        // Transparent — cursor change is the only affordance.
-        wantsLayer = true
-        layer?.backgroundColor = .clear
-    }
-    required init?(coder: NSCoder) { fatalError() }
-
-    override var acceptsFirstResponder: Bool { true }
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        // Block any hits in our rect so the SwiftUI host doesn't steal them.
-        // We still let the panel's own isMovableByWindowBackground handle the
-        // background drag (we only sit on the edges).
-        bounds.contains(point) ? self : nil
-    }
-
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: cursor())
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        // Intentional no-op — see file header.
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        guard let panel = panel else { return }
-        startFrame = panel.frame
-        startOrigin = startFrame.origin
-        startSize = startFrame.size
-        window?.makeFirstResponder(self)
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        guard let panel = panel else { return }
-        // Location in window coords; convert to delta in screen coords (Y up).
-        let loc = event.locationInWindow
-        let start = window?.mouseLocationOutsideOfEventStream ?? loc
-        let dx = loc.x - start.x
-        let dy = loc.y - start.y
-        apply(dx: dx, dy: dy, to: panel)
-    }
-
-    private func apply(dx: CGFloat, dy: CGFloat, to panel: NSPanel) {
-        var origin = startOrigin
-        var size = startSize
-        // NSPanel resize: edges/corners modify origin + size according to which
-        // side the user grabbed. Y is screen-up here (dy > 0 = drag up).
-        switch kind {
-        case .topLeft:
-            origin.x += dx; origin.y += dy
-            size.width -= dx; size.height += dy
-        case .topRight:
-            origin.y += dy
-            size.width += dx; size.height += dy
-        case .bottomLeft:
-            origin.x += dx
-            size.width -= dx; size.height -= dy
-        case .bottomRight:
-            size.width += dx; size.height -= dy
-        case .top:
-            origin.y += dy
-            size.height += dy
-        case .bottom:
-            size.height -= dy
-        case .left:
-            origin.x += dx
-            size.width -= dx
-        case .right:
-            size.width += dx
-        }
-        // Clamp to the same bounds the panel's minSize / maxSize enforce.
-        let minS = panel.minSize, maxS = panel.maxSize
-        size.width = min(max(size.width, minS.width),  maxS.width)
-        size.height = min(max(size.height, minS.height), maxS.height)
-        // Re-derive origin for the clamped size so the grabbed edge stays
-        // anchored to the cursor (only the non-anchored corners move).
-        switch kind {
-        case .topLeft:
-            origin.x = startOrigin.x + (startSize.width - size.width)
-            origin.y = startOrigin.y + (startSize.height - size.height)
-        case .topRight:
-            origin.y = startOrigin.y + (startSize.height - size.height)
-        case .bottomLeft:
-            origin.x = startOrigin.x + (startSize.width - size.width)
-        case .top:
-            origin.y = startOrigin.y + (startSize.height - size.height)
-        case .left:
-            origin.x = startOrigin.x + (startSize.width - size.width)
-        default: break
-        }
-        panel.setFrame(NSRect(origin: origin, size: size), display: true)
-    }
-
-    private func cursor() -> NSCursor {
-        switch kind {
-        case .topLeft, .bottomRight: return .crosshair
-        case .topRight, .bottomLeft: return .crosshair
-        case .top, .bottom:          return .resizeUpDown
-        case .left, .right:          return .resizeLeftRight
-        }
+    func setFixedContentSize(_ size: NSSize) {
+        minSize = size
+        maxSize = size
+        contentMinSize = size
+        contentMaxSize = size
     }
 }
 
@@ -297,13 +62,12 @@ final class ResizeHandle: NSView {
 // (not the view) so SwiftUI sees a single root and we can swap it without
 // rebuilding the panel.
 //
-//   - `.expanded` — the regular HUD: rings, labels, header. Drag from any
-//     inner pixel; resize from the 8 invisible ResizeHandles on the border.
+//   - `.expanded` — fixed-size HUD. Drag body to place.
 //   - `.snapped(edge)` — the panel moved within 14pt of a screen edge and
 //     we animated it flush to the edge. Same content; just relocated.
 //   - `.docked(edge)` — 240ms of stillness after a snap collapsed the panel
 //     into a thin 36pt strip (one cell per visible provider: logo + 5h %).
-//     Strip sits on the chosen edge. Hover or drag the strip → back to expanded.
+//     Strip sits on the chosen edge. Click arrow → back to expanded.
 enum PanelState {
     case expanded
     case snapped(DockEdge)
@@ -331,8 +95,7 @@ final class FloatingPanelController {
     private let prefs: Prefs
     private var cancellables = Set<AnyCancellable>()
 
-    /// Number of providers the user has chosen to show. Drives the panel's
-    /// min size — see `DraggablePanel.minSize(forVisibleRings:)`.
+    /// Number of providers the user has chosen to show. Drives dock tab length.
     private var shownCount: Int {
         store.providers.filter { prefs.isVisible($0.id) }.count
     }
@@ -356,10 +119,13 @@ final class FloatingPanelController {
 
     /// didMoveNotification observer — drives the snap → dock state machine.
     private var moveObserver: NSObjectProtocol?
+    private var suppressMoveHandling = false
+    private var dockReclampTimer: Timer?
 
-    /// Snap + dock constants. Kept on the controller so the behavior is
-    /// self-contained; if these ever need user-tunable, lift to Prefs.
-    private static let stripThickness: CGFloat = 36
+    private static let sideTabWidth: CGFloat = 68
+    private static let topTabHeight: CGFloat = 66
+    private static let dockCellLength: CGFloat = 42
+    private static let dockPadLength: CGFloat = 24
     private static let snapThreshold: CGFloat = 14
     private static let snapAnimationDuration: TimeInterval = 0.18
     private static let dockDelay: TimeInterval = 0.24
@@ -368,15 +134,14 @@ final class FloatingPanelController {
     init(store: QuotaStore, prefs: Prefs) {
         self.store = store
         self.prefs = prefs
-        // Re-apply the min size whenever the user's visible-ring set changes
-        // (provider toggle in the popover/menu) OR the store reports new data
-        // (a provider that was previously "no data" now has a row to show).
-        // MainActor: all UI work; no need to hop.
         store.$providers
-            .sink { [weak self] _ in self?.applyMinSize() }
+            .sink { [weak self] _ in self?.refreshCurrentMode() }
             .store(in: &cancellables)
         prefs.$visibleProviders
-            .sink { [weak self] _ in self?.applyMinSize() }
+            .sink { [weak self] _ in self?.refreshCurrentMode() }
+            .store(in: &cancellables)
+        prefs.$panelSize
+            .sink { [weak self] _ in self?.refreshCurrentMode() }
             .store(in: &cancellables)
         // prefs.dockEdge is persisted via its own didSet; no controller-side
         // hook needed today, but we keep a sink registered for future
@@ -406,12 +171,10 @@ final class FloatingPanelController {
 
     func show() {
         if panel == nil {
-            // Resizable HUD: GaugeRowView runs in `expandToFill` mode so the
-            // SwiftUI view tracks the panel's width and rings scale together.
-            let root = GaugeRowView(store: store, prefs: prefs, expandToFill: true)
+            let root = GaugeRowView(store: store, prefs: prefs, panelSize: prefs.panelSize)
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             let hosting = NSHostingView(rootView: root)
-            hosting.layer?.cornerRadius = 14
+            hosting.configureKajiHost(cornerRadius: 14)
             hosting.frame = NSRect(origin: .zero, size: hosting.fittingSize)
             // Track the panel's content size on resize (width + height), so
             // the SwiftUI view reflows instead of staying anchored top-left.
@@ -431,7 +194,7 @@ final class FloatingPanelController {
             pendingStartupDock = prefs.dockEdge
         }
         panel?.orderFrontRegardless()
-        applyMinSize()  // covers the show-after-data-arrived case
+        refreshCurrentMode()
         // Defer startup-dock to the next runloop tick so the panel's content
         // view is fully wired up before we swap in the dock strip.
         if let edge = pendingStartupDock {
@@ -448,6 +211,8 @@ final class FloatingPanelController {
         // while hidden.
         snapTimer?.invalidate()
         snapTimer = nil
+        dockReclampTimer?.invalidate()
+        dockReclampTimer = nil
         if let obs = moveObserver {
             NotificationCenter.default.removeObserver(obs)
             moveObserver = nil
@@ -461,11 +226,20 @@ final class FloatingPanelController {
         UserDefaults.standard.set(false, forKey: Config.kPanelVisible)
     }
 
-    /// Push the current visible-ring count down to the panel as a min-size
-    /// floor. No-op if the panel isn't shown yet (it'll fire on first show()).
-    private func applyMinSize() {
+    private func refreshCurrentMode() {
         guard let panel else { return }
-        panel.updateMinSize(forVisibleRings: shownCount)
+        switch state {
+        case .expanded, .snapped:
+            swapContentToGaugeRow()
+            let target = frameKeepingTopRight(panel.frame, size: prefs.panelSize.frameSize)
+            panel.setFixedContentSize(target.size)
+            setPanelFrame(target, animated: false)
+        case .docked(let edge):
+            swapContentToDockStrip(for: edge)
+            let target = makeDockFrame(for: edge, base: panel.frame)
+            panel.setFixedContentSize(target.size)
+            setPanelFrame(target, animated: false)
+        }
     }
 
     // MARK: - Snap + dock state machine
@@ -517,6 +291,7 @@ final class FloatingPanelController {
     }
 
     private func handlePanelMoved() {
+        guard !suppressMoveHandling else { return }
         guard let panel else { return }
         let detection = detectNearestEdge(panel: panel)
         switch detection {
@@ -525,8 +300,10 @@ final class FloatingPanelController {
             switch state {
             case .expanded:
                 snapTimer?.invalidate(); snapTimer = nil
-            case .snapped, .docked:
+            case .snapped:
                 expandFromDock(animated: true)
+            case .docked(let edge):
+                scheduleDockReclamp(edge)
             }
         case .near(let edge):
             switch state {
@@ -548,10 +325,8 @@ final class FloatingPanelController {
                     // dock timer so 240ms of stillness commits the dock.
                     scheduleDockTimer(for: edge)
                 }
-            case .docked:
-                // User grabbed the docked strip and dragged — pop back to
-                // expanded immediately. The next edge detection re-arms.
-                expandFromDock(animated: true)
+            case .docked(let edge):
+                scheduleDockReclamp(edge)
             }
         }
     }
@@ -573,11 +348,7 @@ final class FloatingPanelController {
         case .top:    target = NSRect(x: f.minX, y: v.maxY - f.height, width: f.width, height: f.height)
         case .bottom: target = NSRect(x: f.minX, y: v.minY,           width: f.width, height: f.height)
         }
-        NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = Self.snapAnimationDuration
-            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            panel.animator().setFrame(target, display: true)
-        }
+        setPanelFrame(target, animated: true, duration: Self.snapAnimationDuration)
     }
 
     private func scheduleDockTimer(for edge: DockEdge) {
@@ -601,24 +372,35 @@ final class FloatingPanelController {
     private func enterDockedMode(edge: DockEdge, animated: Bool) {
         guard let panel else { return }
         snapTimer?.invalidate(); snapTimer = nil
+        if savedExpandedFrame == nil {
+            savedExpandedFrame = panel.frame
+        }
         state = .docked(edge)
         prefs.dockEdge = edge
+        panel.isMovableByWindowBackground = true
         swapContentToDockStrip(for: edge)
         let target = makeDockFrame(for: edge, base: panel.frame)
-        // Lock the panel to the strip thickness so the user can't drag it
-        // wider from a docked handle. Expanded mode restores the proper min
-        // in expandFromDock().
-        panel.minSize = NSSize(width: Self.stripThickness, height: Self.stripThickness)
-        panel.contentMinSize = panel.minSize
-        if animated {
-            NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = Self.dockAnimationDuration
-                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                panel.animator().setFrame(target, display: true)
-            }
-        } else {
-            panel.setFrame(target, display: true)
+        panel.setFixedContentSize(target.size)
+        setPanelFrame(target, animated: animated, duration: Self.dockAnimationDuration)
+    }
+
+    private func scheduleDockReclamp(_ edge: DockEdge) {
+        dockReclampTimer?.invalidate()
+        dockReclampTimer = Timer.scheduledTimer(withTimeInterval: 0.16,
+                                                repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.reclampDockedTab(edge) }
         }
+    }
+
+    private func reclampDockedTab(_ edge: DockEdge) {
+        guard let panel else { return }
+        if NSEvent.pressedMouseButtons & 1 != 0 {
+            scheduleDockReclamp(edge)
+            return
+        }
+        let target = makeDockFrame(for: edge, base: panel.frame)
+        panel.setFixedContentSize(target.size)
+        setPanelFrame(target, animated: true, duration: 0.12)
     }
 
     /// Restore the panel to `.expanded` at the saved frame. The saved frame
@@ -626,77 +408,134 @@ final class FloatingPanelController {
     private func expandFromDock(animated: Bool) {
         guard let panel else { return }
         snapTimer?.invalidate(); snapTimer = nil
-        // If we were never saved (e.g. direct dock from launch), fall back
-        // to the current frame so the panel doesn't teleport to stale state.
-        let target = savedExpandedFrame ?? panel.frame
+        dockReclampTimer?.invalidate(); dockReclampTimer = nil
+        let edge = state.edge
+        // Startup-dock path may lack a saved HUD frame.
+        let base = savedExpandedFrame ?? fallbackExpandedFrame(from: panel.frame, edge: edge)
+        let target = clampExpandedFrame(NSRect(origin: base.origin, size: prefs.panelSize.frameSize))
         state = .expanded
         prefs.dockEdge = nil
+        panel.isMovableByWindowBackground = true
         swapContentToGaugeRow()
-        // Restore the proper min size for the user's current ring count.
-        panel.updateMinSize(forVisibleRings: shownCount)
+        panel.setFixedContentSize(target.size)
         savedExpandedFrame = nil
-        if animated {
-            NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = Self.dockAnimationDuration
-                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                panel.animator().setFrame(target, display: true)
-            }
-        } else {
-            panel.setFrame(target, display: true)
-        }
+        setPanelFrame(target, animated: animated, duration: Self.dockAnimationDuration)
     }
 
-    /// Frame a docked panel should occupy: flush to the edge, with the
-    /// strip thickness on the cross axis. Long axis (height for left/right,
-    /// width for top/bottom) keeps the user's snap-time size.
+    /// Frame a docked panel should occupy: fully visible, flush to edge.
     private func makeDockFrame(for edge: DockEdge, base: NSRect) -> NSRect {
         guard let screen = panel?.screen ?? NSScreen.main else { return base }
         let v = screen.visibleFrame
-        let t = Self.stripThickness
+        let count = max(1, shownCount)
+        let long = max(132, CGFloat(count) * Self.dockCellLength + Self.dockPadLength)
         switch edge {
-        case .left:   return NSRect(x: v.minX,           y: base.minY, width: t, height: base.height)
-        case .right:  return NSRect(x: v.maxX - t,       y: base.minY, width: t, height: base.height)
-        case .top:    return NSRect(x: base.minX, y: v.maxY - t,       width: base.width, height: t)
-        case .bottom: return NSRect(x: base.minX, y: v.minY,           width: base.width, height: t)
+        case .left:
+            let h = min(long, v.height - 16)
+            let y = clamp(base.midY - h / 2, v.minY + 8, v.maxY - h - 8)
+            return NSRect(x: v.minX, y: y, width: Self.sideTabWidth, height: h)
+        case .right:
+            let h = min(long, v.height - 16)
+            let y = clamp(base.midY - h / 2, v.minY + 8, v.maxY - h - 8)
+            return NSRect(x: v.maxX - Self.sideTabWidth, y: y, width: Self.sideTabWidth, height: h)
+        case .top:
+            let w = min(long, v.width - 16)
+            let x = clamp(base.midX - w / 2, v.minX + 8, v.maxX - w - 8)
+            return NSRect(x: x, y: v.maxY - Self.topTabHeight, width: w, height: Self.topTabHeight)
+        case .bottom:
+            let w = min(long, v.width - 16)
+            let x = clamp(base.midX - w / 2, v.minX + 8, v.maxX - w - 8)
+            return NSRect(x: x, y: v.minY, width: w, height: Self.topTabHeight)
         }
+    }
+
+    private func fallbackExpandedFrame(from strip: NSRect, edge: DockEdge?) -> NSRect {
+        guard let screen = panel?.screen ?? NSScreen.main else { return strip }
+        let v = screen.visibleFrame
+        let size = prefs.panelSize.frameSize
+        let margin: CGFloat = 8
+        let x: CGFloat
+        let y: CGFloat
+        switch edge {
+        case .left:
+            x = v.minX + margin
+            y = clamp(strip.midY - size.height / 2, v.minY + margin, v.maxY - size.height - margin)
+        case .right:
+            x = v.maxX - size.width - margin
+            y = clamp(strip.midY - size.height / 2, v.minY + margin, v.maxY - size.height - margin)
+        case .top:
+            x = clamp(strip.midX - size.width / 2, v.minX + margin, v.maxX - size.width - margin)
+            y = v.maxY - size.height - margin
+        case .bottom:
+            x = clamp(strip.midX - size.width / 2, v.minX + margin, v.maxX - size.width - margin)
+            y = v.minY + margin
+        case .none:
+            x = clamp(strip.minX, v.minX + margin, v.maxX - size.width - margin)
+            y = clamp(strip.minY, v.minY + margin, v.maxY - size.height - margin)
+        }
+        return NSRect(origin: NSPoint(x: x, y: y), size: size)
+    }
+
+    private func clampExpandedFrame(_ frame: NSRect) -> NSRect {
+        guard let screen = panel?.screen ?? NSScreen.main else { return frame }
+        let v = screen.visibleFrame
+        let margin: CGFloat = 8
+        let x = clamp(frame.minX, v.minX + margin, v.maxX - frame.width - margin)
+        let y = clamp(frame.minY, v.minY + margin, v.maxY - frame.height - margin)
+        return NSRect(x: x, y: y, width: frame.width, height: frame.height)
+    }
+
+    private func frameKeepingTopRight(_ frame: NSRect, size: CGSize) -> NSRect {
+        let origin = NSPoint(x: frame.maxX - size.width, y: frame.maxY - size.height)
+        return clampExpandedFrame(NSRect(origin: origin, size: size))
+    }
+
+    private func setPanelFrame(_ frame: NSRect, animated: Bool, duration: TimeInterval = 0) {
+        guard let panel else { return }
+        suppressMoveHandling = true
+        if animated {
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = duration
+                ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                panel.animator().setFrame(frame, display: true)
+            } completionHandler: { [weak self] in
+                Task { @MainActor in self?.suppressMoveHandling = false }
+            }
+        } else {
+            panel.setFrame(frame, display: true)
+            suppressMoveHandling = false
+        }
+    }
+
+    private func clamp(_ value: CGFloat, _ low: CGFloat, _ high: CGFloat) -> CGFloat {
+        min(max(value, low), high)
     }
 
     // MARK: - Content swap (HUD ↔ dock strip)
     //
-    // We rebuild the SwiftUI hosting view because the SwiftUI root differs
-    // (GaugeRowView vs DockStripView). The 8 ResizeHandle subviews stay —
-    // we just re-stack them on top of the new host so hit-testing still
-    // works on the edges.
+    // We rebuild the SwiftUI hosting view because the SwiftUI root differs.
 
     private func swapContentToDockStrip(for edge: DockEdge) {
         guard let panel, let host = panel.contentView else { return }
-        // Remove the existing hosting view; keep the resize handles.
-        host.subviews
-            .filter { !($0 is ResizeHandle) }
-            .forEach { $0.removeFromSuperview() }
+        host.subviews.forEach { $0.removeFromSuperview() }
         let root = DockStripView(store: store, prefs: prefs, edge: edge) { [weak self] in
             Task { @MainActor in self?.expandFromDock(animated: true) }
         }
         let hosting = NSHostingView(rootView: root)
+        hosting.configureKajiHost(cornerRadius: 14)
         hosting.frame = host.bounds
         hosting.autoresizingMask = [.width, .height]
         host.addSubview(hosting)
-        // Bring resize handles to the front (z-order) so they win edge hits.
-        panel.reinstallResizeHandles()
     }
 
     private func swapContentToGaugeRow() {
         guard let panel, let host = panel.contentView else { return }
-        host.subviews
-            .filter { !($0 is ResizeHandle) }
-            .forEach { $0.removeFromSuperview() }
-        let root = GaugeRowView(store: store, prefs: prefs, expandToFill: true)
+        host.subviews.forEach { $0.removeFromSuperview() }
+        let root = GaugeRowView(store: store, prefs: prefs, panelSize: prefs.panelSize)
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         let hosting = NSHostingView(rootView: root)
-        hosting.layer?.cornerRadius = 14
+        hosting.configureKajiHost(cornerRadius: 14)
         hosting.frame = host.bounds
         hosting.autoresizingMask = [.width, .height]
         host.addSubview(hosting)
-        panel.reinstallResizeHandles()
     }
 }

--- a/Sources/KajiGauge/GaugeRowView.swift
+++ b/Sources/KajiGauge/GaugeRowView.swift
@@ -15,16 +15,7 @@ struct GaugeRowView: View {
 
     var controls: Controls? = nil
 
-    /// When true the view expands to fill its container (used by the resizable
-    /// floating HUD — rings scale up with the panel width). Popover leaves
-    /// this false so the view still hugs its content and the popover stays
-    /// tight around its rings.
-    var expandToFill: Bool = false
-
-    /// Minimum / maximum ring diameter when scaling with the panel. Keeps the
-    /// gauge readable at small widths and prevents over-stretch at large ones.
-    private let minRing: CGFloat = 64
-    private let maxRing: CGFloat = 160
+    var panelSize: PanelSize? = nil
     /// Default ring size when the view is hugging its content (popover, or a
     /// panel that's at its natural fitting size).
     private let defaultRing: CGFloat = 84
@@ -45,36 +36,6 @@ struct GaugeRowView: View {
         store.providers.filter { prefs.isVisible($0.id) }
     }
 
-    /// Pick a ring diameter from BOTH width and height so the gauge never
-    /// overflows either axis. When the panel is tall+narrow we wrap to a
-    /// vertical stack; the ring then has the full row height to grow into.
-    /// - Parameter isTall: true → LazyVStack mode (one ring per row).
-    private func ringSize(width w: CGFloat, height h: CGFloat,
-                          n: Int, isTall: Bool) -> CGFloat {
-        guard n > 0 else { return minRing }
-        let rowSpacing: CGFloat = isTall ? 10 : 16
-        let padding: CGFloat = 28
-        // Chrome above (header) + below (label) the ring within each cell.
-        // 22 (header row including dot) + 38 (3-line label VStack at 12/10/10)
-        // + 12 (top→rings spacing) = 72. Real chrome in production = ~78 with
-        // 14pt top padding. We keep the under-estimate so 3-ring vertical
-        // mode still grows the ring at the panel's true min height.
-        let verticalChrome: CGFloat = 22 + 38 + 12
-        let perRingW = max(0, (w - padding - rowSpacing * CGFloat(n - 1)) / CGFloat(n))
-        let rowsHeight = max(0, h - verticalChrome)
-        let perRowH = isTall
-            ? (rowsHeight - rowSpacing * CGFloat(n - 1)) / CGFloat(n)
-            : rowsHeight
-        let maxFromHeight = max(0, perRowH - 38 - 7)   // label + VStack spacing
-        let raw = min(perRingW, maxFromHeight)
-        // Floor: when the panel is too narrow for n rings at minRing, fall
-        // back to whatever fits. 36pt keeps the label captions legible (the
-        // 3-line label VStack needs ~38pt to render at full size).
-        let effectiveMin = max(36, min(minRing,
-                                       (w - padding) / CGFloat(n) - rowSpacing))
-        return min(max(raw, effectiveMin), maxRing)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             header
@@ -89,51 +50,13 @@ struct GaugeRowView: View {
         }
         .padding(14)
         .background(background)
-        .modifier(FitOrFill(expand: expandToFill))
+        .modifier(PanelOrPopoverFrame(panelSize: panelSize))
     }
 
     @ViewBuilder
     private var ringsRow: some View {
-        if expandToFill {
-            // GeometryReader drives both axis. Pick a layout that matches the
-            // panel's actual aspect: wide/short → HStack of stacked rings;
-            // tall/narrow → list rows (ring left, text right) so the
-            // provider name NEVER truncates to "Clau" / "Cod" / "Mini".
-            GeometryReader { geo in
-                let n = max(1, shown.count)
-                // Go list-mode when the row would overflow horizontally. A
-                // 3-ring stacked card needs ~130pt per slot (ring 84 + chrome
-                // + label width) — anything tighter goes to the list layout
-                // where the label gets the full panel width to breathe.
-                let slotNeeded: CGFloat = 130
-                let totalNeeded = slotNeeded * CGFloat(n) + 16 * CGFloat(n - 1) + 28
-                let isTall = n > 1 && geo.size.width < totalNeeded
-                let size = ringSize(width: geo.size.width,
-                                    height: geo.size.height,
-                                    n: n, isTall: isTall)
-                Group {
-                    if isTall {
-                        LazyVStack(alignment: .leading, spacing: 10) {
-                            ForEach(shown) { provider in
-                                CompactRingRow(provider: provider,
-                                               lang: prefs.language,
-                                               showRemaining: prefs.showRemaining,
-                                               ringSize: 56)
-                            }
-                        }
-                        .scrollDisabled(true)
-                    } else {
-                        HStack(alignment: .top, spacing: 16) {
-                            ForEach(shown) { provider in
-                                RingGauge(provider: provider, lang: prefs.language,
-                                          showRemaining: prefs.showRemaining,
-                                          ringSize: size)
-                            }
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
+        if let panelSize {
+            panelRings(panelSize)
         } else {
             HStack(alignment: .top, spacing: 16) {
                 ForEach(shown) { provider in
@@ -145,12 +68,40 @@ struct GaugeRowView: View {
         }
     }
 
-    /// `.fixedSize()` for the popover (hugs content) → removed when the panel
-    /// mode is on (fills the panel, rings scale with width).
-    private struct FitOrFill: ViewModifier {
-        let expand: Bool
+    @ViewBuilder
+    private func panelRings(_ size: PanelSize) -> some View {
+        if size == .small {
+            VStack(alignment: .leading, spacing: 9) {
+                ForEach(shown) { provider in
+                    CompactRingRow(provider: provider,
+                                   lang: prefs.language,
+                                   showRemaining: prefs.showRemaining,
+                                   ringSize: size.ringSize)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .top, spacing: size == .medium ? 14 : 18) {
+                ForEach(shown) { provider in
+                    RingGauge(provider: provider, lang: prefs.language,
+                              showRemaining: prefs.showRemaining,
+                              ringSize: size.ringSize)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    private struct PanelOrPopoverFrame: ViewModifier {
+        let panelSize: PanelSize?
         func body(content: Content) -> some View {
-            if expand { content } else { content.fixedSize() }
+            if let panelSize {
+                content.frame(width: panelSize.frameSize.width,
+                              height: panelSize.frameSize.height,
+                              alignment: .topLeading)
+            } else {
+                content.fixedSize()
+            }
         }
     }
 
@@ -198,6 +149,22 @@ struct GaugeRowView: View {
                 }
                 segment(L10n.t(.showRemaining, prefs.language), on: prefs.showRemaining) {
                     prefs.showRemaining = true
+                }
+            }
+
+            HStack(spacing: 7) {
+                Text(L10n.t(.panelSize, prefs.language))
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundColor(t.mute)
+                Spacer(minLength: 8)
+                segment(L10n.t(.sizeSmall, prefs.language), on: prefs.panelSize == .small) {
+                    prefs.panelSize = .small
+                }
+                segment(L10n.t(.sizeMedium, prefs.language), on: prefs.panelSize == .medium) {
+                    prefs.panelSize = .medium
+                }
+                segment(L10n.t(.sizeLarge, prefs.language), on: prefs.panelSize == .large) {
+                    prefs.panelSize = .large
                 }
             }
 

--- a/Sources/KajiGauge/HostingView.swift
+++ b/Sources/KajiGauge/HostingView.swift
@@ -1,0 +1,14 @@
+import AppKit
+
+// Shared AppKit host setup for SwiftUI surfaces.
+extension NSView {
+    func configureKajiHost(cornerRadius: CGFloat? = nil) {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+        if let cornerRadius {
+            layer?.cornerRadius = cornerRadius
+            layer?.cornerCurve = .continuous
+            layer?.masksToBounds = true
+        }
+    }
+}

--- a/Sources/KajiGauge/Prefs.swift
+++ b/Sources/KajiGauge/Prefs.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import CoreGraphics
 
 // MARK: - Prefs
 //
@@ -34,6 +35,9 @@ final class Prefs: ObservableObject {
     @Published var showRemaining: Bool {
         didSet { UserDefaults.standard.set(showRemaining, forKey: Key.showRemaining) }
     }
+    @Published var panelSize: PanelSize {
+        didSet { UserDefaults.standard.set(panelSize.rawValue, forKey: Key.panelSize) }
+    }
 
     enum Key {
         static let visibleProviders = "visibleProviders"
@@ -41,6 +45,7 @@ final class Prefs: ObservableObject {
         static let menubarStyle = "menubarStyle"
         static let dockEdge = "panelDockEdge"
         static let showRemaining = "showRemaining"
+        static let panelSize = "panelSize"
     }
 
     init() {
@@ -73,6 +78,11 @@ final class Prefs: ObservableObject {
             showRemaining = d.bool(forKey: Key.showRemaining)
         } else {
             showRemaining = false
+        }
+        if let raw = d.string(forKey: Key.panelSize), let size = PanelSize(rawValue: raw) {
+            panelSize = size
+        } else {
+            panelSize = .medium
         }
     }
 
@@ -123,6 +133,26 @@ enum MenubarStyle: String {
     var toggled: MenubarStyle { self == .mono ? .color : .mono }
 }
 
+enum PanelSize: String, CaseIterable {
+    case small, medium, large
+
+    var frameSize: CGSize {
+        switch self {
+        case .small:  return CGSize(width: 236, height: 278)
+        case .medium: return CGSize(width: 360, height: 206)
+        case .large:  return CGSize(width: 520, height: 246)
+        }
+    }
+
+    var ringSize: CGFloat {
+        switch self {
+        case .small:  return 52
+        case .medium: return 78
+        case .large:  return 98
+        }
+    }
+}
+
 // MARK: - L10n
 //
 // Minimal two-language string table, keyed by an enum so callers can't typo a
@@ -135,7 +165,8 @@ enum L10n {
         case refreshNow, quitApp, language, providers, show
         case menubar, styleMono, styleColor
         case dockExpand, dockHint
-        case usage, showUsed, showRemaining
+            case usage, showUsed, showRemaining
+            case panelSize, sizeSmall, sizeMedium, sizeLarge
     }
 
     private static let table: [K: (en: String, zh: String)] = [
@@ -156,10 +187,14 @@ enum L10n {
         .styleMono:    ("Mono",               "\u{9ED1}\u{767D}"),                         // 黑白
         .styleColor:   ("Color",              "\u{5F69}\u{8272}"),                         // 彩色
         .dockExpand:   ("tap to expand",      "\u{70B9}\u{51FB}\u{5C55}\u{5F00}"),         // 点击展开
-        .dockHint:     ("drag to undock",     "\u{62D6}\u{52A8}\u{5C55}\u{5F00}"),         // 拖动展开
+        .dockHint:     ("click arrow",        "\u{70B9}\u{7BAD}\u{5934}"),                 // 点箭头
         .usage:        ("Usage",              "\u{7528}\u{91CF}"),                         // 用量
         .showUsed:     ("Used",               "\u{5DF2}\u{7528}"),                         // 已用
         .showRemaining:("Remaining",          "\u{5269}\u{4F59}"),                         // 剩余
+        .panelSize:    ("Size",               "\u{5927}\u{5C0F}"),                         // 大小
+        .sizeSmall:    ("S",                  "\u{5C0F}"),                                 // 小
+        .sizeMedium:   ("M",                  "\u{4E2D}"),                                 // 中
+        .sizeLarge:    ("L",                  "\u{5927}"),                                 // 大
     ]
 
     static func t(_ k: K, _ lang: Lang) -> String {


### PR DESCRIPTION
## Summary
- remove free resizing and use fixed small/medium/large panel sizes
- redesign edge-docked tab behavior and visuals
- keep docked tab draggable along the screen edge and reclamp after release

## Verification
- xcrun swiftc -target arm64-apple-macosx13.0 Sources/KajiGauge/*.swift -o /tmp/KajiGauge-check
- git diff --check