### PR TITLE
ship v0.5.9

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.6</string>
+	<string>0.5.9</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -24,7 +24,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hostingView: KajiHostingView<StatusItemView>!
     private let updateChecker = UpdateChecker()
     private let sleepController = SleepController()
-    private let petRunner = PetRunner()
     private let petCatalog = PetCatalogStore()
     private lazy var workSession = WorkSessionController(prefs: prefs)
     private let systemMonitor = SystemMonitor()
@@ -77,12 +76,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         prefs.$visibleProviders
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.rebuildPopoverContentIfShown() }
-            .store(in: &cancellables)
-        prefs.$petId
-            .receive(on: RunLoop.main)
-            .sink { [weak self] petId in
-                self?.handlePetSelectionChanged(petId)
-            }
             .store(in: &cancellables)
         NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didActivateApplicationNotification)
             .receive(on: RunLoop.main)
@@ -162,7 +155,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         store.stop()
         breakWatchdogTimer?.invalidate()
         petStateTimer?.invalidate()
-        petRunner.stop(force: true)
         closeBreakOverlay()
     }
 
@@ -249,19 +241,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onRefresh: { [weak self] in self?.store.refresh() },
             onUpdate: { [weak self] in self?.handleUpdateAction() },
             onToggleKeepAwake: { [weak self] in self?.prefs.preventSleep.toggle() },
-            onTogglePet: { [weak self] in
-                guard let self else { return }
-                self.petRunner.toggle(petId: self.prefs.petId)
-            },
+            onTogglePet: {},
             onOpenSettings: { [weak self] in self?.openSettings() },
             onQuit: { NSApp.terminate(nil) }
         )
         let content = KajiPopoverView(store: store,
                                       prefs: prefs,
-                                      updateChecker: updateChecker,
-                                      sleepController: sleepController,
-                                      petRunner: petRunner,
-                                      petCatalog: petCatalog,
                                       workSession: workSession,
                                       systemMonitor: systemMonitor,
                                       dailyGoals: dailyGoals,
@@ -365,15 +350,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         prefs.petId = resolvedPetId
     }
 
-    private func handlePetSelectionChanged(_ petId: String) {
-        guard petRunner.isRunning,
-              !petRunner.isBusy,
-              petRunner.runningPetId != petId else {
-            return
-        }
-        petRunner.toggle(petId: petId)
-    }
-
     private func publishPetState() {
         PetBridge.write(providers: store.providers,
                         lastError: store.lastError,
@@ -421,11 +397,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showBreakOverlay() {
         if !breakWindows.isEmpty {
-            for window in breakWindows {
-                window.makeKeyAndOrderFront(nil)
-                window.orderFrontRegardless()
-            }
-            NSApp.activate(ignoringOtherApps: true)
+            // The watchdog calls this every second. Only recover windows that
+            // somehow became hidden; repeatedly taking key focus prevents the
+            // system screenshot UI from staying active.
+            breakWindows
+                .filter { !$0.isVisible }
+                .forEach { $0.orderFrontRegardless() }
             return
         }
         let mainScreen = NSScreen.main
@@ -456,12 +433,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             window.backgroundColor = NSColor.windowBackgroundColor
             window.hasShadow = false
             window.ignoresMouseEvents = !isPrimary
-            window.level = .screenSaver
+            // Stay above normal/full-screen app windows, but below system UI
+            // such as Screenshot's selection overlay and toolbar.
+            window.level = .statusBar
             window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
             window.isMovableByWindowBackground = false
             window.hidesOnDeactivate = false
-            window.makeKeyAndOrderFront(nil)
-            window.orderFrontRegardless()
+            if isPrimary {
+                window.makeKeyAndOrderFront(nil)
+            } else {
+                window.orderFrontRegardless()
+            }
             return window
         }
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/Kaji/BreakExerciseView.swift
+++ b/Sources/Kaji/BreakExerciseView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+enum BreakExercise: String, CaseIterable, Identifiable {
+    case shoulderRoll
+    case neckRelease
+    case chestOpen
+    case standingTwist
+    case squat
+    case calfRaise
+    case wristReset
+    case eyeReset
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .shoulderRoll: return "肩膀绕环"
+        case .neckRelease: return "颈部放松"
+        case .chestOpen: return "扩胸伸展"
+        case .standingTwist: return "站姿转体"
+        case .squat: return "慢速深蹲"
+        case .calfRaise: return "提踵"
+        case .wristReset: return "手腕重置"
+        case .eyeReset: return "20-20-20 护眼"
+        }
+    }
+
+    var duration: String {
+        switch self {
+        case .eyeReset: return "20 秒"
+        case .squat: return "8 次"
+        case .standingTwist: return "左右 6 次"
+        case .calfRaise: return "12 次"
+        default: return "30 秒"
+        }
+    }
+
+    var cue: String {
+        switch self {
+        case .shoulderRoll: return "肩膀向后画大圈，保持呼吸。"
+        case .neckRelease: return "耳朵缓慢靠向肩膀，不要耸肩。"
+        case .chestOpen: return "双手向后展开，胸口向前。"
+        case .standingTwist: return "髋部朝前，上身左右转动。"
+        case .squat: return "膝盖朝脚尖方向，慢下慢起。"
+        case .calfRaise: return "扶稳桌面，脚跟缓慢抬起落下。"
+        case .wristReset: return "手臂伸直，轻拉手掌和手指。"
+        case .eyeReset: return "看向 6 米外，让眼睛离开屏幕。"
+        }
+    }
+}
+
+struct BreakExerciseMotionView: View {
+    let exercise: BreakExercise
+    let accent: Color
+    let ink: Color
+    let muted: Color
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @ViewBuilder
+    var body: some View {
+        if reduceMotion {
+            motionCanvas(0)
+        } else {
+            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+                let seconds = timeline.date.timeIntervalSinceReferenceDate
+                motionCanvas(sin(seconds * .pi * 1.15))
+            }
+        }
+    }
+
+    private func motionCanvas(_ motion: Double) -> some View {
+        Canvas { context, size in
+            if exercise == .eyeReset {
+                drawEyes(context: &context, size: size, motion: motion)
+            } else {
+                drawFigure(context: &context, size: size, motion: motion)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func drawFigure(context: inout GraphicsContext, size: CGSize, motion: Double) {
+        let w = size.width
+        let h = size.height
+        let centerX = w * 0.5
+        let cycle = CGFloat((motion + 1) * 0.5)
+        var lift: CGFloat = 0
+        var headShift: CGFloat = 0
+        var shoulderSpread: CGFloat = 0
+        var armLift: CGFloat = 0
+        var hipTwist: CGFloat = 0
+        var kneeBend: CGFloat = 0
+
+        switch exercise {
+        case .shoulderRoll:
+            armLift = CGFloat(motion) * h * 0.12
+            shoulderSpread = cycle * w * 0.06
+        case .neckRelease:
+            headShift = CGFloat(motion) * w * 0.08
+        case .chestOpen:
+            shoulderSpread = cycle * w * 0.18
+            armLift = -cycle * h * 0.08
+        case .standingTwist:
+            hipTwist = CGFloat(motion) * w * 0.12
+        case .squat:
+            kneeBend = cycle * h * 0.16
+        case .calfRaise:
+            lift = cycle * h * 0.11
+        case .wristReset:
+            shoulderSpread = w * 0.14
+            armLift = CGFloat(motion) * h * 0.05
+        case .eyeReset:
+            break
+        }
+
+        let head = CGPoint(x: centerX + headShift, y: h * 0.18 + kneeBend - lift)
+        let neck = CGPoint(x: centerX, y: h * 0.31 + kneeBend - lift)
+        let leftShoulder = CGPoint(x: centerX - w * 0.12 - shoulderSpread, y: h * 0.35 + kneeBend - lift)
+        let rightShoulder = CGPoint(x: centerX + w * 0.12 + shoulderSpread, y: h * 0.35 + kneeBend - lift)
+        let hip = CGPoint(x: centerX + hipTwist * 0.35, y: h * 0.59 + kneeBend - lift)
+        let leftHand = CGPoint(x: centerX - w * 0.27 - shoulderSpread, y: h * 0.55 + armLift + kneeBend - lift)
+        let rightHand = CGPoint(x: centerX + w * 0.27 + shoulderSpread, y: h * 0.55 - armLift + kneeBend - lift)
+        let leftKnee = CGPoint(x: centerX - w * 0.10 - kneeBend * 0.45, y: h * 0.76 + kneeBend * 0.28 - lift)
+        let rightKnee = CGPoint(x: centerX + w * 0.10 + kneeBend * 0.45, y: h * 0.76 + kneeBend * 0.28 - lift)
+        let leftFoot = CGPoint(x: centerX - w * 0.16, y: h * 0.94)
+        let rightFoot = CGPoint(x: centerX + w * 0.16, y: h * 0.94)
+
+        var skeleton = Path()
+        skeleton.move(to: neck)
+        skeleton.addLine(to: hip)
+        skeleton.move(to: leftShoulder)
+        skeleton.addLine(to: rightShoulder)
+        skeleton.move(to: leftShoulder)
+        skeleton.addLine(to: leftHand)
+        skeleton.move(to: rightShoulder)
+        skeleton.addLine(to: rightHand)
+        skeleton.move(to: hip)
+        skeleton.addLine(to: leftKnee)
+        skeleton.addLine(to: leftFoot)
+        skeleton.move(to: hip)
+        skeleton.addLine(to: rightKnee)
+        skeleton.addLine(to: rightFoot)
+        context.stroke(skeleton,
+                       with: .color(ink),
+                       style: StrokeStyle(lineWidth: max(3, w * 0.035), lineCap: .round, lineJoin: .round))
+
+        let headSize = min(w, h) * 0.20
+        context.fill(Path(ellipseIn: CGRect(x: head.x - headSize / 2,
+                                            y: head.y - headSize / 2,
+                                            width: headSize,
+                                            height: headSize)),
+                     with: .color(accent))
+
+        for point in [leftHand, rightHand] {
+            let radius = max(3, w * 0.03)
+            context.fill(Path(ellipseIn: CGRect(x: point.x - radius,
+                                                y: point.y - radius,
+                                                width: radius * 2,
+                                                height: radius * 2)),
+                         with: .color(accent))
+        }
+
+        if exercise == .shoulderRoll {
+            let ringRadius = w * (0.15 + cycle * 0.025)
+            let ringRect = CGRect(x: centerX - ringRadius,
+                                  y: h * 0.35 - ringRadius,
+                                  width: ringRadius * 2,
+                                  height: ringRadius * 2)
+            context.stroke(Path(ellipseIn: ringRect),
+                           with: .color(accent.opacity(0.35)),
+                           style: StrokeStyle(lineWidth: 2, dash: [3, 5]))
+        }
+    }
+
+    private func drawEyes(context: inout GraphicsContext, size: CGSize, motion: Double) {
+        let eyeWidth = size.width * 0.30
+        let eyeHeight = size.height * 0.34
+        let pupilShift = CGFloat(motion) * eyeWidth * 0.20
+        for centerX in [size.width * 0.30, size.width * 0.70] {
+            let rect = CGRect(x: centerX - eyeWidth / 2,
+                              y: size.height * 0.5 - eyeHeight / 2,
+                              width: eyeWidth,
+                              height: eyeHeight)
+            context.stroke(Path(roundedRect: rect, cornerRadius: eyeHeight / 2),
+                           with: .color(ink),
+                           lineWidth: max(2, size.width * 0.025))
+            let pupil = min(eyeWidth, eyeHeight) * 0.34
+            context.fill(Path(ellipseIn: CGRect(x: centerX + pupilShift - pupil / 2,
+                                                y: size.height * 0.5 - pupil / 2,
+                                                width: pupil,
+                                                height: pupil)),
+                         with: .color(accent))
+        }
+        var horizon = Path()
+        horizon.move(to: CGPoint(x: size.width * 0.18, y: size.height * 0.88))
+        horizon.addLine(to: CGPoint(x: size.width * 0.82, y: size.height * 0.88))
+        context.stroke(horizon,
+                       with: .color(muted.opacity(0.55)),
+                       style: StrokeStyle(lineWidth: 2, dash: [4, 5]))
+    }
+}

--- a/Sources/Kaji/BreakOverlayView.swift
+++ b/Sources/Kaji/BreakOverlayView.swift
@@ -11,7 +11,9 @@ struct BreakOverlayView: View {
     let onStartBreak: () -> Void
     let onSkip: () -> Void
 
+    @State private var exerciseIndex = Int.random(in: 0..<BreakExercise.allCases.count)
     @Environment(\.colorScheme) private var scheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var t: KajiTheme { .resolve(scheme, prefs.menubarStyle) }
 
     var body: some View {
@@ -19,37 +21,36 @@ struct BreakOverlayView: View {
             ZStack {
                 background
                 if isPrimary {
-                    petMark(in: geo.size)
-                    VStack(spacing: 14) {
-                        Spacer()
-                        VStack(spacing: 8) {
-                            Text(title)
-                                .font(.system(size: 42, weight: .bold, design: .rounded))
-                                .foregroundColor(t.cream)
-                            Text(subtitle)
-                                .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                .foregroundColor(t.mute)
-                                .multilineTextAlignment(.center)
+                    let compactHeight = geo.size.height < 1_280
+                    let controlsWidth = min(560, max(0, geo.size.width - 48))
+                    if compactHeight {
+                        VStack(spacing: 10) {
+                            Spacer(minLength: 8)
+                            petMark(in: geo.size, heightScale: 0.42)
+                            breakControls(spacing: 10, showGoals: false)
+                                .frame(width: controlsWidth)
                         }
-                        Text(clock)
-                            .font(.system(size: 64, weight: .bold, design: .rounded))
-                            .foregroundColor(t.cream)
-                            .monospacedDigit()
-                        pendingGoalStrip
-                        HStack(spacing: 12) {
-                            actionButton(workSession.phase == .breaking ? "Breaking" : "Start Break",
-                                         filled: true,
-                                         action: onStartBreak)
-                            if prefs.allowBreakSkip {
-                                actionButton("Skip", filled: false, action: onSkip)
-                            }
+                        .frame(width: min(760, max(0, geo.size.width - 48)))
+                        .padding(.bottom, max(28, geo.safeAreaInsets.bottom + 24))
+                    } else {
+                        petMark(in: geo.size, heightScale: 0.72)
+                        VStack(spacing: 14) {
+                            Spacer()
+                            breakControls(spacing: 14, showGoals: true)
                         }
-                        Text("Skip today \(workSession.skipCountToday)")
-                            .font(.system(size: 11, weight: .semibold, design: .rounded))
-                            .foregroundColor(t.ash)
+                        .frame(width: controlsWidth)
+                        .padding(.bottom, max(28, geo.safeAreaInsets.bottom + 24))
                     }
-                    .frame(width: min(560, geo.size.width - 48))
-                    .padding(.bottom, max(28, geo.safeAreaInsets.bottom + 24))
+                }
+            }
+        }
+        .task {
+            guard isPrimary, !reduceMotion else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(10))
+                guard !Task.isCancelled else { break }
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    exerciseIndex = (exerciseIndex + 1) % BreakExercise.allCases.count
                 }
             }
         }
@@ -83,8 +84,8 @@ struct BreakOverlayView: View {
     }
 
     @ViewBuilder
-    private func petMark(in size: CGSize) -> some View {
-        let width = min(size.width * 0.78, size.height * 0.92, 760)
+    private func petMark(in size: CGSize, heightScale: CGFloat) -> some View {
+        let width = min(size.width * 0.78, size.height * heightScale, 760)
         ZStack {
             Ellipse()
                 .fill(t.panel.opacity(0.36))
@@ -96,6 +97,93 @@ struct BreakOverlayView: View {
                 .shadow(color: t.gold.opacity(0.16), radius: 38, x: 0, y: 24)
         }
         .accessibilityLabel(Text("Navi Panda blocks work"))
+    }
+
+    private func breakControls(spacing: CGFloat, showGoals: Bool) -> some View {
+        VStack(spacing: spacing) {
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: 42, weight: .bold, design: .rounded))
+                    .foregroundColor(t.cream)
+                Text(subtitle)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .multilineTextAlignment(.center)
+            }
+            Text(clock)
+                .font(.system(size: 64, weight: .bold, design: .rounded))
+                .foregroundColor(t.cream)
+                .monospacedDigit()
+            exerciseCard
+            if showGoals {
+                pendingGoalStrip
+            }
+            HStack(spacing: 12) {
+                actionButton(workSession.phase == .breaking ? "Breaking" : "Start Break",
+                             filled: true,
+                             action: onStartBreak)
+                if prefs.allowBreakSkip {
+                    actionButton("Skip", filled: false, action: onSkip)
+                }
+            }
+            Text("Skip today \(workSession.skipCountToday)")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(t.ash)
+        }
+    }
+
+    private var selectedExercise: BreakExercise {
+        BreakExercise.allCases[exerciseIndex % BreakExercise.allCases.count]
+    }
+
+    private var exerciseCard: some View {
+        HStack(spacing: 14) {
+            BreakExerciseMotionView(exercise: selectedExercise,
+                                    accent: t.gold,
+                                    ink: t.cream,
+                                    muted: t.mute)
+                .frame(width: 92, height: 82)
+                .padding(.horizontal, 4)
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 7) {
+                    Text("推荐动作")
+                        .font(.system(size: 11, weight: .bold, design: .rounded))
+                        .foregroundColor(t.gold)
+                    Text(selectedExercise.duration)
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.mute)
+                }
+                Text(selectedExercise.title)
+                    .font(.system(size: 17, weight: .bold, design: .rounded))
+                    .foregroundColor(t.cream)
+                    .contentTransition(.opacity)
+                Text(selectedExercise.cue)
+                    .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 4)
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    exerciseIndex = (exerciseIndex + 1) % BreakExercise.allCases.count
+                }
+            } label: {
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(t.cream)
+                    .frame(width: 34, height: 34)
+                    .background(Circle().fill(t.track.opacity(0.7)))
+            }
+            .buttonStyle(.plain)
+            .help("换一个动作")
+            .accessibilityLabel(Text("换一个动作"))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .frame(maxWidth: .infinity, minHeight: 100, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(t.panel.opacity(0.82)))
+        .id(selectedExercise.id)
+        .transition(.opacity)
     }
 
     private var pendingGoalStrip: some View {

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -19,10 +19,6 @@ private struct PopoverContentSizeKey: PreferenceKey {
 struct KajiPopoverView: View {
     @ObservedObject var store: QuotaStore
     @ObservedObject var prefs: Prefs
-    @ObservedObject var updateChecker: UpdateChecker
-    @ObservedObject var sleepController: SleepController
-    @ObservedObject var petRunner: PetRunner
-    @ObservedObject var petCatalog: PetCatalogStore
     @ObservedObject var workSession: WorkSessionController
     @ObservedObject var systemMonitor: SystemMonitor
     @ObservedObject var dailyGoals: DailyGoalStore
@@ -33,6 +29,7 @@ struct KajiPopoverView: View {
 
     @State private var panel: KajiPanel = .quota
     @State private var hoveredGoalDay: DailyGoalHistoryDay?
+    @State private var showCleanConfirmation = false
     @Environment(\.colorScheme) private var scheme
 
     private var t: KajiTheme { .resolve(scheme, prefs.menubarStyle) }
@@ -259,138 +256,302 @@ struct KajiPopoverView: View {
     }
 
     private var systemPanel: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 8) {
-                metricCard("CPU", "cpu", systemValue(systemMonitor.snapshot.cpuPercent),
-                           fraction: systemMonitor.snapshot.cpuPercent / 100,
-                           warning: systemMonitor.snapshot.cpuPercent >= 80)
-                metricCard("Mem", "memorychip", systemValue(systemMonitor.snapshot.memoryPercent),
-                           fraction: systemMonitor.snapshot.memoryPercent / 100,
-                           warning: systemMonitor.snapshot.memoryPercent >= 75)
-            }
-            HStack(spacing: 8) {
-                metricCard("Disk", "internaldrive", systemValue(systemMonitor.snapshot.diskPercent),
-                           fraction: systemMonitor.snapshot.diskPercent / 100,
-                           warning: systemMonitor.snapshot.diskPercent >= 85)
-                metricCard("Clean", "sparkles", bytes(systemMonitor.selectedCleanableBytes),
-                           fraction: cleanFraction,
-                           warning: systemMonitor.selectedCleanableBytes >= 512 * 1024 * 1024)
-            }
-            systemRows
-            .frame(maxWidth: .infinity, minHeight: 64, alignment: .topLeading)
-            cleanControls
-            autoCleanStatus
+        VStack(alignment: .leading, spacing: 10) {
+            systemPulse
+            systemMetrics
+            hotProcesses
+            cleanupReview
         }
         .onAppear {
             systemMonitor.refresh()
             systemMonitor.scanCleanables()
         }
-    }
-
-    private var cleanControls: some View {
-        Button {
-            prefs.autoCleanEnabled.toggle()
-            if prefs.autoCleanEnabled {
-                systemMonitor.runAutoMaintenanceIfNeeded()
+        .confirmationDialog("永久删除所选缓存？",
+                            isPresented: $showCleanConfirmation,
+                            titleVisibility: .visible) {
+            Button("删除 \(bytes(systemMonitor.selectedCleanableBytes))", role: .destructive) {
+                systemMonitor.cleanKajiArtifacts()
             }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: prefs.autoCleanEnabled ? "bolt.circle.fill" : "bolt.circle")
-                    .font(.system(size: 11, weight: .bold))
-                Text(prefs.autoCleanEnabled ? "Auto Reclaim On" : "Auto Reclaim")
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
-                Spacer(minLength: 8)
-                Text(prefs.autoCleanEnabled ? "On" : "Off")
-                    .font(.system(size: 10, weight: .bold, design: .rounded))
-            }
-            .foregroundColor(prefs.autoCleanEnabled ? t.bg : t.mute)
-            .padding(.horizontal, 12)
-            .frame(height: 36)
-            .frame(maxWidth: .infinity)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(prefs.autoCleanEnabled ? t.gold : Color.clear)
-                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(prefs.autoCleanEnabled ? Color.clear : t.track, lineWidth: 1))
-            )
-            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var autoCleanStatus: some View {
-        HStack(spacing: 6) {
-            Image(systemName: prefs.autoCleanEnabled ? "bolt.circle.fill" : "bolt.circle")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundColor(prefs.autoCleanEnabled ? t.gold : t.ash)
-            Text(autoCleanText)
-                .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                .foregroundColor(t.mute)
-                .lineLimit(1)
-            Spacer(minLength: 4)
+            Button("取消", role: .cancel) {}
+        } message: {
+            Text("将删除所选缓存和构建产物。开发工具会按需重新生成；操作无法撤销。")
         }
     }
 
-    private var autoCleanText: String {
-        if !prefs.autoCleanEnabled {
-            return "Auto off · no background cleanup"
-        }
-        if systemMonitor.isAutoCleaning {
-            return "Cleaning safe caches"
-        }
-        if systemMonitor.isReclaimingMemory {
-            return "Reclaiming inactive memory"
-        }
-        if systemMonitor.lastAutoCleanedBytes > 0 {
-            return "Cleaned \(bytes(systemMonitor.lastAutoCleanedBytes)) · Mem 75% / Disk 85%"
-        }
-        if systemMonitor.lastMemoryReclaimAt != nil {
-            return "Memory reclaimed · Mem 75% / Disk 85%"
-        }
-        if systemMonitor.lastOrphanCleanedCount > 0 {
-            return "Cleaned \(systemMonitor.lastOrphanCleanedCount) Kaji orphan processes"
-        }
-        return "Auto on · Mem 75% / Disk 85% / Kaji orphans / Cache 512M"
-    }
-
-    private var systemRows: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack(spacing: 8) {
-                Text("Processes")
-                    .font(.system(size: 10.5, weight: .semibold, design: .rounded))
-                    .foregroundColor(t.mute)
-                    .lineLimit(1)
-                Spacer(minLength: 6)
-                Text("\(systemMonitor.snapshot.processCount)")
-                    .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                    .foregroundColor(t.gold)
+    private var systemPulse: some View {
+        HStack(spacing: 11) {
+            ZStack {
+                Circle()
+                    .fill(healthColor.opacity(0.13))
+                Circle()
+                    .stroke(healthColor.opacity(0.25), lineWidth: 5)
+                Circle()
+                    .trim(from: 0, to: Double(systemHealthScore) / 100)
+                    .stroke(healthColor,
+                            style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                Text("\(systemHealthScore)")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(t.cream)
                     .monospacedDigit()
             }
-            ForEach(systemMonitor.snapshot.topProcesses.prefix(2)) { proc in
-                HStack(spacing: 8) {
-                    Text(proc.command)
+            .frame(width: 54, height: 54)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(systemHealthTitle)
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .foregroundColor(t.cream)
+                Text(systemHealthDetail)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 5)
+            Button {
+                systemMonitor.refresh()
+                systemMonitor.scanCleanables()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(t.mute)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(t.track.opacity(0.55)))
+                    .rotationEffect(.degrees(systemMonitor.isRefreshing ? 180 : 0))
+                    .animation(systemMonitor.isRefreshing ? .linear(duration: 0.5).repeatForever(autoreverses: false) : .default,
+                               value: systemMonitor.isRefreshing)
+            }
+            .buttonStyle(.plain)
+            .disabled(systemMonitor.isRefreshing)
+            .help("刷新系统状态")
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(t.panel.opacity(0.78)))
+    }
+
+    private var systemMetrics: some View {
+        HStack(spacing: 7) {
+            pulseMetric("CPU", "cpu", systemMonitor.snapshot.cpuPercent, warningAt: 80)
+            pulseMetric("MEM", "memorychip", systemMonitor.snapshot.memoryPercent, warningAt: 75)
+            pulseMetric("DISK", "internaldrive", systemMonitor.snapshot.diskPercent, warningAt: 85)
+        }
+    }
+
+    private func pulseMetric(_ title: String,
+                             _ systemImage: String,
+                             _ value: Double,
+                             warningAt: Double) -> some View {
+        let warning = value >= warningAt
+        let accent = warning ? t.amber : t.gold
+        return VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 4) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 9, weight: .bold))
+                Text(title)
+                    .font(.system(size: 8.5, weight: .bold, design: .rounded))
+                Spacer(minLength: 2)
+                if warning {
+                    Circle().fill(accent).frame(width: 5, height: 5)
+                }
+            }
+            .foregroundColor(warning ? accent : t.mute)
+            Text(systemValue(value))
+                .font(.system(size: 17, weight: .bold, design: .rounded))
+                .foregroundColor(t.cream)
+                .monospacedDigit()
+            progressBar(value / 100, color: accent)
+                .frame(height: 5)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(t.panel.opacity(0.68)))
+    }
+
+    private var hotProcesses: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            sectionHeader("Hot Processes", detail: "\(systemMonitor.snapshot.processCount) running", image: "flame")
+            if systemMonitor.snapshot.topProcesses.isEmpty {
+                Text("等待系统采样…")
+                    .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .frame(maxWidth: .infinity, minHeight: 36, alignment: .center)
+            } else {
+                ForEach(systemMonitor.snapshot.topProcesses.prefix(3)) { process in
+                    processRow(process)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(t.panel.opacity(0.62)))
+    }
+
+    private func processRow(_ process: ProcessSnapshot) -> some View {
+        HStack(spacing: 8) {
+            Text(String(process.command.prefix(1)).uppercased())
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .foregroundColor(t.bg)
+                .frame(width: 22, height: 22)
+                .background(Circle().fill(process.cpu >= 50 ? t.amber : t.gold))
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 5) {
+                    Text(process.command)
                         .font(.system(size: 10.5, weight: .semibold, design: .rounded))
                         .foregroundColor(t.cream)
                         .lineLimit(1)
-                    Spacer(minLength: 6)
-                    Text("\(Int(proc.cpu.rounded()))%")
-                        .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                        .foregroundColor(t.gold)
-                        .monospacedDigit()
-                }
-            }
-            if !systemMonitor.orphanProcesses.isEmpty {
-                HStack(spacing: 8) {
-                    Text("Kaji orphans")
-                        .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    Spacer(minLength: 5)
+                    Text("CPU \(Int(process.cpu.rounded()))%")
+                        .foregroundColor(process.cpu >= 50 ? t.amber : t.gold)
+                    Text("MEM \(String(format: "%.1f", process.memory))%")
                         .foregroundColor(t.mute)
-                    Spacer(minLength: 6)
-                    Text("\(systemMonitor.orphanProcesses.count)")
-                        .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                        .foregroundColor(t.amber)
-                        .monospacedDigit()
                 }
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                progressBar(min(process.cpu / maxTopProcessCPU, 1),
+                            color: process.cpu >= 50 ? t.amber : t.gold)
+                    .frame(height: 4)
             }
         }
+        .help("PID \(process.pid)")
+    }
+
+    private var cleanupReview: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Cleanup",
+                          detail: systemMonitor.isScanningCleanables ? "Scanning…" : "Review \(bytes(systemMonitor.selectedCleanableBytes))",
+                          image: "sparkles")
+            let visible = systemMonitor.cleanableItems.filter { !$0.isEmpty }
+            if visible.isEmpty {
+                Text(systemMonitor.isScanningCleanables ? "正在扫描可清理项目…" : "当前没有可清理缓存")
+                    .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .frame(maxWidth: .infinity, minHeight: 32, alignment: .center)
+            } else {
+                ForEach(visible.prefix(4)) { item in
+                    cleanableRow(item)
+                }
+                if visible.count > 4 {
+                    Text("另有 \(visible.count - 4) 项 · 清理时包含已选项目")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.ash)
+                }
+            }
+            HStack(spacing: 7) {
+                Button {
+                    prefs.autoCleanEnabled.toggle()
+                    if prefs.autoCleanEnabled { systemMonitor.runAutoMaintenanceIfNeeded() }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: prefs.autoCleanEnabled ? "bolt.fill" : "bolt")
+                        Text(prefs.autoCleanEnabled ? "Auto On" : "Auto")
+                    }
+                    .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                    .foregroundColor(prefs.autoCleanEnabled ? t.bg : t.mute)
+                    .padding(.horizontal, 9)
+                    .frame(height: 30)
+                    .background(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(prefs.autoCleanEnabled ? t.gold : Color.clear)
+                        .overlay(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .stroke(prefs.autoCleanEnabled ? Color.clear : t.track, lineWidth: 1)))
+                }
+                .buttonStyle(.plain)
+                Spacer(minLength: 5)
+                Button {
+                    showCleanConfirmation = true
+                } label: {
+                    Text(systemMonitor.isCleaning ? "Cleaning…" : "Clean \(bytes(systemMonitor.selectedCleanableBytes))")
+                        .font(.system(size: 10, weight: .bold, design: .rounded))
+                        .foregroundColor(t.bg)
+                        .padding(.horizontal, 11)
+                        .frame(height: 30)
+                        .background(RoundedRectangle(cornerRadius: 7, style: .continuous).fill(t.gold))
+                }
+                .buttonStyle(.plain)
+                .disabled(systemMonitor.selectedCleanableBytes <= 0 || systemMonitor.isCleaning)
+                .opacity(systemMonitor.selectedCleanableBytes <= 0 ? 0.45 : 1)
+            }
+            if systemMonitor.lastCleanedBytes > 0 {
+                Text("已清理 \(bytes(systemMonitor.lastCleanedBytes))")
+                    .font(.system(size: 9.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.gold)
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(t.panel.opacity(0.62)))
+    }
+
+    private func cleanableRow(_ item: CleanableItem) -> some View {
+        Button {
+            systemMonitor.toggleCleanable(item)
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: systemMonitor.selectedCleanableIds.contains(item.id) ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(systemMonitor.selectedCleanableIds.contains(item.id) ? t.gold : t.ash)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(item.title)
+                        .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.cream)
+                        .lineLimit(1)
+                    Text(item.isAutoSafe ? "Kaji safe cache" : "Review before cleaning")
+                        .font(.system(size: 8.5, weight: .medium, design: .rounded))
+                        .foregroundColor(item.isAutoSafe ? t.mute : t.amber)
+                }
+                Spacer(minLength: 5)
+                Text(bytes(item.bytes))
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .monospacedDigit()
+            }
+        }
+        .buttonStyle(.plain)
+        .help(item.path)
+    }
+
+    private func sectionHeader(_ title: String, detail: String, image: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: image)
+                .font(.system(size: 9.5, weight: .bold))
+                .foregroundColor(t.gold)
+            Text(title)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .foregroundColor(t.cream)
+            Spacer(minLength: 5)
+            Text(detail)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(t.ash)
+                .lineLimit(1)
+        }
+    }
+
+    private var maxTopProcessCPU: Double {
+        max(systemMonitor.snapshot.topProcesses.map(\.cpu).max() ?? 1, 1)
+    }
+
+    private var systemHealthScore: Int {
+        guard systemMonitor.snapshot.hasSample else { return 0 }
+        let cpuPenalty = max(0, systemMonitor.snapshot.cpuPercent - 35) * 0.48
+        let memoryPenalty = max(0, systemMonitor.snapshot.memoryPercent - 55) * 0.62
+        let diskPenalty = max(0, systemMonitor.snapshot.diskPercent - 70) * 0.72
+        return max(0, min(100, Int((100 - cpuPenalty - memoryPenalty - diskPenalty).rounded())))
+    }
+
+    private var systemHealthTitle: String {
+        if !systemMonitor.snapshot.hasSample { return "System Pulse" }
+        if systemHealthScore >= 85 { return "运行流畅" }
+        if systemHealthScore >= 65 { return "负载偏高" }
+        return "系统忙碌"
+    }
+
+    private var systemHealthDetail: String {
+        if let error = systemMonitor.lastError { return "采样失败 · \(error)" }
+        if !systemMonitor.snapshot.hasSample { return "正在读取 CPU、内存和磁盘" }
+        if let hottest = systemMonitor.snapshot.topProcesses.first {
+            return "当前最热 \(hottest.command) · CPU \(Int(hottest.cpu.rounded()))%"
+        }
+        return "没有持续高负载进程"
+    }
+
+    private var healthColor: Color {
+        if systemHealthScore >= 85 { return t.gold }
+        if systemHealthScore >= 65 { return t.cream.opacity(0.8) }
+        return t.amber
     }
 
     private var goalsPanel: some View {
@@ -504,14 +665,7 @@ struct KajiPopoverView: View {
 
     private var controlsFooter: some View {
         HStack(spacing: 7) {
-            iconButton("pawprint", title: L10n.t(.pet, prefs.language), action: controls.onTogglePet,
-                       filled: petRunner.isRunning)
-            Spacer(minLength: 4)
-            compactTab("Q", active: panel == .quota) { panel = .quota }
-            compactTab("W", active: panel == .work) { panel = .work }
-            compactTab("S", active: panel == .system) { panel = .system }
-            compactTab("G", active: panel == .goals) { panel = .goals }
-            Spacer(minLength: 4)
+            Spacer()
             iconButton("gearshape", title: L10n.t(.settings, prefs.language), action: controls.onOpenSettings)
             iconButton("power", title: L10n.t(.quit, prefs.language), action: controls.onQuit)
         }
@@ -531,7 +685,7 @@ struct KajiPopoverView: View {
         switch panel {
         case .quota: return "5h + 7d pressure"
         case .work: return "45m work, hard break"
-        case .system: return "CPU + processes + Kaji clean"
+        case .system: return "Health + hot processes + cleanup"
         case .goals: return "Daily completion"
         }
     }
@@ -635,22 +789,6 @@ struct KajiPopoverView: View {
         .help(systemName == "plus" ? "Increase" : "Decrease")
     }
 
-    private func compactTab(_ title: String, active: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 10.5, weight: .bold, design: .rounded))
-                .foregroundColor(active ? t.bg : t.mute)
-                .frame(width: 30, height: 28)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(active ? t.gold : Color.clear)
-                        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(active ? Color.clear : t.track, lineWidth: 1))
-                )
-                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
     private func chip(_ title: String, filled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
@@ -668,48 +806,6 @@ struct KajiPopoverView: View {
                 .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
-    }
-
-    private func metricCard(_ title: String,
-                            _ systemImage: String,
-                            _ value: String,
-                            fraction: Double? = nil,
-                            warning: Bool = false) -> some View {
-        let safeFraction = fraction.map { min(max($0, 0), 1) }
-        let accent = warning ? t.amber : t.gold
-        return HStack(spacing: 8) {
-            ZStack {
-                GaugeDot(fraction: safeFraction ?? 0, color: accent, track: t.track)
-                Image(systemName: systemImage)
-                    .font(.system(size: 10.5, weight: .bold))
-                    .foregroundColor(accent)
-            }
-            .frame(width: 34, height: 34)
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 4) {
-                    Text(title)
-                    if warning {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 7.5, weight: .bold))
-                    }
-                }
-                .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                .foregroundColor(warning ? accent : t.mute)
-                Text(value)
-                    .font(.system(size: 15, weight: .bold, design: .rounded))
-                    .foregroundColor(t.cream)
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                if let safeFraction {
-                    progressBar(safeFraction, color: accent)
-                        .frame(height: 4)
-                }
-            }
-        }
-        .padding(8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(t.panel.opacity(0.75)))
     }
 
     private func miniStat(_ title: String, _ value: String, _ caption: String) -> some View {
@@ -797,30 +893,6 @@ struct KajiPopoverView: View {
         return String(format: "$%.2f", value)
     }
 
-    private var cleanFraction: Double {
-        guard systemMonitor.cleanableBytes > 0 else { return 0 }
-        return Double(systemMonitor.selectedCleanableBytes) / Double(systemMonitor.cleanableBytes)
-    }
-}
-
-private struct GaugeDot: View {
-    let fraction: Double
-    let color: Color
-    let track: Color
-
-    var body: some View {
-        ZStack {
-            Circle()
-                .stroke(track.opacity(0.75), lineWidth: 5)
-            Circle()
-                .trim(from: 0, to: min(max(fraction, 0), 1))
-                .stroke(color, style: StrokeStyle(lineWidth: 5, lineCap: .round))
-                .rotationEffect(.degrees(-90))
-            Circle()
-                .fill(color.opacity(0.18))
-                .frame(width: 12, height: 12)
-        }
-    }
 }
 
 private struct SparklineView: View {

--- a/Sources/Kaji/SystemMonitor.swift
+++ b/Sources/Kaji/SystemMonitor.swift
@@ -25,6 +25,7 @@ struct CleanableItem: Identifiable, Equatable, Sendable {
     let title: String
     let path: String
     let bytes: Int64
+    let isAutoSafe: Bool
 
     var isEmpty: Bool { bytes <= 0 }
 }
@@ -49,6 +50,7 @@ final class SystemMonitor: ObservableObject {
     @Published private(set) var isRefreshing = false
     @Published private(set) var lastError: String?
     @Published private(set) var lastCleanedBytes: Int64 = 0
+    @Published private(set) var isCleaning = false
     @Published private(set) var cleanableItems: [CleanableItem] = []
     @Published private(set) var selectedCleanableIds: Set<String> = []
     @Published private(set) var isScanningCleanables = false
@@ -62,6 +64,7 @@ final class SystemMonitor: ObservableObject {
     nonisolated(unsafe) private var timer: Timer?
     nonisolated(unsafe) private var scanTimer: Timer?
     private var lastAutoMaintenanceAt: Date?
+    private var hasInitializedCleanableSelection = false
 
     private enum AutoClean {
         static let memoryPercent = 75.0
@@ -121,6 +124,12 @@ final class SystemMonitor: ObservableObject {
             .reduce(0) { $0 + $1.bytes }
     }
 
+    private var autoCleanableBytes: Int64 {
+        cleanableItems
+            .filter(\.isAutoSafe)
+            .reduce(0) { $0 + $1.bytes }
+    }
+
     func scanCleanables() {
         if isScanningCleanables { return }
         isScanningCleanables = true
@@ -130,7 +139,13 @@ final class SystemMonitor: ObservableObject {
             }.value
             await MainActor.run {
                 self.cleanableItems = items
-                self.selectedCleanableIds = Set(items.filter { !$0.isEmpty }.map(\.id))
+                let availableIds = Set(items.filter { !$0.isEmpty }.map(\.id))
+                if self.hasInitializedCleanableSelection {
+                    self.selectedCleanableIds.formIntersection(availableIds)
+                } else {
+                    self.selectedCleanableIds = Set(items.filter { $0.isAutoSafe && !$0.isEmpty }.map(\.id))
+                    self.hasInitializedCleanableSelection = true
+                }
                 self.isScanningCleanables = false
             }
         }
@@ -146,13 +161,17 @@ final class SystemMonitor: ObservableObject {
     }
 
     func cleanKajiArtifacts() {
+        if isCleaning { return }
         let selected = selectedCleanableIds
+        guard !selected.isEmpty else { return }
+        isCleaning = true
         Task {
             let bytes = await Task.detached(priority: .utility) {
                 Self.cleanKajiArtifacts(selectedIds: selected)
             }.value
             await MainActor.run {
                 self.lastCleanedBytes = bytes
+                self.isCleaning = false
                 self.scanCleanables()
             }
         }
@@ -190,10 +209,10 @@ final class SystemMonitor: ObservableObject {
             return
         }
         let shouldReclaimMemory = snapshot.memoryPercent >= AutoClean.memoryPercent
-        let shouldCleanDisk = snapshot.diskPercent >= AutoClean.diskPercent || selectedCleanableBytes >= AutoClean.cleanableBytes
+        let shouldCleanDisk = snapshot.diskPercent >= AutoClean.diskPercent || autoCleanableBytes >= AutoClean.cleanableBytes
         let shouldCleanOrphans = !orphanProcesses.isEmpty
         guard shouldReclaimMemory || shouldCleanDisk || shouldCleanOrphans else { return }
-        if shouldCleanDisk && selectedCleanableIds.isEmpty {
+        if shouldCleanDisk && cleanableItems.filter(\.isAutoSafe).allSatisfy(\.isEmpty) {
             if !isScanningCleanables { scanCleanables() }
             if !shouldReclaimMemory { return }
         }
@@ -212,7 +231,7 @@ final class SystemMonitor: ObservableObject {
     }
 
     private func autoCleanDisk() {
-        let selected = selectedCleanableIds
+        let selected = Set(cleanableItems.filter { $0.isAutoSafe && !$0.isEmpty }.map(\.id))
         guard !selected.isEmpty else {
             scanCleanables()
             return
@@ -234,13 +253,17 @@ final class SystemMonitor: ObservableObject {
         if isReclaimingMemory { return }
         isReclaimingMemory = true
         Task {
-            _ = await Task.detached(priority: .utility) {
+            let succeeded = await Task.detached(priority: .utility) {
                 Self.runPurge()
             }.value
             await MainActor.run {
-                self.lastMemoryReclaimAt = Date()
+                if succeeded {
+                    self.lastMemoryReclaimAt = Date()
+                    self.refresh()
+                } else {
+                    self.lastError = "memory_reclaim_failed"
+                }
                 self.isReclaimingMemory = false
-                self.refresh()
             }
         }
     }
@@ -400,11 +423,12 @@ final class SystemMonitor: ObservableObject {
     }
 
     nonisolated private static func scanKajiCleanables() -> [CleanableItem] {
-        cleanableURLs().map { title, url in
+        cleanableURLs().map { title, url, isAutoSafe in
             CleanableItem(id: url.path,
                           title: title,
                           path: url.path,
-                          bytes: sizeOfItem(at: url))
+                          bytes: sizeOfItem(at: url),
+                          isAutoSafe: isAutoSafe)
         }
     }
 
@@ -414,16 +438,15 @@ final class SystemMonitor: ObservableObject {
         }
     }
 
-    nonisolated private static func cleanableURLs() -> [(title: String, url: URL)] {
+    nonisolated private static func cleanableURLs() -> [(title: String, url: URL, isAutoSafe: Bool)] {
         let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
         return [
-            ("Pet log", URL(fileURLWithPath: "/tmp/kaji-pethatch.log")),
-            ("Kaji cache", home.appendingPathComponent("Library/Caches/Kaji", isDirectory: true)),
-            ("Kaji cache", home.appendingPathComponent("Library/Caches/dev.kaji", isDirectory: true)),
-            ("Kaji logs", home.appendingPathComponent("Library/Logs/Kaji", isDirectory: true)),
-            ("Xcode DerivedData", home.appendingPathComponent("Library/Developer/Xcode/DerivedData", isDirectory: true)),
-            ("SwiftPM cache", home.appendingPathComponent("Library/Caches/org.swift.swiftpm", isDirectory: true)),
-            ("SwiftPM security", home.appendingPathComponent("Library/org.swift.swiftpm/security", isDirectory: true)),
+            ("Pet log", URL(fileURLWithPath: "/tmp/kaji-pethatch.log"), true),
+            ("Kaji cache", home.appendingPathComponent("Library/Caches/Kaji", isDirectory: true), true),
+            ("Kaji cache", home.appendingPathComponent("Library/Caches/dev.kaji", isDirectory: true), true),
+            ("Kaji logs", home.appendingPathComponent("Library/Logs/Kaji", isDirectory: true), true),
+            ("Xcode DerivedData", home.appendingPathComponent("Library/Developer/Xcode/DerivedData", isDirectory: true), false),
+            ("SwiftPM cache", home.appendingPathComponent("Library/Caches/org.swift.swiftpm", isDirectory: true), false),
         ]
     }
 
@@ -436,7 +459,7 @@ final class SystemMonitor: ObservableObject {
         }
         guard let enumerator = fm.enumerator(at: url,
                                              includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
-                                             options: [.skipsHiddenFiles]) else {
+                                             options: []) else {
             return 0
         }
         var total: Int64 = 0


### PR DESCRIPTION
## Changes

- add eight animated break exercise recommendations
- simplify popover navigation; remove pet and Q/W/S/G controls
- stop Kaji from launching or terminating external pets while keeping PetBridge state publishing
- redesign System with health score, hot processes, cleanup review, and confirmation
- restrict automatic cleanup to Kaji-owned caches
- bump bundle version to 0.5.9 (19)

## Why

Make breaks more useful, reduce popover clutter, and turn System into a safer actionable dashboard.

## Checks

- `swift build`
- `./scripts/build-app.sh`
- release bundle plist/resource validation
- system monitor live smoke test
- 1440×900 break overlay render
- `git diff --check`