### PR TITLE
Avoid repeated admin prompts for Prevent Sleep

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     ],
     products: [
         .executable(name: "Kaji", targets: ["Kaji"]),
+        .executable(name: "KajiSleepHelper", targets: ["KajiSleepHelper"]),
         .library(name: "KajiCore", targets: ["KajiCore"])
     ],
     targets: [
@@ -18,8 +19,17 @@ let package = Package(
         ),
         .executableTarget(
             name: "Kaji",
-            dependencies: ["KajiCore"],
+            dependencies: ["KajiCore", "KajiSleepSupport"],
             path: "Sources/Kaji"
+        ),
+        .target(
+            name: "KajiSleepSupport",
+            path: "Sources/KajiSleepSupport"
+        ),
+        .executableTarget(
+            name: "KajiSleepHelper",
+            dependencies: ["KajiSleepSupport"],
+            path: "Sources/KajiSleepHelper"
         ),
         .testTarget(
             name: "KajiTests",

--- a/Resources/dev.kaji.sleep-helper.plist
+++ b/Resources/dev.kaji.sleep-helper.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.kaji.sleep-helper</string>
+    <key>BundleProgram</key>
+    <string>Contents/Library/HelperTools/KajiSleepHelper</string>
+    <key>MachServices</key>
+    <dict>
+        <key>dev.kaji.sleep-helper</key>
+        <true/>
+    </dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>dev.kaji</string>
+    </array>
+</dict>
+</plist>

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -35,6 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var cancellables = Set<AnyCancellable>()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        sleepController.onStateChanged = { [weak self] enabled in
+            self?.prefs.preventSleep = enabled
+        }
+        sleepController.refresh()
         store.start()
         applyModuleLifecycle(prefs.enabledModules)
         refreshPetCatalogSelection()
@@ -118,13 +122,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if !LoginItemManager.setEnabled(enabled) {
                     self?.prefs.launchAtLogin = !enabled
                 }
-            }
-            .store(in: &cancellables)
-        prefs.$preventSleep
-            .removeDuplicates()
-            .receive(on: RunLoop.main)
-            .sink { [weak self] enabled in
-                self?.sleepController.setEnabled(enabled)
             }
             .store(in: &cancellables)
         prefs.$breakOverlayEnabled
@@ -296,7 +293,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let controls = GaugeRowView.Controls(
             onRefresh: { [weak self] in self?.store.refresh() },
             onUpdate: { [weak self] in self?.handleUpdateAction() },
-            onToggleKeepAwake: { [weak self] in self?.prefs.preventSleep.toggle() },
+            onToggleKeepAwake: { [weak self] in self?.sleepController.toggle() },
             onTogglePet: {},
             onOpenSettings: { [weak self] in self?.openSettings() },
             onQuit: { NSApp.terminate(nil) }

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -62,8 +62,8 @@ struct SettingsView: View {
                         }
                     }
                     settingRow(title: L10n.t(.keepAwake, prefs.language)) {
-                        segment(preventSleepTitle, on: prefs.preventSleep) {
-                            prefs.preventSleep.toggle()
+                        segment(preventSleepTitle, on: sleepController.isEnabled) {
+                            sleepController.toggle()
                         }
                         .disabled(sleepController.isBusy)
                     }
@@ -191,9 +191,9 @@ struct SettingsView: View {
 
     private var preventSleepTitle: String {
         if sleepController.isBusy {
-            return prefs.preventSleep ? "On\u{2026}" : "Off\u{2026}"
+            return sleepController.targetEnabled == true ? "On\u{2026}" : "Off\u{2026}"
         }
-        return prefs.preventSleep ? "On" : "Off"
+        return sleepController.isEnabled ? "On" : "Off"
     }
 
     private func providerRow(_ key: String) -> some View {

--- a/Sources/Kaji/SleepController.swift
+++ b/Sources/Kaji/SleepController.swift
@@ -1,16 +1,20 @@
 import Foundation
+import KajiCore
+import KajiSleepSupport
+import ServiceManagement
 
-// MARK: - SleepController
-//
-// Manages macOS SleepDisabled via pmset. This is intentionally explicit: closed
-// lid / hardware sleep prevention requires a privileged system setting, unlike
-// a plain IOPMAssertion/caffeinate idle assertion.
 @MainActor
 final class SleepController: ObservableObject {
     @Published private(set) var isEnabled = false
     @Published private(set) var isBusy = false
     @Published private(set) var targetEnabled: Bool?
     @Published private(set) var lastError: String?
+
+    var onStateChanged: ((Bool) -> Void)?
+
+    private static let daemon = SMAppService.daemon(
+        plistName: "dev.kaji.sleep-helper.plist"
+    )
 
     init(previewEnabled: Bool? = nil) {
         if let previewEnabled {
@@ -21,7 +25,9 @@ final class SleepController: ObservableObject {
     }
 
     func refresh() {
-        isEnabled = Self.readSleepDisabled()
+        let observed = Self.readSleepDisabled()
+        isEnabled = observed
+        onStateChanged?(observed)
     }
 
     func toggle() {
@@ -29,22 +35,87 @@ final class SleepController: ObservableObject {
     }
 
     func setEnabled(_ enabled: Bool) {
-        if isBusy { return }
+        guard !isBusy else { return }
         refresh()
-        if isEnabled == enabled { return }
+        guard isEnabled != enabled else { return }
+
         isBusy = true
         targetEnabled = enabled
         lastError = nil
+
         Task {
-            let ok = await Self.runPrivilegedPmset(disabled: enabled)
-            await MainActor.run {
-                self.isBusy = false
-                self.targetEnabled = nil
-                self.refresh()
-                if !ok {
-                    self.lastError = "pmset_failed"
-                }
+            let commandSucceeded: Bool
+            do {
+                try Self.registerHelperIfNeeded()
+                commandSucceeded = await Self.requestSleepDisabled(enabled)
+            } catch {
+                commandSucceeded = false
             }
+
+            let observed = Self.readSleepDisabled()
+            isBusy = false
+            targetEnabled = nil
+            isEnabled = observed
+            onStateChanged?(observed)
+
+            if case .failure = SleepControlLogic.resolvedState(
+                requested: enabled,
+                commandSucceeded: commandSucceeded,
+                observed: observed
+            ) {
+                lastError = "pmset_failed"
+            }
+        }
+    }
+
+    func restoreAndRemoveHelper() async throws {
+        guard await Self.requestSleepDisabled(false) else {
+            throw SleepControllerError.restoreFailed
+        }
+        try await Self.daemon.unregister()
+        refresh()
+    }
+
+    private static func registerHelperIfNeeded() throws {
+        switch daemon.status {
+        case .enabled:
+            return
+        case .notRegistered, .notFound:
+            try daemon.register()
+        case .requiresApproval:
+            throw SleepControllerError.approvalRequired
+        @unknown default:
+            throw SleepControllerError.registrationFailed
+        }
+    }
+
+    private static func requestSleepDisabled(_ disabled: Bool) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let connection = NSXPCConnection(machServiceName: kajiSleepHelperMachService)
+            connection.remoteObjectInterface = NSXPCInterface(with: SleepHelperProtocol.self)
+
+            let lock = NSLock()
+            var resumed = false
+            let finish: (Bool) -> Void = { value in
+                lock.lock()
+                defer { lock.unlock() }
+                guard !resumed else { return }
+                resumed = true
+                connection.invalidate()
+                continuation.resume(returning: value)
+            }
+
+            connection.interruptionHandler = { finish(false) }
+            connection.invalidationHandler = { finish(false) }
+            connection.resume()
+
+            guard let helper = connection.remoteObjectProxyWithErrorHandler({ _ in
+                finish(false)
+            }) as? SleepHelperProtocol else {
+                finish(false)
+                return
+            }
+            helper.setSleepDisabled(disabled) { ok, _ in finish(ok) }
         }
     }
 
@@ -62,38 +133,17 @@ final class SleepController: ObservableObject {
             return false
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let out = String(data: data, encoding: .utf8) else { return false }
-        return parseSleepDisabled(out)
+        guard let output = String(data: data, encoding: .utf8) else { return false }
+        return SleepControlLogic.parseSleepDisabled(output)
     }
 
     static func parseSleepDisabled(_ output: String) -> Bool {
-        output
-            .split(whereSeparator: \.isNewline)
-            .contains { line in
-                let parts = line.split(whereSeparator: \.isWhitespace)
-                return parts.count >= 2 && parts[0] == "SleepDisabled" && parts[1] == "1"
-            }
+        SleepControlLogic.parseSleepDisabled(output)
     }
+}
 
-    private static func runPrivilegedPmset(disabled: Bool) async -> Bool {
-        await Task.detached(priority: .userInitiated) {
-            let value = disabled ? "1" : "0"
-            let command = "/usr/bin/pmset -a disablesleep \(value)"
-            let escaped = command.replacingOccurrences(of: "\"", with: "\\\"")
-            let script = "do shell script \"\(escaped)\" with administrator privileges"
-
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            process.arguments = ["-e", script]
-            process.standardOutput = Pipe()
-            process.standardError = Pipe()
-            do {
-                try process.run()
-                process.waitUntilExit()
-                return process.terminationStatus == 0
-            } catch {
-                return false
-            }
-        }.value
-    }
+private enum SleepControllerError: Error {
+    case approvalRequired
+    case registrationFailed
+    case restoreFailed
 }

--- a/Sources/Kaji/SleepController.swift
+++ b/Sources/Kaji/SleepController.swift
@@ -48,6 +48,9 @@ final class SleepController: ObservableObject {
             do {
                 try Self.registerHelperIfNeeded()
                 commandSucceeded = await Self.requestSleepDisabled(enabled)
+            } catch SleepControllerError.approvalRequired {
+                SMAppService.openSystemSettingsLoginItems()
+                commandSucceeded = false
             } catch {
                 commandSucceeded = false
             }
@@ -82,6 +85,9 @@ final class SleepController: ObservableObject {
             return
         case .notRegistered, .notFound:
             try daemon.register()
+            guard daemon.status == .enabled else {
+                throw SleepControllerError.approvalRequired
+            }
         case .requiresApproval:
             throw SleepControllerError.approvalRequired
         @unknown default:

--- a/Sources/KajiCore/SleepControlLogic.swift
+++ b/Sources/KajiCore/SleepControlLogic.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum SleepControlLogic {
+    public static func parseSleepDisabled(_ output: String) -> Bool {
+        output
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                let parts = line.split(whereSeparator: \.isWhitespace)
+                return parts.count >= 2 && parts[0] == "SleepDisabled" && parts[1] == "1"
+            }
+    }
+
+    public static func resolvedState(
+        requested: Bool,
+        commandSucceeded: Bool,
+        observed: Bool
+    ) -> Result<Bool, SleepControlError> {
+        guard commandSucceeded else { return .failure(.commandFailed) }
+        guard requested == observed else { return .failure(.stateMismatch(observed: observed)) }
+        return .success(observed)
+    }
+}
+
+public enum SleepControlError: Error, Equatable {
+    case commandFailed
+    case stateMismatch(observed: Bool)
+}

--- a/Sources/KajiSleepHelper/main.swift
+++ b/Sources/KajiSleepHelper/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+import KajiSleepSupport
+
+private final class SleepHelper: NSObject, SleepHelperProtocol {
+    func setSleepDisabled(_ disabled: Bool, reply: @escaping (Bool, String?) -> Void) {
+        let process = Process()
+        let errorPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        process.arguments = ["-a", "disablesleep", disabled ? "1" : "0"]
+        process.standardOutput = Pipe()
+        process.standardError = errorPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let error = String(data: errorData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            reply(process.terminationStatus == 0, error?.isEmpty == false ? error : nil)
+        } catch {
+            reply(false, error.localizedDescription)
+        }
+    }
+}
+
+private final class ListenerDelegate: NSObject, NSXPCListenerDelegate {
+    func listener(
+        _ listener: NSXPCListener,
+        shouldAcceptNewConnection connection: NSXPCConnection
+    ) -> Bool {
+        connection.exportedInterface = NSXPCInterface(with: SleepHelperProtocol.self)
+        connection.exportedObject = SleepHelper()
+        connection.resume()
+        return true
+    }
+}
+
+private let delegate = ListenerDelegate()
+private let listener = NSXPCListener(machServiceName: kajiSleepHelperMachService)
+listener.delegate = delegate
+listener.resume()
+RunLoop.current.run()

--- a/Sources/KajiSleepSupport/SleepHelperProtocol.swift
+++ b/Sources/KajiSleepSupport/SleepHelperProtocol.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public let kajiSleepHelperMachService = "dev.kaji.sleep-helper"
+
+@objc public protocol SleepHelperProtocol {
+    func setSleepDisabled(_ disabled: Bool, reply: @escaping (Bool, String?) -> Void)
+}

--- a/Tests/KajiTests/SleepControlLogicTests.swift
+++ b/Tests/KajiTests/SleepControlLogicTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import KajiCore
+
+final class SleepControlLogicTests: XCTestCase {
+    func testParsesEnabledState() {
+        XCTAssertTrue(SleepControlLogic.parseSleepDisabled("""
+        System-wide power settings:
+         SleepDisabled          1
+        """))
+    }
+
+    func testMissingOrDisabledStateIsFalse() {
+        XCTAssertFalse(SleepControlLogic.parseSleepDisabled(" SleepDisabled 0"))
+        XCTAssertFalse(SleepControlLogic.parseSleepDisabled("sleep 1"))
+    }
+
+    func testSuccessfulMatchingRequestCommitsObservedState() {
+        XCTAssertEqual(
+            try SleepControlLogic.resolvedState(
+                requested: true,
+                commandSucceeded: true,
+                observed: true
+            ).get(),
+            true
+        )
+    }
+
+    func testFailedRequestDoesNotCommitRequestedState() {
+        XCTAssertThrowsError(
+            try SleepControlLogic.resolvedState(
+                requested: true,
+                commandSucceeded: false,
+                observed: false
+            ).get()
+        ) { error in
+            XCTAssertEqual(error as? SleepControlError, .commandFailed)
+        }
+    }
+
+    func testObservedMismatchIsReported() {
+        XCTAssertThrowsError(
+            try SleepControlLogic.resolvedState(
+                requested: true,
+                commandSucceeded: true,
+                observed: false
+            ).get()
+        ) { error in
+            XCTAssertEqual(error as? SleepControlError, .stateMismatch(observed: false))
+        }
+    }
+}

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -15,6 +15,7 @@
 | Done | [product/lean-module-host.md](product/lean-module-host.md) |
 | Done | [product/architecture-modules.md](product/architecture-modules.md) |
 | Done | [integrate/pet-bridge.md](integrate/pet-bridge.md) |
+| Done | [integrate/sleep-helper.md](integrate/sleep-helper.md) |
 | Done | [ship/distribution.md](ship/distribution.md) |
 | **Approved** | [specs/2026-07-24-lean-modules-v1.md](specs/2026-07-24-lean-modules-v1.md) — 已落地 |
 | **Approved** | [specs/2026-07-24-work-status-slot.md](specs/2026-07-24-work-status-slot.md) — focus/break 剩余数字；无 BREAK 文案 |

--- a/dev_docs/integrate/sleep-helper.md
+++ b/dev_docs/integrate/sleep-helper.md
@@ -1,0 +1,36 @@
+# Prevent Sleep privileged helper
+
+Kaji uses an embedded `SMAppService` LaunchDaemon for `pmset` changes. Registration
+is requested on the first Prevent Sleep enable. Later toggles reuse the registered
+service.
+
+The XPC contract accepts one `Bool`. The helper maps it to exactly one of:
+
+```text
+/usr/bin/pmset -a disablesleep 1
+/usr/bin/pmset -a disablesleep 0
+```
+
+No executable path, argument array, command string, or shell text crosses XPC.
+After every request, Kaji reads `pmset -g`; UI and preferences only commit that
+observed state.
+
+## Build layout
+
+`scripts/build-app.sh` embeds:
+
+```text
+Kaji.app/Contents/Library/HelperTools/KajiSleepHelper
+Kaji.app/Contents/Library/LaunchDaemons/dev.kaji.sleep-helper.plist
+```
+
+The local build script ad-hoc signs `KajiSleepHelper` before sealing the outer
+app so `SMAppService` can inspect a valid bundle. Distribution builds must replace
+that identity with the same Apple Developer team for helper and app.
+
+## Removal
+
+Before deleting the app, call `SleepController.restoreAndRemoveHelper()`. It first
+requests `disablesleep 0`, verifies command success, then calls
+`SMAppService.unregister()`. Never remove the app bundle while its helper remains
+registered.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -26,9 +26,17 @@ echo "==> assembling ${BUNDLE}"
 rm -rf "$BUNDLE"
 mkdir -p "${BUNDLE}/Contents/MacOS"
 mkdir -p "${BUNDLE}/Contents/Resources"
+mkdir -p "${BUNDLE}/Contents/Library/HelperTools"
+mkdir -p "${BUNDLE}/Contents/Library/LaunchDaemons"
 
 cp "$BIN_PATH" "${BUNDLE}/Contents/MacOS/${EXEC_NAME}"
 chmod +x "${BUNDLE}/Contents/MacOS/${EXEC_NAME}"
+
+HELPER_PATH="$(swift build -c release --show-bin-path)/KajiSleepHelper"
+cp "$HELPER_PATH" "${BUNDLE}/Contents/Library/HelperTools/KajiSleepHelper"
+chmod +x "${BUNDLE}/Contents/Library/HelperTools/KajiSleepHelper"
+cp "Resources/dev.kaji.sleep-helper.plist" \
+    "${BUNDLE}/Contents/Library/LaunchDaemons/dev.kaji.sleep-helper.plist"
 
 # Prefer the tracked Info.plist; fall back to generating one if absent.
 if [[ -f "Info.plist" ]]; then
@@ -75,6 +83,13 @@ fi
 
 # PkgInfo (harmless, conventional).
 printf 'APPL????' > "${BUNDLE}/Contents/PkgInfo"
+
+# SMAppService requires a sealed app bundle. Local source builds use ad-hoc
+# signing; release pipelines can replace "-" with an Apple Developer identity.
+xattr -cr "${BUNDLE}"
+codesign --force --sign - --identifier dev.kaji.sleep-helper \
+	"${BUNDLE}/Contents/Library/HelperTools/KajiSleepHelper"
+codesign --force --sign - --identifier dev.kaji "${BUNDLE}"
 
 echo "==> done: ${BUNDLE}"
 echo "    run with: open ${BUNDLE}"

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -25,6 +25,10 @@ sleep 1
 rm -rf /Applications/Kaji.app
 rm -rf /Applications/KajiGauge.app
 cp -R "$APP" /Applications/
+xattr -cr /Applications/Kaji.app
+codesign --force --sign - --identifier dev.kaji.sleep-helper \
+  /Applications/Kaji.app/Contents/Library/HelperTools/KajiSleepHelper
+codesign --force --sign - --identifier dev.kaji /Applications/Kaji.app
 
 if [[ "${1:-}" != "--no-open" ]]; then
   echo "==> launch"

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -12,33 +12,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-APP="build/Kaji.app"
-EXEC_NAME="Kaji"
-
-echo "==> swift build -c release"
-swift build -c release
-BIN_PATH="$(swift build -c release --show-bin-path)/${EXEC_NAME}"
-if [[ ! -x "$BIN_PATH" ]]; then
-  echo "error: built executable not found at $BIN_PATH" >&2
-  exit 1
-fi
-
-echo "==> assemble $APP"
-rm -rf build/Kaji.app
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
-cp "$BIN_PATH" "$APP/Contents/MacOS/Kaji"
-cp Info.plist "$APP/Contents/Info.plist"
-# Resources/quota.py is the single source of truth for the bundled reader.
-# Always copy it so the .app never drifts from the repo (see the bundle-drift
-# pitfall that hid one provider in v0.4.4).
-cp Resources/quota.py "$APP/Contents/Resources/quota.py"
-[ -f Resources/AppIcon.icns ] && cp Resources/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
-[ -f Resources/navi-panda.png ] && cp Resources/navi-panda.png "$APP/Contents/Resources/navi-panda.png"
-# Break intensity art (optional; ignore if not present on this branch).
-for img in break-forest.png break-ocean.png break-alpine.png; do
-  [ -f "Resources/$img" ] && cp "Resources/$img" "$APP/Contents/Resources/$img"
-done
-printf 'APPL????' > "$APP/Contents/PkgInfo"
+./scripts/build-app.sh
+APP="dist/Kaji.app"
 
 echo "==> md5 quota.py (source vs bundle — must match)"
 md5 -q Resources/quota.py "$APP/Contents/Resources/quota.py"


### PR DESCRIPTION
Closes #22

## What changed

- replace per-toggle privileged AppleScript with an embedded `SMAppService` LaunchDaemon
- expose a typed XPC method accepting only `Bool`; helper maps it to fixed `/usr/bin/pmset -a disablesleep 0|1` arguments
- read `pmset -g` after every request and commit UI/preferences only from observed system state
- keep authorization cancellation, helper failure, and state mismatches from leaving a false toggle state
- add helper restore/unregister path and contributor documentation
- embed and seal the helper in both release and local app builds
- add focused parsing and request/result tests

## Root cause

`SleepController` launched `osascript ... with administrator privileges` for every toggle. The preference changed before authorization completed, so cancellation or command failure could also leave persisted/UI state out of sync with `pmset`.

## Impact

First enable registers the privileged helper and uses macOS approval. Later toggles reuse that narrowly scoped service instead of asking for a password each time. Closed-lid behavior remains backed by the same `pmset disablesleep` setting.

## Validation

- `swift test` — 44 tests passed
- debug and release Swift builds passed
- `scripts/build-app.sh` assembled helper-enabled app
- `codesign --verify --deep --strict dist/Kaji.app` passed
- LaunchDaemon and app plists passed `plutil -lint`
- shell syntax and `git diff --check` passed

## Manual verification needed

Run signed app on macOS and confirm first-use approval plus repeated toggles on a real machine. CI cannot exercise System Settings approval or root `pmset` behavior.
