### PR TITLE
feat: add AI News module powered by AI HOT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         ),
         .testTarget(
             name: "KajiTests",
-            dependencies: ["KajiCore"],
+            dependencies: ["KajiCore", "Kaji"],
             path: "Tests/KajiTests"
         )
     ]

--- a/Sources/Kaji/AIHotAPIClient.swift
+++ b/Sources/Kaji/AIHotAPIClient.swift
@@ -1,0 +1,79 @@
+import Foundation
+import KajiCore
+
+struct AIHotResponse<Value> {
+    let value: Value?
+    let statusCode: Int
+    let etag: String?
+    let cacheControl: String?
+    let retryAfter: String?
+}
+
+final class AIHotAPIClient: @unchecked Sendable {
+    static let baseURL = URL(string: "https://aihot.virxact.com/api/v1/")!
+    private let session: URLSession
+    init(session: URLSession = .shared) { self.session = session }
+
+    func hotTopics(etag: String?) async throws -> AIHotResponse<[AIHotTopic]> {
+        var request = request(path: "hot-topics", etag: etag)
+        request.timeoutInterval = 20
+        let (data, response) = try await session.data(for: request, delegate: AIHotRedirectDelegate(allowsStoryRedirect: false))
+        let http = try validated(response, expectedPathPrefix: "/api/v1/hot-topics")
+        let topics = http.statusCode == 200 ? try AIHotDecoder.topics(from: data) : nil
+        return responseValue(topics, http)
+    }
+
+    func story(publicID: String, etag: String?) async throws -> AIHotResponse<AIHotStory> {
+        let safeID = publicID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        let (data, response) = try await session.data(for: request(path: "stories/\(safeID)", etag: etag),
+                                                      delegate: AIHotRedirectDelegate(allowsStoryRedirect: true))
+        let http = try validated(response, expectedPathPrefix: "/api/v1/stories/")
+        let story = http.statusCode == 200 ? try AIHotDecoder.story(from: data) : nil
+        return responseValue(story, http)
+    }
+
+    private func request(path: String, etag: String?) -> URLRequest {
+        var request = URLRequest(url: Self.baseURL.appendingPathComponent(path))
+        request.setValue("Kaji/0.6 (+https://github.com/blackblue-labs/kaji)", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let etag { request.setValue(etag, forHTTPHeaderField: "If-None-Match") }
+        return request
+    }
+
+    private func validated(_ response: URLResponse, expectedPathPrefix: String) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse, let url = http.url,
+              url.scheme == "https", url.host == "aihot.virxact.com",
+              url.path.hasPrefix(expectedPathPrefix) else { throw URLError(.badServerResponse) }
+        guard http.statusCode == 200 || http.statusCode == 304 || http.statusCode == 429 ||
+                http.statusCode == 503 || (500...599).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return http
+    }
+
+    private func responseValue<Value>(_ value: Value?, _ http: HTTPURLResponse) -> AIHotResponse<Value> {
+        AIHotResponse(value: value, statusCode: http.statusCode,
+                      etag: http.value(forHTTPHeaderField: "ETag"),
+                      cacheControl: http.value(forHTTPHeaderField: "Cache-Control"),
+                      retryAfter: http.value(forHTTPHeaderField: "Retry-After"))
+    }
+}
+
+private final class AIHotRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let allowsStoryRedirect: Bool
+    private var followed = false
+    init(allowsStoryRedirect: Bool) { self.allowsStoryRedirect = allowsStoryRedirect }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        guard allowsStoryRedirect, !followed, response.statusCode == 308,
+              let url = request.url, url.scheme == "https", url.host == "aihot.virxact.com",
+              url.path.hasPrefix("/api/v1/stories/") else {
+            completionHandler(nil); return
+        }
+        followed = true
+        completionHandler(request)
+    }
+}

--- a/Sources/Kaji/AIHotNewsStore.swift
+++ b/Sources/Kaji/AIHotNewsStore.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Combine
+import KajiCore
+
+enum AIHotNewsState: Equatable { case idle, loading, ready, stale, empty, failed }
+
+@MainActor
+final class AIHotNewsStore: ObservableObject {
+    @Published private(set) var topics: [AIHotTopic] = []
+    @Published private(set) var state: AIHotNewsState = .idle
+    @Published private(set) var lastSuccessfulRefresh: Date?
+    @Published private(set) var lastError: String?
+    @Published private(set) var hoveredStoryByID: [String: AIHotStory] = [:]
+    @Published private(set) var readTopicIDs: Set<String> = []
+
+    private let client: AIHotAPIClient
+    private let cacheURL: URL
+    private var cache = AIHotCache()
+    private var refreshTask: Task<Void, Never>?
+    private var storyTasks: [String: Task<Void, Never>] = [:]
+    private var timer: Timer?
+    private var enabled = false
+    private var refreshHours = AIHotRefreshPolicy.defaultHours
+    private var freshnessFloorUntil: Date?
+
+    init(client: AIHotAPIClient = AIHotAPIClient(), cacheURL: URL? = nil) {
+        self.client = client
+        self.cacheURL = cacheURL ?? Self.defaultCacheURL()
+    }
+
+    func setEnabled(_ enabled: Bool, refreshHours: Int) {
+        self.refreshHours = AIHotRefreshPolicy.normalize(hours: refreshHours)
+        guard enabled else { stop(); return }
+        if !self.enabled { loadCache() }
+        self.enabled = true
+        scheduleOrRefresh()
+    }
+
+    func updateRefreshHours(_ hours: Int) {
+        refreshHours = AIHotRefreshPolicy.normalize(hours: hours)
+        guard enabled else { return }
+        timer?.invalidate(); timer = nil
+        scheduleOrRefresh()
+    }
+
+    func refresh(force: Bool = false) {
+        guard enabled, refreshTask == nil else { return }
+        let now = Date()
+        if let floor = freshnessFloorUntil, floor > now { schedule(at: floor); return }
+        if !force && !AIHotRefreshPolicy.shouldRefresh(hasCache: !topics.isEmpty,
+                                                       lastSuccessfulRefresh: lastSuccessfulRefresh,
+                                                       hours: refreshHours, now: now) { scheduleDue(); return }
+        state = topics.isEmpty ? .loading : .ready
+        refreshTask = Task { [weak self] in await self?.performRefresh(attempt: 0) }
+    }
+
+    func loadStory(for topic: AIHotTopic) {
+        guard enabled, let id = topic.storyPublicID, storyTasks[id] == nil else { return }
+        if let entry = cache.stories[id], entry.lastAccessedAt >= Date().addingTimeInterval(-30 * 86400) {
+            hoveredStoryByID[id] = entry.story
+            return
+        }
+        storyTasks[id] = Task { [weak self] in
+            guard let self else { return }
+            defer { self.storyTasks[id] = nil }
+            do {
+                let response = try await self.client.story(publicID: id, etag: self.cache.stories[id]?.etag)
+                guard !Task.isCancelled else { return }
+                if let story = response.value {
+                    self.hoveredStoryByID[id] = story
+                    self.cache.stories[id] = .init(story: story, etag: response.etag, lastAccessedAt: Date())
+                    self.saveCache()
+                }
+            } catch { }
+        }
+    }
+
+    func markRead(_ topic: AIHotTopic) {
+        readTopicIDs.insert(topic.id)
+        cache.readEntries.removeAll { $0.topicID == topic.id }
+        cache.readEntries.append(.init(topicID: topic.id, lastSeenAt: Date()))
+        saveCache()
+    }
+
+    func stop() {
+        enabled = false; timer?.invalidate(); timer = nil
+        refreshTask?.cancel(); refreshTask = nil
+        storyTasks.values.forEach { $0.cancel() }; storyTasks.removeAll()
+        state = .idle
+    }
+
+    private func performRefresh(attempt: Int) async {
+        do {
+            let response = try await client.hotTopics(etag: cache.topicsETag)
+            guard enabled, !Task.isCancelled else { return }
+            if response.statusCode == 200, let newTopics = response.value {
+                topics = newTopics; cache.topics = newTopics; cache.topicsETag = response.etag
+            } else if response.statusCode == 304 {
+                cache.topicsETag = response.etag ?? cache.topicsETag
+            } else if response.statusCode != 304 {
+                if let delay = AIHotRefreshPolicy.retryDelay(statusCode: response.statusCode,
+                                                             retryAfter: response.retryAfter, attempt: attempt) {
+                    refreshTask = Task { [weak self] in
+                        try? await Task.sleep(for: .seconds(delay))
+                        guard !Task.isCancelled else { return }
+                        await self?.performRefresh(attempt: attempt + 1)
+                    }
+                    return
+                }
+                throw URLError(.badServerResponse)
+            }
+            let now = Date(); lastSuccessfulRefresh = now; cache.lastSuccessfulRefresh = now
+            lastError = nil; state = topics.isEmpty ? .empty : .ready
+            freshnessFloorUntil = now.addingTimeInterval(Self.freshnessFloor(response.cacheControl))
+            refreshTask = nil; saveCache(); scheduleDue()
+        } catch {
+            guard enabled, !Task.isCancelled else { return }
+            if attempt == 0, let delay = AIHotRefreshPolicy.retryDelay(statusCode: 0, retryAfter: nil, attempt: 0) {
+                refreshTask = Task { [weak self] in
+                    try? await Task.sleep(for: .seconds(delay))
+                    guard !Task.isCancelled else { return }
+                    await self?.performRefresh(attempt: 1)
+                }
+                return
+            }
+            lastError = "AI HOT unavailable"; state = topics.isEmpty ? .failed : .stale
+            refreshTask = nil; scheduleDue()
+        }
+    }
+
+    private func scheduleOrRefresh() {
+        if AIHotRefreshPolicy.shouldRefresh(hasCache: !topics.isEmpty, lastSuccessfulRefresh: lastSuccessfulRefresh,
+                                            hours: refreshHours, now: Date()) { refresh() } else { scheduleDue() }
+    }
+    private func scheduleDue() {
+        let due = AIHotRefreshPolicy.dueDate(lastSuccessfulRefresh: lastSuccessfulRefresh, hours: refreshHours, now: Date())
+        schedule(at: max(due, freshnessFloorUntil ?? .distantPast))
+    }
+    private func schedule(at date: Date) {
+        timer?.invalidate()
+        timer = Timer(fireAt: date, interval: 0, target: BlockTarget { [weak self] in self?.refresh(force: true) }, selector: #selector(BlockTarget.fire), userInfo: nil, repeats: false)
+        if let timer { RunLoop.main.add(timer, forMode: .common) }
+    }
+
+    private func loadCache() {
+        guard FileManager.default.fileExists(atPath: cacheURL.path) else { return }
+        do {
+            let loaded = try JSONDecoder().decode(AIHotCache.self, from: Data(contentsOf: cacheURL))
+            guard loaded.schemaVersion == AIHotCache.currentSchemaVersion else { throw CocoaError(.fileReadCorruptFile) }
+            cache = loaded; cache.prune(now: Date()); topics = cache.topics
+            lastSuccessfulRefresh = cache.lastSuccessfulRefresh
+            readTopicIDs = Set(cache.readEntries.map(\.topicID)); state = topics.isEmpty ? .idle : .ready
+        } catch {
+            let diagnostic = cacheURL.deletingPathExtension().appendingPathExtension("corrupt-\(Int(Date().timeIntervalSince1970)).json")
+            try? FileManager.default.copyItem(at: cacheURL, to: diagnostic)
+            lastError = "Cache unreadable"
+        }
+    }
+    private func saveCache() {
+        cache.prune(now: Date())
+        do {
+            try FileManager.default.createDirectory(at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try JSONEncoder().encode(cache).write(to: cacheURL, options: .atomic)
+        } catch { lastError = "Cache write failed" }
+    }
+    private static func defaultCacheURL() -> URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return support.appendingPathComponent("Kaji", isDirectory: true).appendingPathComponent("ai-news-cache-v1.json")
+    }
+    private static func freshnessFloor(_ cacheControl: String?) -> TimeInterval {
+        guard let cacheControl,
+              let match = cacheControl.range(of: #"(?:s-maxage|max-age)=(\d+)"#, options: .regularExpression),
+              let value = TimeInterval(cacheControl[match].split(separator: "=").last ?? "") else {
+            return AIHotRefreshPolicy.serverFreshnessFloor
+        }
+        return max(AIHotRefreshPolicy.serverFreshnessFloor, value)
+    }
+}
+
+private final class BlockTarget: NSObject {
+    private let block: () -> Void
+    init(_ block: @escaping () -> Void) { self.block = block }
+    @objc func fire() { block() }
+}

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -31,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let dailyGoals = DailyGoalStore()
     private let fixedPlanStore = FixedPlanStore()
     private let popoverNavigation = PopoverNavigation()
+    private let aiNewsStore = AIHotNewsStore()
     private var breakWindows: [NSWindow] = []
     private var breakSceneSeed: UInt64?
     private var breakWatchdogTimer: Timer?
@@ -88,6 +89,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.updateStatusItem()
                 self?.rebuildPopoverContentIfShown()
             }
+            .store(in: &cancellables)
+        prefs.$aiNewsRefreshHours
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] hours in self?.aiNewsStore.updateRefreshHours(hours) }
             .store(in: &cancellables)
         dailyGoals.objectWillChange
             .receive(on: RunLoop.main)
@@ -193,6 +199,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             systemMonitor.stop()
         }
+        aiNewsStore.setEnabled(modules.contains(.aiNews), refreshHours: prefs.aiNewsRefreshHours)
     }
 
     /// Providers the user has chosen to show, in display order — drives both the
@@ -206,6 +213,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         breakWatchdogTimer?.invalidate()
         petStateTimer?.invalidate()
         closeBreakOverlay()
+        aiNewsStore.stop()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -213,6 +221,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // from hitting the network on every menubar interaction.
         updateChecker.checkIfDue()
         dailyGoals.refreshPeriodBoundaries()
+        if prefs.isModuleEnabled(.aiNews) {
+            aiNewsStore.setEnabled(true, refreshHours: prefs.aiNewsRefreshHours)
+        }
     }
 
     // MARK: - Status item
@@ -226,9 +237,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                   updateAvailable: updateChecker.available != nil,
                                   workSlotLabel: workStatusSlotLabel,
                                   goalsSlotLabel: goalsStatusSlotLabel,
+                                  showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
-                                  onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) })
+                                  onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
+                                  onAINewsClick: { [weak self] in self?.showPopover(.aiNews) })
         hostingView = KajiHostingView(rootView: view)
         hostingView.configureKajiHost()
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -247,9 +260,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                updateAvailable: updateChecker.available != nil,
                                                workSlotLabel: workStatusSlotLabel,
                                                goalsSlotLabel: goalsStatusSlotLabel,
+                                               showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
-                                               onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) })
+                                               onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
+                                               onAINewsClick: { [weak self] in self?.showPopover(.aiNews) })
         statusItem.length = statusItemLength
     }
 
@@ -288,6 +303,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let goalsStatusSlotLabel {
             length += 20 + CGFloat(goalsStatusSlotLabel.count) * 7
         }
+        if prefs.isModuleEnabled(.aiNews) { length += 20 }
         return length
     }
 
@@ -346,7 +362,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if prefs.isModuleEnabled(.work) { return .work }
             if prefs.isModuleEnabled(.goals) { return .goalsToday }
             return .quota
-        case .work, .goalsToday:
+        case .work, .goalsToday, .aiNews:
             return .quota
         }
     }
@@ -359,6 +375,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return popoverNavigation.panel == .work
         case .goalsToday:
             return popoverNavigation.panel == .goals
+        case .aiNews:
+            return popoverNavigation.panel == .aiNews
         }
     }
 
@@ -379,6 +397,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             popoverNavigation.panel = .goals
             popoverNavigation.goalHorizon = .today
+        case .aiNews:
+            popoverNavigation.panel = prefs.isModuleEnabled(.aiNews) ? .aiNews : .quota
         }
     }
 
@@ -397,6 +417,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                       systemMonitor: systemMonitor,
                                       dailyGoals: dailyGoals,
                                       fixedPlanStore: fixedPlanStore,
+                                      aiNewsStore: aiNewsStore,
                                       navigation: popoverNavigation,
                                       controls: controls,
                                       maxContentHeight: maxContentHeight ?? maxPopoverHeight(on: statusItem.button?.window?.screen),

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import KajiCore
 
@@ -23,6 +24,7 @@ struct KajiPopoverView: View {
     @ObservedObject var systemMonitor: SystemMonitor
     @ObservedObject var dailyGoals: DailyGoalStore
     @ObservedObject var fixedPlanStore: FixedPlanStore
+    @ObservedObject var aiNewsStore: AIHotNewsStore
     @ObservedObject var navigation: PopoverNavigation
 
     let controls: GaugeRowView.Controls
@@ -39,6 +41,8 @@ struct KajiPopoverView: View {
     @State private var fixedPlanHoverGeneration = 0
     @FocusState private var focusedGoalID: UUID?
     @State private var showCleanConfirmation = false
+    @State private var hoveredNewsID: String?
+    @State private var newsHoverGeneration = 0
     @Environment(\.colorScheme) private var scheme
 
     private var t: KajiTheme { .resolve(scheme) }
@@ -144,6 +148,82 @@ struct KajiPopoverView: View {
             systemPanel
         case .goals:
             goalsPanel
+        case .aiNews:
+            aiNewsPanel
+        }
+    }
+
+    private var aiNewsPanel: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            switch aiNewsStore.state {
+            case .loading where aiNewsStore.topics.isEmpty:
+                HStack { Spacer(); ProgressView(); Text(L10n.t(.loading, prefs.language)); Spacer() }.padding(24)
+            case .failed where aiNewsStore.topics.isEmpty:
+                Button(L10n.t(.retry, prefs.language)) { aiNewsStore.refresh(force: true) }
+                    .frame(maxWidth: .infinity).padding(20)
+            case .empty:
+                Text(L10n.t(.noHotNews, prefs.language)).foregroundColor(t.mute).frame(maxWidth: .infinity).padding(24)
+            default:
+                ForEach(aiNewsStore.topics) { topic in
+                    aiNewsRow(topic)
+                }
+            }
+            if aiNewsStore.state == .stale {
+                Text("AI HOT unavailable · cached results")
+                    .font(.system(size: 9, weight: .medium)).foregroundColor(t.mute)
+            }
+            HStack {
+                Button { aiNewsStore.refresh(force: true) } label: {
+                    Image(systemName: "arrow.clockwise").font(.system(size: 10, weight: .semibold))
+                }.buttonStyle(.plain).help(L10n.t(.refreshNow, prefs.language))
+                Spacer()
+                Link("\(L10n.t(.dataSource, prefs.language)): AI HOT", destination: URL(string: "https://aihot.virxact.com")!)
+                    .font(.system(size: 9, weight: .medium)).foregroundColor(t.mute)
+            }.padding(.top, 3)
+        }
+    }
+
+    private func aiNewsRow(_ topic: AIHotTopic) -> some View {
+        Button {
+            aiNewsStore.markRead(topic)
+            NSWorkspace.shared.open(topic.originalURL)
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                Text(String(format: "%02d", topic.rank))
+                    .font(.system(size: 10, weight: .bold, design: .monospaced)).foregroundColor(t.ash).frame(width: 20)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(topic.title).font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.cream).lineLimit(2).frame(maxWidth: .infinity, alignment: .leading)
+                    Text("\(topic.sourceName) · \(topic.sourceCount) \(L10n.t(.sources, prefs.language)) · \(topic.latestAt.formatted(.relative(presentation: .numeric)))")
+                        .font(.system(size: 8.5, weight: .medium)).foregroundColor(t.mute).lineLimit(1)
+                }
+            }.padding(7).background(RoundedRectangle(cornerRadius: 7).fill(t.panel.opacity(0.7)))
+                .opacity(aiNewsStore.readTopicIDs.contains(topic.id) ? 0.58 : 1)
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in updateNewsHover(topic, inside: inside) }
+        .popover(isPresented: Binding(get: { hoveredNewsID == topic.id }, set: { if !$0 { hoveredNewsID = nil } }), arrowEdge: .trailing) {
+            aiNewsDetail(topic).onHover { inside in updateNewsHover(topic, inside: inside) }
+        }
+    }
+
+    private func aiNewsDetail(_ topic: AIHotTopic) -> some View {
+        let story = topic.storyPublicID.flatMap { aiNewsStore.hoveredStoryByID[$0] }
+        return VStack(alignment: .leading, spacing: 7) {
+            Text(topic.title).font(.system(size: 12, weight: .bold)).lineLimit(3)
+            Divider()
+            Text(story?.digest ?? story?.latest ?? "\(topic.sourceCount) \(L10n.t(.sources, prefs.language))")
+                .font(.system(size: 10)).textSelection(.enabled)
+            Link("AI HOT", destination: topic.aiHotURL).font(.system(size: 9, weight: .semibold))
+        }.padding(12).frame(width: 250, alignment: .leading)
+    }
+
+    private func updateNewsHover(_ topic: AIHotTopic, inside: Bool) {
+        newsHoverGeneration += 1; let generation = newsHoverGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + (inside ? 0.2 : 0.22)) {
+            guard generation == newsHoverGeneration else { return }
+            if inside { hoveredNewsID = topic.id; aiNewsStore.loadStory(for: topic) }
+            else if hoveredNewsID == topic.id { hoveredNewsID = nil }
         }
     }
 
@@ -1008,6 +1088,7 @@ struct KajiPopoverView: View {
         case .work: return "Work / Break"
         case .system: return "System"
         case .goals: return "Goals"
+        case .aiNews: return L10n.t(.aiNews, prefs.language)
         }
     }
 
@@ -1017,6 +1098,9 @@ struct KajiPopoverView: View {
         case .work: return "45m work, hard break"
         case .system: return "Health + hot processes + cleanup"
         case .goals: return ""
+        case .aiNews:
+            guard let date = aiNewsStore.lastSuccessfulRefresh else { return L10n.t(.loading, prefs.language) }
+            return "\(L10n.t(.updated, prefs.language)) \(date.formatted(.relative(presentation: .numeric)))"
         }
     }
 

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -66,6 +66,13 @@ final class Prefs: ObservableObject {
     @Published var preventSleep: Bool {
         didSet { UserDefaults.standard.set(preventSleep, forKey: Key.preventSleep) }
     }
+    @Published var aiNewsRefreshHours: Int {
+        didSet {
+            let normalized = AIHotRefreshPolicy.normalize(hours: aiNewsRefreshHours)
+            if normalized != aiNewsRefreshHours { aiNewsRefreshHours = normalized; return }
+            UserDefaults.standard.set(normalized, forKey: Key.aiNewsRefreshHours)
+        }
+    }
 
     enum Key {
         static let visibleProviders = "visibleProviders"
@@ -86,12 +93,13 @@ final class Prefs: ObservableObject {
         static let launchAtLogin = "launchAtLogin"
         static let preventSleep = "preventSleep"
         static let preferencesInitialized = "preferencesInitialized"
+        static let aiNewsRefreshHours = "aiNewsRefreshHours"
 
         static let existingPreferenceKeys = [
             visibleProviders, enabledModules, language, menubarStyle,
             showRemaining, panelSize, petId, focusMinutes, breakMinutes,
             allowBreakSkip, breakOverlayEnabled, visibleProvidersV2,
-            visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep
+            visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep, aiNewsRefreshHours
         ]
     }
 
@@ -189,6 +197,8 @@ final class Prefs: ObservableObject {
         } else {
             preventSleep = false
         }
+        aiNewsRefreshHours = AIHotRefreshPolicy.normalize(hours: d.object(forKey: Key.aiNewsRefreshHours) == nil ? 5 : d.integer(forKey: Key.aiNewsRefreshHours))
+        d.set(aiNewsRefreshHours, forKey: Key.aiNewsRefreshHours)
         d.set(true, forKey: Key.preferencesInitialized)
     }
 

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -53,6 +53,7 @@ struct SettingsView: View {
                     moduleRow(.work, title: L10n.t(.moduleWork, prefs.language), lockedOn: false)
                     moduleRow(.system, title: L10n.t(.moduleSystem, prefs.language), lockedOn: false)
                     moduleRow(.goals, title: L10n.t(.moduleGoals, prefs.language), lockedOn: false)
+                    moduleRow(.aiNews, title: L10n.t(.moduleAINews, prefs.language), lockedOn: false)
                     if prefs.isModuleEnabled(.goals) {
                         HStack {
                             Spacer()
@@ -141,6 +142,14 @@ struct SettingsView: View {
                     ForEach(providerSettingsKeys, id: \.self) { key in
                         providerRow(key)
                     }
+                    settingRow(title: L10n.t(.refreshInterval, prefs.language)) {
+                        ForEach(AIHotRefreshPolicy.allowedHours, id: \.self) { hours in
+                            segment("\(hours)h", on: prefs.aiNewsRefreshHours == hours) {
+                                prefs.aiNewsRefreshHours = hours
+                            }
+                        }
+                    }
+                    .help("AI News uses AI HOT's anonymous read-only v1 API.")
                 }
             }
         }

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -24,9 +24,11 @@ struct StatusItemView: View {
     var workSlotLabel: String? = nil
     /// Optional today's completion summary (`n/n`) when Goals is enabled.
     var goalsSlotLabel: String? = nil
+    var showsAINewsSlot: Bool = false
     var onQuotaClick: () -> Void = {}
     var onWorkClick: () -> Void = {}
     var onGoalsClick: () -> Void = {}
+    var onAINewsClick: () -> Void = {}
 
     @Environment(\.colorScheme) private var scheme
 
@@ -58,6 +60,15 @@ struct StatusItemView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+            }
+            if showsAINewsSlot {
+                Button(action: onAINewsClick) {
+                    Image(systemName: "newspaper")
+                        .font(.system(size: 10.5, weight: .medium))
+                        .foregroundStyle(scheme == .dark ? .white : .black)
+                        .frame(width: 15, height: 18)
+                        .contentShape(Rectangle())
+                }.buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 3)

--- a/Sources/KajiCore/AIHotCache.swift
+++ b/Sources/KajiCore/AIHotCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct AIHotStoryCacheEntry: Codable, Equatable, Sendable {
+    public let story: AIHotStory
+    public let etag: String?
+    public let lastAccessedAt: Date
+    public init(story: AIHotStory, etag: String?, lastAccessedAt: Date) {
+        self.story = story; self.etag = etag; self.lastAccessedAt = lastAccessedAt
+    }
+}
+public struct AIHotReadEntry: Codable, Equatable, Sendable {
+    public let topicID: String
+    public let lastSeenAt: Date
+    public init(topicID: String, lastSeenAt: Date) { self.topicID = topicID; self.lastSeenAt = lastSeenAt }
+}
+public struct AIHotCache: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+    public var schemaVersion = AIHotCache.currentSchemaVersion
+    public var topics: [AIHotTopic]
+    public var topicsETag: String?
+    public var lastSuccessfulRefresh: Date?
+    public var stories: [String: AIHotStoryCacheEntry]
+    public var readEntries: [AIHotReadEntry]
+    public init(topics: [AIHotTopic] = [], topicsETag: String? = nil, lastSuccessfulRefresh: Date? = nil,
+                stories: [String: AIHotStoryCacheEntry] = [:], readEntries: [AIHotReadEntry] = []) {
+        self.topics = topics; self.topicsETag = topicsETag; self.lastSuccessfulRefresh = lastSuccessfulRefresh
+        self.stories = stories; self.readEntries = readEntries
+    }
+    public mutating func prune(now: Date, retention: TimeInterval = 30 * 24 * 3600) {
+        let cutoff = now.addingTimeInterval(-retention)
+        stories = stories.filter { $0.value.lastAccessedAt >= cutoff }
+        readEntries = readEntries.filter { $0.lastSeenAt >= cutoff }
+    }
+}

--- a/Sources/KajiCore/AIHotModels.swift
+++ b/Sources/KajiCore/AIHotModels.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+public struct AIHotTopic: Codable, Identifiable, Equatable, Sendable {
+    public let rank: Int
+    public let id: String
+    public let title: String
+    public let sourceName: String
+    public let sourceCount: Int
+    public let signalCount: Int
+    public let sourceNames: [String]
+    public let latestAt: Date
+    public let aiHotURL: URL
+    public let originalURL: URL
+    public let storyPublicID: String?
+
+    public init(rank: Int, id: String, title: String, sourceName: String, sourceCount: Int,
+                signalCount: Int, sourceNames: [String], latestAt: Date, aiHotURL: URL,
+                originalURL: URL, storyPublicID: String?) {
+        self.rank = rank; self.id = id; self.title = title; self.sourceName = sourceName
+        self.sourceCount = sourceCount; self.signalCount = signalCount; self.sourceNames = sourceNames
+        self.latestAt = latestAt; self.aiHotURL = aiHotURL; self.originalURL = originalURL
+        self.storyPublicID = storyPublicID
+    }
+}
+
+public struct AIHotStory: Codable, Equatable, Sendable {
+    public let publicID: String
+    public let title: String
+    public let latest: String
+    public let digest: String?
+    public let digestUpdatedAt: Date?
+    public let sourceCount: Int
+    public let latestAt: Date
+    public let aiHotURL: URL
+    public init(publicID: String, title: String, latest: String, digest: String?, digestUpdatedAt: Date?,
+                sourceCount: Int, latestAt: Date, aiHotURL: URL) {
+        self.publicID = publicID; self.title = title; self.latest = latest; self.digest = digest
+        self.digestUpdatedAt = digestUpdatedAt; self.sourceCount = sourceCount
+        self.latestAt = latestAt; self.aiHotURL = aiHotURL
+    }
+}
+
+public enum AIHotDecoder {
+    private struct Source: Decodable { let name: String }
+    private struct Links: Decodable { let aihot: URL?; let original: URL?; let story: URL? }
+    private struct TopicDTO: Decodable {
+        let rank: Int?; let id: String?; let title: String?; let source: Source?; let links: Links?
+        let sourceCount: Int?; let signalCount: Int?; let sourceNames: [String]?; let latestAt: Date?
+    }
+    private struct TopicsEnvelope: Decodable { let items: [Failable<TopicDTO>] }
+    private struct StoryEnvelope: Decodable { let story: StoryDTO }
+    private struct StoryDTO: Decodable {
+        let publicId: String; let title: String; let latest: String; let digest: String?
+        let digestUpdatedAt: Date?; let sourceCount: Int; let latestAt: Date; let links: Links
+    }
+    private struct Failable<Value: Decodable>: Decodable {
+        let value: Value?
+        init(from decoder: Decoder) throws { value = try? Value(from: decoder) }
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value) { return date }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO 8601 date")
+        }
+        return decoder
+    }
+
+    public static func topics(from data: Data) throws -> [AIHotTopic] {
+        try decoder().decode(TopicsEnvelope.self, from: data).items.compactMap { item in
+            guard let dto = item.value, let rank = dto.rank, (1...10).contains(rank),
+                  let id = dto.id, !id.isEmpty, let title = dto.title, !title.isEmpty,
+                  let source = dto.source, let links = dto.links, let aiHotURL = links.aihot,
+                  let originalURL = links.original, aiHotURL.scheme == "https", originalURL.scheme == "https",
+                  let latestAt = dto.latestAt else { return nil }
+            let storyID = links.story?.pathComponents.last.flatMap { $0 == "/" || $0.isEmpty ? nil : $0 }
+            return AIHotTopic(rank: rank, id: id, title: title, sourceName: source.name,
+                              sourceCount: dto.sourceCount ?? 0, signalCount: dto.signalCount ?? 0,
+                              sourceNames: dto.sourceNames ?? [], latestAt: latestAt, aiHotURL: aiHotURL,
+                              originalURL: originalURL, storyPublicID: storyID)
+        }
+    }
+
+    public static func story(from data: Data) throws -> AIHotStory {
+        let value = try decoder().decode(StoryEnvelope.self, from: data).story
+        guard let url = value.links.aihot, url.scheme == "https" else { throw URLError(.badURL) }
+        return AIHotStory(publicID: value.publicId, title: value.title, latest: value.latest,
+                          digest: value.digest, digestUpdatedAt: value.digestUpdatedAt,
+                          sourceCount: value.sourceCount, latestAt: value.latestAt, aiHotURL: url)
+    }
+}

--- a/Sources/KajiCore/AIHotRefreshPolicy.swift
+++ b/Sources/KajiCore/AIHotRefreshPolicy.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum AIHotRefreshPolicy {
+    public static let allowedHours = [1, 3, 5, 12, 24]
+    public static let defaultHours = 5
+    public static let serverFreshnessFloor: TimeInterval = 300
+    public static func normalize(hours: Int) -> Int { allowedHours.contains(hours) ? hours : defaultHours }
+    public static func dueDate(lastSuccessfulRefresh: Date?, hours: Int, now: Date) -> Date {
+        guard let lastSuccessfulRefresh else { return now }
+        return lastSuccessfulRefresh.addingTimeInterval(TimeInterval(normalize(hours: hours) * 3600))
+    }
+    public static func shouldRefresh(hasCache: Bool, lastSuccessfulRefresh: Date?, hours: Int, now: Date) -> Bool {
+        !hasCache || dueDate(lastSuccessfulRefresh: lastSuccessfulRefresh, hours: hours, now: now) <= now
+    }
+    public static func retryDelay(statusCode: Int, retryAfter: String?, attempt: Int) -> TimeInterval? {
+        if statusCode == 429 || statusCode == 503 {
+            guard attempt == 0, let retryAfter, let seconds = TimeInterval(retryAfter), seconds > 0 else { return nil }
+            return seconds
+        }
+        if statusCode >= 500 || statusCode == 0 { return attempt == 0 ? 2 : nil }
+        return nil
+    }
+}

--- a/Sources/KajiCore/GoalHorizonModel.swift
+++ b/Sources/KajiCore/GoalHorizonModel.swift
@@ -206,6 +206,7 @@ public enum MenuBarDestination: Equatable, Sendable {
     case quota
     case work
     case goalsToday
+    case aiNews
 }
 
 public enum MenuBarSlotLogic {
@@ -226,6 +227,7 @@ public enum MenuBarSlotLogic {
         case .quota, .background: .quota
         case .work: .work
         case .goals: .goalsToday
+        case .aiNews: .aiNews
         }
     }
 }
@@ -234,5 +236,6 @@ public enum MenuBarSlot: Equatable, Sendable {
     case quota
     case work
     case goals
+    case aiNews
     case background
 }

--- a/Sources/KajiCore/LanguageLocalization.swift
+++ b/Sources/KajiCore/LanguageLocalization.swift
@@ -61,7 +61,8 @@ public enum L10n {
         case fixedPlan
         case launchAtLogin
         case modules, modulesHint
-        case moduleQuota, moduleWork, moduleSystem, moduleGoals
+        case moduleQuota, moduleWork, moduleSystem, moduleGoals, moduleAINews
+        case aiNews, dataSource, updated, loading, noHotNews, retry, sources, refreshInterval
     }
 
     private struct Text {
@@ -148,7 +149,16 @@ public enum L10n {
         .moduleQuota: .init(en: "Quota", zh: "Quota", ptBR: "Quota", es: "Quota"),
         .moduleWork: .init(en: "Work / Break", zh: "Work / Break", ptBR: "Trabalho / Pausa", es: "Trabajo / Descanso"),
         .moduleSystem: .init(en: "System", zh: "System", ptBR: "Sistema", es: "Sistema"),
-        .moduleGoals: .init(en: "Goals", zh: "Goals", ptBR: "Metas", es: "Metas")
+        .moduleGoals: .init(en: "Goals", zh: "Goals", ptBR: "Metas", es: "Metas"),
+        .moduleAINews: .init(en: "AI News", zh: "AI 新闻", ptBR: "Notícias de IA", es: "Noticias de IA"),
+        .aiNews: .init(en: "AI News", zh: "AI 新闻", ptBR: "Notícias de IA", es: "Noticias de IA"),
+        .dataSource: .init(en: "Data source", zh: "数据来源", ptBR: "Fonte de dados", es: "Fuente de datos"),
+        .updated: .init(en: "Updated", zh: "更新于", ptBR: "Atualizado", es: "Actualizado"),
+        .loading: .init(en: "Loading…", zh: "加载中…", ptBR: "Carregando…", es: "Cargando…"),
+        .noHotNews: .init(en: "No hot news", zh: "暂无热点", ptBR: "Sem notícias em alta", es: "Sin noticias destacadas"),
+        .retry: .init(en: "Retry", zh: "重试", ptBR: "Tentar novamente", es: "Reintentar"),
+        .sources: .init(en: "sources", zh: "个来源", ptBR: "fontes", es: "fuentes"),
+        .refreshInterval: .init(en: "Refresh", zh: "刷新间隔", ptBR: "Atualização", es: "Actualización")
     ]
 
     public static func t(_ key: K, _ language: AppLanguage) -> String {

--- a/Sources/KajiCore/ModulePrefsLogic.swift
+++ b/Sources/KajiCore/ModulePrefsLogic.swift
@@ -6,9 +6,10 @@ public enum KajiModuleID: String, CaseIterable, Codable, Sendable, Comparable {
     case work
     case system
     case goals
+    case aiNews
 
     /// Stable popover order. Unknown / disabled ids never appear here.
-    public static let stableOrder: [KajiModuleID] = [.quota, .work, .system, .goals]
+    public static let stableOrder: [KajiModuleID] = [.quota, .work, .system, .goals, .aiNews]
 
     public static func < (lhs: KajiModuleID, rhs: KajiModuleID) -> Bool {
         let li = stableOrder.firstIndex(of: lhs) ?? Int.max

--- a/Tests/KajiTests/AIHotAPIClientTests.swift
+++ b/Tests/KajiTests/AIHotAPIClientTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Kaji
+
+final class AIHotAPIClientTests: XCTestCase {
+    override func tearDown() {
+        AIHotURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testHotTopicsSendsIdentityAndConditionalETag() async throws {
+        AIHotURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://aihot.virxact.com/api/v1/hot-topics")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "If-None-Match"), "old-tag")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "Kaji/0.6 (+https://github.com/blackblue-labs/kaji)")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil,
+                                           headerFields: ["ETag": "new-tag", "Cache-Control": "s-maxage=300"])!
+            return (response, Data())
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AIHotURLProtocol.self]
+        let result = try await AIHotAPIClient(session: URLSession(configuration: config)).hotTopics(etag: "old-tag")
+        XCTAssertEqual(result.statusCode, 304)
+        XCTAssertEqual(result.etag, "new-tag")
+        XCTAssertNil(result.value)
+    }
+
+    func testRateLimitResponsePreservesRetryAfterWithoutDecodingProblemBody() async throws {
+        AIHotURLProtocol.handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 429, httpVersion: nil,
+                                           headerFields: ["Retry-After": "23"])!
+            return (response, Data(#"{"title":"rate limited"}"#.utf8))
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AIHotURLProtocol.self]
+        let result = try await AIHotAPIClient(session: URLSession(configuration: config)).hotTopics(etag: nil)
+        XCTAssertEqual(result.retryAfter, "23")
+        XCTAssertNil(result.value)
+    }
+}
+
+private final class AIHotURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        do {
+            guard let handler = Self.handler else { throw URLError(.unknown) }
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch { client?.urlProtocol(self, didFailWithError: error) }
+    }
+    override func stopLoading() { }
+}

--- a/Tests/KajiTests/AIHotCacheTests.swift
+++ b/Tests/KajiTests/AIHotCacheTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import KajiCore
+
+final class AIHotCacheTests: XCTestCase {
+    func testPruneRetainsOnlyThirtyDayEntries() {
+        let now = Date(timeIntervalSince1970: 4_000_000)
+        let url = URL(string: "https://aihot.virxact.com/story")!
+        let story = AIHotStory(publicID: "s", title: "t", latest: "l", digest: nil,
+                               digestUpdatedAt: nil, sourceCount: 1, latestAt: now, aiHotURL: url)
+        var cache = AIHotCache(stories: [
+            "old": .init(story: story, etag: nil, lastAccessedAt: now.addingTimeInterval(-31 * 86400)),
+            "new": .init(story: story, etag: nil, lastAccessedAt: now)
+        ], readEntries: [
+            .init(topicID: "old", lastSeenAt: now.addingTimeInterval(-31 * 86400)),
+            .init(topicID: "new", lastSeenAt: now)
+        ])
+        cache.prune(now: now)
+        XCTAssertEqual(Set(cache.stories.keys), ["new"])
+        XCTAssertEqual(cache.readEntries.map(\.topicID), ["new"])
+    }
+}

--- a/Tests/KajiTests/AIHotModelsTests.swift
+++ b/Tests/KajiTests/AIHotModelsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import KajiCore
+
+final class AIHotModelsTests: XCTestCase {
+    func testValidFixturePreservesOrderAndExtractsStoryPathSegment() throws {
+        let data = Data(#"{"schemaVersion":1,"count":2,"items":[{"rank":2,"id":"b","title":"Second","source":{"name":"Beta"},"links":{"aihot":"https://aihot.virxact.com/hot/b","original":"https://example.com/b"},"sourceCount":2,"signalCount":4,"sourceNames":["Beta","B2"],"latestAt":"2026-08-05T01:02:03Z"},{"rank":1,"id":"a","title":"First","source":{"name":"Alpha"},"links":{"aihot":"https://aihot.virxact.com/hot/a","original":"https://example.com/a","story":"https://aihot.virxact.com/stories/story-public-1"},"sourceCount":3,"signalCount":5,"sourceNames":["Alpha"],"latestAt":"2026-08-05T02:02:03.123Z","future":"ok"}]}"#.utf8)
+        let topics = try AIHotDecoder.topics(from: data)
+        XCTAssertEqual(topics.map(\.rank), [2, 1])
+        XCTAssertEqual(topics[0].sourceCount, 2)
+        XCTAssertNil(topics[0].storyPublicID)
+        XCTAssertEqual(topics[1].storyPublicID, "story-public-1")
+    }
+
+    func testMalformedItemIsSkippedWithoutClearingValidItems() throws {
+        let data = Data(#"{"items":[{"rank":1,"id":"ok","title":"Good","source":{"name":"A"},"links":{"aihot":"https://aihot.virxact.com/x","original":"https://example.com/x"},"latestAt":"2026-08-05T00:00:00Z"},{"rank":2,"id":"bad","title":"Bad","source":{"name":"B"},"links":{"aihot":"not-a-url","original":"https://example.com"},"latestAt":"oops"}]}"#.utf8)
+        XCTAssertEqual(try AIHotDecoder.topics(from: data).map(\.id), ["ok"])
+    }
+}

--- a/Tests/KajiTests/AIHotRefreshPolicyTests.swift
+++ b/Tests/KajiTests/AIHotRefreshPolicyTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import KajiCore
+
+final class AIHotRefreshPolicyTests: XCTestCase {
+    func testRefreshHoursNormalizeAndDuePolicy() {
+        XCTAssertEqual(AIHotRefreshPolicy.normalize(hours: 7), 5)
+        XCTAssertEqual(AIHotRefreshPolicy.allowedHours, [1, 3, 5, 12, 24])
+        let now = Date(timeIntervalSince1970: 100_000)
+        XCTAssertFalse(AIHotRefreshPolicy.shouldRefresh(hasCache: true, lastSuccessfulRefresh: now.addingTimeInterval(-4 * 3600), hours: 5, now: now))
+        XCTAssertTrue(AIHotRefreshPolicy.shouldRefresh(hasCache: true, lastSuccessfulRefresh: now.addingTimeInterval(-5 * 3600), hours: 5, now: now))
+        XCTAssertTrue(AIHotRefreshPolicy.shouldRefresh(hasCache: false, lastSuccessfulRefresh: now, hours: 5, now: now))
+    }
+
+    func testRetryOccursAtMostOnce() {
+        XCTAssertEqual(AIHotRefreshPolicy.retryDelay(statusCode: 429, retryAfter: "17", attempt: 0), 17)
+        XCTAssertNil(AIHotRefreshPolicy.retryDelay(statusCode: 429, retryAfter: "17", attempt: 1))
+        XCTAssertEqual(AIHotRefreshPolicy.retryDelay(statusCode: 500, retryAfter: nil, attempt: 0), 2)
+        XCTAssertNil(AIHotRefreshPolicy.retryDelay(statusCode: 500, retryAfter: nil, attempt: 1))
+    }
+}

--- a/Tests/KajiTests/MenuBarSlotLogicTests.swift
+++ b/Tests/KajiTests/MenuBarSlotLogicTests.swift
@@ -48,5 +48,6 @@ final class MenuBarSlotLogicTests: XCTestCase {
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .work), .work)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .goals), .goalsToday)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .background), .quota)
+        XCTAssertEqual(MenuBarSlotLogic.destination(for: .aiNews), .aiNews)
     }
 }

--- a/Tests/KajiTests/ModulePrefsLogicTests.swift
+++ b/Tests/KajiTests/ModulePrefsLogicTests.swift
@@ -62,9 +62,14 @@ final class ModulePrefsLogicTests: XCTestCase {
 
     func testPopoverPages_allEnabled_fullOrder() {
         let pages = ModulePrefsLogic.popoverPages(
-            enabled: [.quota, .work, .system, .goals]
+            enabled: [.quota, .work, .system, .goals, .aiNews]
         )
         XCTAssertEqual(pages, KajiModuleID.stableOrder)
+    }
+
+    func testAIHotDefaultsOffAndAppearsAfterGoalsWhenEnabled() {
+        XCTAssertFalse(ModulePrefsLogic.normalizeEnabledModules(nil).contains(.aiNews))
+        XCTAssertEqual(ModulePrefsLogic.popoverPages(enabled: [.quota, .goals, .aiNews]), [.quota, .goals, .aiNews])
     }
 
     func testPopoverPages_ignoresQuotaMissingInSet_byCallerContract() {

--- a/scripts/snapshot.swift
+++ b/scripts/snapshot.swift
@@ -90,6 +90,8 @@ struct Snap {
             let workSession = WorkSessionController(prefs: prefs)
             let systemMonitor = SystemMonitor()
             let dailyGoals = DailyGoalStore()
+            let fixedPlanStore = FixedPlanStore()
+            let aiNewsStore = AIHotNewsStore()
             let navigation = PopoverNavigation()
             let controls = GaugeRowView.Controls(
                 onRefresh: {},
@@ -106,6 +108,8 @@ struct Snap {
                 workSession: workSession,
                 systemMonitor: systemMonitor,
                 dailyGoals: dailyGoals,
+                fixedPlanStore: fixedPlanStore,
+                aiNewsStore: aiNewsStore,
                 navigation: navigation,
                 controls: controls,
                 maxContentHeight: 720,


### PR DESCRIPTION
Closes #28

Adds the opt-in AI News module backed by AI HOT anonymous read-only v1 APIs. Includes Top 10 page, lazy story details, ETag-aware refresh scheduling, versioned local cache, read state, menu-bar destination, settings, localization, and fixture-based tests.

Verification:
- swift test (92 tests)
- scripts/build-app.sh
- codesign --verify --deep --strict --verbose=2 dist/Kaji.app