### PR TITLE
ship v0.6.2

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.1</string>
+	<string>0.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/dev_docs/ship/releases/v0.6.2.md
+++ b/dev_docs/ship/releases/v0.6.2.md
@@ -1,0 +1,37 @@
+# v0.6.2 — Sleep helper + four languages
+
+Kaji now changes Prevent Sleep through a narrow privileged helper instead of
+asking for an administrator password on every toggle. This release also makes
+English the default for new installs and adds Simplified Chinese, Brazilian
+Portuguese, and Spanish language choices.
+
+Existing users keep their saved language.
+
+## Highlights
+
+- **One-time sleep approval** — an embedded `SMAppService` helper handles later
+  Prevent Sleep toggles without repeated password prompts.
+- **Narrow privilege boundary** — the helper accepts one boolean and can only
+  run `/usr/bin/pmset -a disablesleep 0|1`; no shell text or arbitrary arguments.
+- **Truthful sleep state** — Kaji reads `pmset -g` after every request and keeps
+  UI/preferences aligned with the observed system value.
+- **Four language choices** — `EN / 中文 / PT-BR / ES`.
+- **English-first installs** — new installs default to English; saved `en` or
+  `zh` choices remain unchanged during upgrade.
+- **Localized project guides** — complete English, Chinese, Portuguese, and
+  Spanish README editions.
+
+## Install
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/blackblue-labs/kaji/main/install.sh | bash
+```
+
+Or clone the tag and run `./scripts/build-local.sh`.
+
+## Notes
+
+- First use of Prevent Sleep requires approval in macOS Login Items.
+- No notarized binary is attached; installer continues to build locally.
+
+**Full Changelog:** https://github.com/blackblue-labs/kaji/compare/v0.6.1...v0.6.2

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -89,6 +89,7 @@ printf 'APPL????' > "${BUNDLE}/Contents/PkgInfo"
 xattr -cr "${BUNDLE}"
 codesign --force --sign - --identifier dev.kaji.sleep-helper \
 	"${BUNDLE}/Contents/Library/HelperTools/KajiSleepHelper"
+xattr -cr "${BUNDLE}"
 codesign --force --sign - --identifier dev.kaji "${BUNDLE}"
 
 echo "==> done: ${BUNDLE}"


### PR DESCRIPTION
Ships Prevent Sleep helper and four-language baseline. Bumps app version to 0.6.2 (build 23), adds authored release notes, and hardens local app bundle signing against Finder xattrs. Validation: 53 tests, release build, strict codesign, plist and shell checks.