### PR TITLE
feat: ship Kaji v0.7 Local MCP

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var workSession = WorkSessionController(prefs: prefs)
     private let systemMonitor = SystemMonitor()
     private let dailyGoals = DailyGoalStore()
+    private lazy var mcpServer = KajiMCPServer(goals: dailyGoals)
     private let fixedPlanStore = FixedPlanStore()
     private let popoverNavigation = PopoverNavigation()
     private let aiNewsStore = AIHotNewsStore()
@@ -45,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         sleepController.refresh()
         store.start()
         applyModuleLifecycle(prefs.enabledModules)
+        mcpServer.setEnabled(prefs.mcpEnabled)
         refreshPetCatalogSelection()
 
         setupStatusItem()
@@ -145,6 +147,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
             .store(in: &cancellables)
+        prefs.$mcpEnabled
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] enabled in
+                self?.mcpServer.setEnabled(enabled)
+            }
+            .store(in: &cancellables)
         // Update availability re-renders the glyph (adds/removes the badge dot).
         updateChecker.$available
             .receive(on: RunLoop.main)
@@ -189,6 +198,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         petStateTimer?.invalidate()
         closeBreakOverlay()
         aiNewsStore.stop()
+        mcpServer.stop()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -477,7 +487,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let controller = KajiHostingController(rootView: SettingsView(prefs: prefs,
                                                                        sleepController: sleepController,
                                                                        petCatalog: petCatalog,
-                                                                       fixedPlanStore: fixedPlanStore))
+                                                                       fixedPlanStore: fixedPlanStore,
+                                                                       mcpServer: mcpServer))
         controller.view.configureKajiHost()
         let window = NSWindow(contentViewController: controller)
         window.title = "Kaji Settings"

--- a/Sources/Kaji/DailyGoalStore.swift
+++ b/Sources/Kaji/DailyGoalStore.swift
@@ -105,6 +105,79 @@ final class DailyGoalStore: ObservableObject {
         }
     }
 
+    @discardableResult
+    func addGoal(
+        title: String,
+        tag: String,
+        note: String,
+        in horizon: GoalHorizon
+    ) throws -> DailyGoal {
+        let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedTitle.isEmpty else {
+            throw GoalStoreMutationError.emptyTitle
+        }
+        let goal = DailyGoal(
+            id: UUID(),
+            title: normalizedTitle,
+            isDone: false,
+            tag: GoalTagLogic.resolve(tag, title: normalizedTitle).rawValue,
+            note: note
+        )
+        mutate(horizon) { $0.append(goal) }
+        return goal
+    }
+
+    func updateGoal(
+        id: UUID,
+        title: String?,
+        tag: String?,
+        note: String?,
+        in horizon: GoalHorizon
+    ) throws {
+        var next = state
+        guard let index = next[horizon].firstIndex(where: { $0.id == id }) else {
+            throw GoalStoreMutationError.goalNotFound
+        }
+        if let title {
+            let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedTitle.isEmpty else {
+                throw GoalStoreMutationError.emptyTitle
+            }
+            next[horizon][index].title = normalizedTitle
+        }
+        if let tag {
+            next[horizon][index].tag = GoalTagLogic.resolve(
+                tag,
+                title: next[horizon][index].title
+            ).rawValue
+        }
+        if let note {
+            next[horizon][index].note = note
+        }
+        state = next
+        if horizon == .today { recordToday() }
+    }
+
+    func setGoalCompleted(id: UUID, isDone: Bool, in horizon: GoalHorizon) throws {
+        var next = state
+        guard let index = next[horizon].firstIndex(where: { $0.id == id }) else {
+            throw GoalStoreMutationError.goalNotFound
+        }
+        next[horizon][index].isDone = isDone
+        state = next
+        if horizon == .today { recordToday() }
+    }
+
+    func deleteGoal(id: UUID, in horizon: GoalHorizon) throws {
+        var next = state
+        guard next[horizon].contains(where: { $0.id == id }) else {
+            throw GoalStoreMutationError.goalNotFound
+        }
+        next[horizon].removeAll { $0.id == id }
+        state = next
+        if horizon == .today { recordToday() }
+    }
+
     func move(_ goal: DailyGoal, in horizon: GoalHorizon, offset: Int) {
         mutate(horizon) { goals in
             guard let source = goals.firstIndex(where: { $0.id == goal.id }) else { return }
@@ -208,4 +281,9 @@ final class DailyGoalStore: ObservableObject {
         return "\(components.yearForWeekOfYear ?? 0)-\(components.weekOfYear ?? 0)"
     }
 
+}
+
+enum GoalStoreMutationError: Error {
+    case goalNotFound
+    case emptyTitle
 }

--- a/Sources/Kaji/KajiMCPServer.swift
+++ b/Sources/Kaji/KajiMCPServer.swift
@@ -1,0 +1,459 @@
+import Foundation
+import Network
+import KajiCore
+
+@MainActor
+final class KajiMCPServer: ObservableObject {
+    static let port: UInt16 = 37_841
+    static let endpoint = "http://127.0.0.1:\(port)/mcp"
+
+    enum Status: Equatable {
+        case stopped
+        case starting
+        case running
+        case failed(String)
+    }
+
+    @Published private(set) var status: Status = .stopped
+
+    private weak var goals: DailyGoalStore?
+    private let host: NWEndpoint.Host
+    private let port: NWEndpoint.Port
+    private var listener: NWListener?
+    private var connections: [ObjectIdentifier: NWConnection] = [:]
+    private let queue = DispatchQueue(label: "dev.kaji.mcp")
+
+    init(
+        goals: DailyGoalStore,
+        host: String = "127.0.0.1",
+        port: UInt16 = KajiMCPServer.port
+    ) {
+        self.goals = goals
+        self.host = NWEndpoint.Host(host)
+        self.port = NWEndpoint.Port(rawValue: port)!
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        enabled ? start() : stop()
+    }
+
+    func start() {
+        guard listener == nil else { return }
+        status = .starting
+        do {
+            let parameters = NWParameters.tcp
+            parameters.requiredLocalEndpoint = .hostPort(
+                host: host,
+                port: port
+            )
+            let listener = try NWListener(using: parameters)
+            self.listener = listener
+            listener.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor in
+                    guard let self else { return }
+                    switch state {
+                    case .ready:
+                        self.status = .running
+                    case .failed(let error):
+                        self.listener?.cancel()
+                        self.listener = nil
+                        self.status = .failed(error.localizedDescription)
+                    default:
+                        break
+                    }
+                }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor in self?.accept(connection) }
+            }
+            listener.start(queue: queue)
+        } catch {
+            listener = nil
+            status = .failed(error.localizedDescription)
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+        connections.values.forEach { $0.cancel() }
+        connections.removeAll()
+        status = .stopped
+    }
+
+    private func accept(_ connection: NWConnection) {
+        connections[ObjectIdentifier(connection)] = connection
+        connection.start(queue: queue)
+        receive(on: connection, buffer: Data())
+    }
+
+    private func receive(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) {
+            [weak self] data, _, isComplete, error in
+            var next = buffer
+            if let data { next.append(data) }
+            if let request = MCPHTTPRequest.parse(next) {
+                Task { @MainActor in
+                    guard let self else {
+                        connection.cancel()
+                        return
+                    }
+                    let response = self.handle(request)
+                    connection.send(
+                        content: response,
+                        contentContext: .defaultMessage,
+                        isComplete: false,
+                        completion: .contentProcessed { sendError in
+                            Task { @MainActor in
+                                if sendError != nil {
+                                    self.finish(connection)
+                                } else {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                        self.finish(connection)
+                                    }
+                                }
+                            }
+                        }
+                    )
+                }
+                return
+            }
+            if isComplete || error != nil || next.count > 1_048_576 {
+                Task { @MainActor in self?.finish(connection) }
+                return
+            }
+            Task { @MainActor in self?.receive(on: connection, buffer: next) }
+        }
+    }
+
+    private func finish(_ connection: NWConnection) {
+        connections.removeValue(forKey: ObjectIdentifier(connection))
+        connection.cancel()
+    }
+
+    private func handle(_ request: MCPHTTPRequest) -> Data {
+        guard request.method == "POST", request.path == "/mcp" else {
+            return MCPHTTPResponse.json(
+                status: "404 Not Found",
+                object: ["error": "Use POST /mcp"]
+            )
+        }
+        guard let value = try? JSONSerialization.jsonObject(with: request.body),
+              let rpc = value as? [String: Any] else {
+            return rpcError(id: NSNull(), code: -32700, message: "Parse error")
+        }
+        let id = rpc["id"] ?? NSNull()
+        guard let method = rpc["method"] as? String else {
+            return rpcError(id: id, code: -32600, message: "Invalid Request")
+        }
+
+        switch method {
+        case "notifications/initialized":
+            return MCPHTTPResponse.empty(status: "202 Accepted")
+        case "ping":
+            return rpcResult(id: id, result: [:])
+        case "initialize":
+            let params = rpc["params"] as? [String: Any]
+            return rpcResult(id: id, result: [
+                "protocolVersion": params?["protocolVersion"] as? String ?? "2025-03-26",
+                "capabilities": ["tools": ["listChanged": false]],
+                "serverInfo": ["name": "Kaji", "version": "0.7.0"]
+            ])
+        case "tools/list":
+            return rpcResult(id: id, result: ["tools": Self.toolDefinitions])
+        case "tools/call":
+            guard let params = rpc["params"] as? [String: Any],
+                  let name = params["name"] as? String else {
+                return rpcError(id: id, code: -32602, message: "Missing tool name")
+            }
+            return callTool(
+                id: id,
+                name: name,
+                arguments: params["arguments"] as? [String: Any] ?? [:]
+            )
+        default:
+            return rpcError(id: id, code: -32601, message: "Method not found")
+        }
+    }
+
+    private func callTool(id: Any, name: String, arguments: [String: Any]) -> Data {
+        guard let goals else { return toolError(id: id, message: "Goals store unavailable") }
+        do {
+            let payload: Any
+            switch name {
+            case "kaji_goals_list":
+                if let raw = arguments["horizon"] as? String {
+                    let horizon = try parseHorizon(raw)
+                    payload = [
+                        "horizon": horizonName(horizon),
+                        "goals": goals.goals(for: horizon).map(goalObject)
+                    ]
+                } else {
+                    payload = Dictionary(uniqueKeysWithValues: GoalHorizon.allCases.map {
+                        (horizonName($0), goals.goals(for: $0).map(goalObject))
+                    })
+                }
+            case "kaji_goal_add":
+                let horizon = try requiredHorizon(arguments)
+                guard let title = arguments["title"] as? String else {
+                    throw MCPToolError.invalid("title is required")
+                }
+                let goal = try goals.addGoal(
+                    title: title,
+                    tag: arguments["tag"] as? String ?? "personal",
+                    note: arguments["note"] as? String ?? "",
+                    in: horizon
+                )
+                payload = goalObject(goal)
+            case "kaji_goal_update":
+                let horizon = try requiredHorizon(arguments)
+                let goalID = try requiredID(arguments)
+                let title = arguments["title"] as? String
+                let tag = arguments["tag"] as? String
+                let note = arguments["note"] as? String
+                guard title != nil || tag != nil || note != nil else {
+                    throw MCPToolError.invalid("title, tag, or note is required")
+                }
+                try goals.updateGoal(
+                    id: goalID,
+                    title: title,
+                    tag: tag,
+                    note: note,
+                    in: horizon
+                )
+                payload = goalObject(try findGoal(goalID, in: horizon, store: goals))
+            case "kaji_goal_complete":
+                let horizon = try requiredHorizon(arguments)
+                let goalID = try requiredID(arguments)
+                guard let isDone = arguments["isDone"] as? Bool else {
+                    throw MCPToolError.invalid("isDone is required")
+                }
+                try goals.setGoalCompleted(id: goalID, isDone: isDone, in: horizon)
+                payload = goalObject(try findGoal(goalID, in: horizon, store: goals))
+            case "kaji_goal_delete":
+                let horizon = try requiredHorizon(arguments)
+                let goalID = try requiredID(arguments)
+                try goals.deleteGoal(id: goalID, in: horizon)
+                payload = ["deleted": goalID.uuidString.lowercased()]
+            default:
+                throw MCPToolError.invalid("Unknown tool: \(name)")
+            }
+            return toolResult(id: id, payload: payload)
+        } catch {
+            return toolError(id: id, message: message(for: error))
+        }
+    }
+
+    private func requiredHorizon(_ arguments: [String: Any]) throws -> GoalHorizon {
+        guard let raw = arguments["horizon"] as? String else {
+            throw MCPToolError.invalid("horizon is required")
+        }
+        return try parseHorizon(raw)
+    }
+
+    private func parseHorizon(_ raw: String) throws -> GoalHorizon {
+        switch raw.lowercased() {
+        case "today": .today
+        case "week": .week
+        case "vision", "longterm", "long_term": .longTerm
+        default: throw MCPToolError.invalid("horizon must be today, week, or vision")
+        }
+    }
+
+    private func horizonName(_ horizon: GoalHorizon) -> String {
+        horizon == .longTerm ? "vision" : horizon.rawValue
+    }
+
+    private func requiredID(_ arguments: [String: Any]) throws -> UUID {
+        guard let raw = arguments["id"] as? String,
+              let id = UUID(uuidString: raw) else {
+            throw MCPToolError.invalid("id must be a UUID")
+        }
+        return id
+    }
+
+    private func findGoal(
+        _ id: UUID,
+        in horizon: GoalHorizon,
+        store: DailyGoalStore
+    ) throws -> DailyGoal {
+        guard let goal = store.goals(for: horizon).first(where: { $0.id == id }) else {
+            throw GoalStoreMutationError.goalNotFound
+        }
+        return goal
+    }
+
+    private func goalObject(_ goal: DailyGoal) -> [String: Any] {
+        [
+            "id": goal.id.uuidString.lowercased(),
+            "title": goal.title,
+            "isDone": goal.isDone,
+            "tag": goal.tag,
+            "note": goal.note
+        ]
+    }
+
+    private func message(for error: Error) -> String {
+        switch error {
+        case GoalStoreMutationError.goalNotFound: "Goal not found"
+        case GoalStoreMutationError.emptyTitle: "title cannot be empty"
+        case MCPToolError.invalid(let message): message
+        default: error.localizedDescription
+        }
+    }
+
+    private func rpcResult(id: Any, result: Any) -> Data {
+        MCPHTTPResponse.json(object: ["jsonrpc": "2.0", "id": id, "result": result])
+    }
+
+    private func rpcError(id: Any, code: Int, message: String) -> Data {
+        MCPHTTPResponse.json(object: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": ["code": code, "message": message]
+        ])
+    }
+
+    private func toolResult(id: Any, payload: Any) -> Data {
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let text = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        return rpcResult(id: id, result: [
+            "content": [["type": "text", "text": text]],
+            "structuredContent": payload,
+            "isError": false
+        ])
+    }
+
+    private func toolError(id: Any, message: String) -> Data {
+        rpcResult(id: id, result: [
+            "content": [["type": "text", "text": message]],
+            "isError": true
+        ])
+    }
+
+    private enum MCPToolError: Error {
+        case invalid(String)
+    }
+
+    private static let horizonSchema: [String: Any] = [
+        "type": "string",
+        "enum": ["today", "week", "vision"]
+    ]
+
+    private static let toolDefinitions: [[String: Any]] = [
+        tool(
+            "kaji_goals_list",
+            "List Kaji goals. Omit horizon to list all horizons.",
+            properties: ["horizon": horizonSchema]
+        ),
+        tool(
+            "kaji_goal_add",
+            "Add a Goal with an optional note.",
+            properties: [
+                "horizon": horizonSchema,
+                "title": ["type": "string"],
+                "tag": ["type": "string"],
+                "note": ["type": "string"]
+            ],
+            required: ["horizon", "title"]
+        ),
+        tool(
+            "kaji_goal_update",
+            "Update a Goal title, Tag, and/or note.",
+            properties: [
+                "horizon": horizonSchema,
+                "id": ["type": "string"],
+                "title": ["type": "string"],
+                "tag": ["type": "string"],
+                "note": ["type": "string"]
+            ],
+            required: ["horizon", "id"]
+        ),
+        tool(
+            "kaji_goal_complete",
+            "Set a Goal's completion state.",
+            properties: [
+                "horizon": horizonSchema,
+                "id": ["type": "string"],
+                "isDone": ["type": "boolean"]
+            ],
+            required: ["horizon", "id", "isDone"]
+        ),
+        tool(
+            "kaji_goal_delete",
+            "Delete a Goal by ID.",
+            properties: [
+                "horizon": horizonSchema,
+                "id": ["type": "string"]
+            ],
+            required: ["horizon", "id"]
+        )
+    ]
+
+    private static func tool(
+        _ name: String,
+        _ description: String,
+        properties: [String: Any],
+        required: [String] = []
+    ) -> [String: Any] {
+        var schema: [String: Any] = [
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": false
+        ]
+        if !required.isEmpty { schema["required"] = required }
+        return [
+            "name": name,
+            "description": description,
+            "inputSchema": schema
+        ]
+    }
+}
+
+private struct MCPHTTPRequest {
+    let method: String
+    let path: String
+    let body: Data
+
+    static func parse(_ data: Data) -> MCPHTTPRequest? {
+        let marker = Data("\r\n\r\n".utf8)
+        guard let headerRange = data.range(of: marker),
+              let header = String(data: data[..<headerRange.lowerBound], encoding: .utf8)
+        else { return nil }
+        let lines = header.components(separatedBy: "\r\n")
+        let requestLine = lines.first?.split(separator: " ") ?? []
+        guard requestLine.count >= 2 else { return nil }
+        let contentLength = lines.dropFirst().compactMap { line -> Int? in
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces).lowercased()
+                    == "content-length" else { return nil }
+            return Int(parts[1].trimmingCharacters(in: .whitespaces))
+        }.first ?? 0
+        let bodyStart = headerRange.upperBound
+        guard data.count >= bodyStart + contentLength else { return nil }
+        return MCPHTTPRequest(
+            method: String(requestLine[0]),
+            path: String(requestLine[1]),
+            body: data.subdata(in: bodyStart..<(bodyStart + contentLength))
+        )
+    }
+}
+
+private enum MCPHTTPResponse {
+    static func json(status: String = "200 OK", object: Any) -> Data {
+        let body = (try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys]
+        )) ?? Data()
+        let header = "HTTP/1.1 \(status)\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: \(body.count)\r\n" +
+            "Connection: close\r\n\r\n"
+        return Data(header.utf8) + body
+    }
+
+    static func empty(status: String) -> Data {
+        Data("HTTP/1.1 \(status)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+    }
+}

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -63,6 +63,9 @@ final class Prefs: ObservableObject {
     @Published var preventSleep: Bool {
         didSet { UserDefaults.standard.set(preventSleep, forKey: Key.preventSleep) }
     }
+    @Published var mcpEnabled: Bool {
+        didSet { UserDefaults.standard.set(mcpEnabled, forKey: Key.mcpEnabled) }
+    }
     @Published var aiNewsRefreshHours: Int {
         didSet {
             let normalized = AIHotRefreshPolicy.normalize(hours: aiNewsRefreshHours)
@@ -88,6 +91,7 @@ final class Prefs: ObservableObject {
         static let autoCleanEnabled = "autoCleanEnabled"
         static let launchAtLogin = "launchAtLogin"
         static let preventSleep = "preventSleep"
+        static let mcpEnabled = "mcpEnabled"
         static let preferencesInitialized = "preferencesInitialized"
         static let aiNewsRefreshHours = "aiNewsRefreshHours"
 
@@ -95,7 +99,8 @@ final class Prefs: ObservableObject {
             visibleProviders, enabledModules, language, menubarStyle,
             showRemaining, petId, focusMinutes, breakMinutes,
             allowBreakSkip, breakOverlayEnabled, visibleProvidersV2,
-            visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep, aiNewsRefreshHours
+            visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep,
+            aiNewsRefreshHours, mcpEnabled
         ]
     }
 
@@ -188,6 +193,9 @@ final class Prefs: ObservableObject {
         } else {
             preventSleep = false
         }
+        mcpEnabled = d.object(forKey: Key.mcpEnabled) == nil
+            ? false
+            : d.bool(forKey: Key.mcpEnabled)
         aiNewsRefreshHours = AIHotRefreshPolicy.normalize(hours: d.object(forKey: Key.aiNewsRefreshHours) == nil ? 5 : d.integer(forKey: Key.aiNewsRefreshHours))
         d.set(aiNewsRefreshHours, forKey: Key.aiNewsRefreshHours)
         d.set(true, forKey: Key.preferencesInitialized)

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -32,6 +32,7 @@ struct SettingsView: View {
     @ObservedObject var sleepController: SleepController
     @ObservedObject var petCatalog: PetCatalogStore
     @ObservedObject var fixedPlanStore: FixedPlanStore
+    @ObservedObject var mcpServer: KajiMCPServer
     var onFixedPlanEditorChange: ((Bool) -> Void)? = nil
 
     @State private var selectedScheduleID: UUID?
@@ -118,6 +119,42 @@ struct SettingsView: View {
                     }
                 }
             }
+            settingBlock(title: "Local MCP") {
+                VStack(alignment: .leading, spacing: 8) {
+                    settingRow(title: "AI access") {
+                        segment(L10n.t(.on, prefs.language), on: prefs.mcpEnabled) {
+                            prefs.mcpEnabled = true
+                        }
+                        segment(L10n.t(.off, prefs.language), on: !prefs.mcpEnabled) {
+                            prefs.mcpEnabled = false
+                        }
+                    }
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(mcpStatusColor)
+                            .frame(width: 6, height: 6)
+                        Text(mcpStatusText)
+                            .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                            .foregroundColor(t.mute)
+                            .lineLimit(1)
+                        Spacer()
+                        Button("Copy endpoint") {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(
+                                KajiMCPServer.endpoint,
+                                forType: .string
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.cream)
+                    }
+                    Text("Localhost only. While enabled, local AI tools can read and edit Goals.")
+                        .font(.system(size: 9.5, weight: .medium, design: .rounded))
+                        .foregroundColor(t.mute)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
             }
             if selection == .work {
                 settingBlock(title: L10n.t(.work, prefs.language)) {
@@ -173,6 +210,24 @@ struct SettingsView: View {
         .padding(24)
         .onAppear {
             refreshPetCatalogSelection()
+        }
+    }
+
+    private var mcpStatusText: String {
+        switch mcpServer.status {
+        case .stopped: "Stopped · \(KajiMCPServer.endpoint)"
+        case .starting: "Starting · \(KajiMCPServer.endpoint)"
+        case .running: "Running · \(KajiMCPServer.endpoint)"
+        case .failed(let message): "Failed · \(message)"
+        }
+    }
+
+    private var mcpStatusColor: Color {
+        switch mcpServer.status {
+        case .running: t.cream
+        case .failed: .red
+        case .starting: t.gold
+        case .stopped: t.mute
         }
     }
 

--- a/Tests/KajiTests/KajiMCPServerTests.swift
+++ b/Tests/KajiTests/KajiMCPServerTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import Kaji
+
+@MainActor
+final class KajiMCPServerTests: XCTestCase {
+    private var suiteName = ""
+    private var defaults: UserDefaults!
+    private var store: DailyGoalStore!
+    private var server: KajiMCPServer!
+    private var endpoint: URL!
+
+    override func setUp() async throws {
+        suiteName = "KajiMCPServerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        store = DailyGoalStore(defaults: defaults)
+        let port = UInt16.random(in: 40_000...60_000)
+        endpoint = URL(string: "http://127.0.0.1:\(port)/mcp")!
+        server = KajiMCPServer(goals: store, port: port)
+        server.start()
+        try await waitUntilRunning()
+    }
+
+    override func tearDown() async throws {
+        server.stop()
+        defaults.removePersistentDomain(forName: suiteName)
+        server = nil
+        store = nil
+        defaults = nil
+        endpoint = nil
+    }
+
+    func testProtocolAndGoalCRUDOverRealHTTP() async throws {
+        let initialized = try await rpc(method: "initialize", params: [
+            "protocolVersion": "2025-03-26"
+        ])
+        XCTAssertEqual(
+            (initialized["result"] as? [String: Any])?["protocolVersion"] as? String,
+            "2025-03-26"
+        )
+
+        let ping = try await rpc(method: "ping")
+        XCTAssertNotNil(ping["result"])
+
+        let listedTools = try await rpc(method: "tools/list")
+        let tools = (listedTools["result"] as? [String: Any])?["tools"] as? [[String: Any]]
+        XCTAssertEqual(Set(tools?.compactMap { $0["name"] as? String } ?? []), [
+            "kaji_goals_list", "kaji_goal_add", "kaji_goal_update",
+            "kaji_goal_complete", "kaji_goal_delete"
+        ])
+
+        let added = try await callTool("kaji_goal_add", arguments: [
+            "horizon": "today", "title": "Ship local MCP", "tag": "work",
+            "note": "Round-trip note"
+        ])
+        let goal = try XCTUnwrap(added["structuredContent"] as? [String: Any])
+        let id = try XCTUnwrap(goal["id"] as? String)
+        XCTAssertEqual(goal["note"] as? String, "Round-trip note")
+
+        let updated = try await callTool("kaji_goal_update", arguments: [
+            "horizon": "today", "id": id, "title": "Ship Kaji MCP",
+            "note": "Updated note"
+        ])
+        XCTAssertEqual(
+            (updated["structuredContent"] as? [String: Any])?["note"] as? String,
+            "Updated note"
+        )
+
+        let completed = try await callTool("kaji_goal_complete", arguments: [
+            "horizon": "today", "id": id, "isDone": true
+        ])
+        XCTAssertEqual(
+            (completed["structuredContent"] as? [String: Any])?["isDone"] as? Bool,
+            true
+        )
+
+        let reloaded = DailyGoalStore(defaults: defaults)
+        XCTAssertEqual(reloaded.goals.first?.id.uuidString.lowercased(), id)
+        XCTAssertEqual(reloaded.goals.first?.note, "Updated note")
+        XCTAssertEqual(reloaded.goals.first?.isDone, true)
+
+        let deleted = try await callTool("kaji_goal_delete", arguments: [
+            "horizon": "today", "id": id
+        ])
+        XCTAssertEqual(
+            (deleted["structuredContent"] as? [String: Any])?["deleted"] as? String,
+            id
+        )
+        XCTAssertTrue(store.goals.isEmpty)
+    }
+
+    func testInvalidArgumentsReturnStructuredToolErrors() async throws {
+        let invalidHorizon = try await callTool("kaji_goals_list", arguments: [
+            "horizon": "later"
+        ])
+        XCTAssertEqual(invalidHorizon["isError"] as? Bool, true)
+        let content = invalidHorizon["content"] as? [[String: Any]]
+        XCTAssertTrue((content?.first?["text"] as? String)?.contains("horizon") == true)
+
+        let missingID = try await callTool("kaji_goal_update", arguments: [
+            "horizon": "week", "id": UUID().uuidString, "note": "missing"
+        ])
+        XCTAssertEqual(missingID["isError"] as? Bool, true)
+        XCTAssertEqual(
+            (missingID["content"] as? [[String: Any]])?.first?["text"] as? String,
+            "Goal not found"
+        )
+    }
+
+    private func waitUntilRunning() async throws {
+        for _ in 0..<100 {
+            if server.status == .running { return }
+            if case .failed(let message) = server.status {
+                XCTFail("MCP listener failed: \(message)")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("MCP listener did not start")
+    }
+
+    private func callTool(_ name: String, arguments: [String: Any]) async throws -> [String: Any] {
+        let response = try await rpc(method: "tools/call", params: [
+            "name": name, "arguments": arguments
+        ])
+        return try XCTUnwrap(response["result"] as? [String: Any])
+    }
+
+    private func rpc(method: String, params: [String: Any]? = nil) async throws -> [String: Any] {
+        var payload: [String: Any] = [
+            "jsonrpc": "2.0", "id": UUID().uuidString, "method": method
+        ]
+        if let params { payload["params"] = params }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        return try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+    }
+}

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -37,6 +37,7 @@
 | **Approved** | [specs/2026-08-05-ai-news-module.md](specs/2026-08-05-ai-news-module.md) — AI HOT Top 10 第五模块 |
 | **Approved** | [specs/2026-08-05-ai-news-list-hover-polish.md](specs/2026-08-05-ai-news-list-hover-polish.md) — 一级信息减法 + 稳定 hover 切换 |
 | **Approved** | [specs/2026-08-05-settings-information-architecture-polish.md](specs/2026-08-05-settings-information-architecture-polish.md) — Quota / AI News 分栏；Goals 暂留空 |
+| **Approved** | [specs/2026-08-05-local-mcp.md](specs/2026-08-05-local-mcp.md) — v0.7 localhost MCP 读写 Goals |
 | Optional | [design/palette.html](design/palette.html) |
 
 ## Catalog
@@ -95,6 +96,7 @@
 | [specs/2026-08-05-ai-news-module.md](specs/2026-08-05-ai-news-module.md) | 已通过：AI HOT Top 10、5h 刷新与 hover digest |
 | [specs/2026-08-05-ai-news-list-hover-polish.md](specs/2026-08-05-ai-news-list-hover-polish.md) | 已通过：来源移入详情、相邻 hover 即时切换 |
 | [specs/2026-08-05-settings-information-architecture-polish.md](specs/2026-08-05-settings-information-architecture-polish.md) | 已通过：Quota / AI News 职责拆分，Goals 只保留设置入口 |
+| [specs/2026-08-05-local-mcp.md](specs/2026-08-05-local-mcp.md) | 已通过：不改 v0.7 Goals UI，仅增加 localhost MCP |
 | `plans/` | 可选；大任务 / 多 agent 零上下文时再用 |
 
 ### Assets

--- a/dev_docs/specs/2026-08-05-local-mcp.md
+++ b/dev_docs/specs/2026-08-05-local-mcp.md
@@ -1,0 +1,68 @@
+# Kaji v0.7 Local MCP
+
+Status: approved by user
+
+## Problem
+
+Kaji v0.7 has the intended Goals model and interaction: one first-level Goal,
+an optional multiline note, and a secondary note popover. The data is still
+available only through Kaji's UI and private `UserDefaults`, so agents must
+inspect source code or automate the menu-bar UI before reading or editing it.
+
+## Decision
+
+Add an opt-in local MCP server without changing the v0.7 Goals UI or model.
+
+- Settings → General exposes an `MCP` On / Off control.
+- Default Off.
+- When enabled, listen only on `127.0.0.1:37841`.
+- Endpoint: `http://127.0.0.1:37841/mcp`.
+- Reuse v0.7's existing `DailyGoalStore`, `GoalItem.note`, persistence, and
+  secondary note popover.
+- No Goal glyph, row, creation, Schedule, AI News, or popover changes.
+
+## Tools
+
+- `kaji_goals_list`: list one horizon or all horizons.
+- `kaji_goal_add`: add an incomplete Goal with optional `note`.
+- `kaji_goal_update`: update title, Tag, and/or note.
+- `kaji_goal_complete`: set completion explicitly.
+- `kaji_goal_delete`: delete by stable Goal ID.
+
+MCP horizons use `today`, `week`, and `vision`; `vision` maps to v0.7's
+existing `longTerm` storage.
+
+## Protocol
+
+Implement the JSON response path of MCP Streamable HTTP:
+
+- `initialize`
+- `notifications/initialized`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+One JSON-RPC request per HTTP POST is sufficient. SSE, remote sessions, OAuth,
+resources, prompts, and batch requests are out of scope.
+
+## Acceptance
+
+1. Branch is based directly on the released `v0.7.0` tag (`deb600e`).
+2. The diff does not change `KajiPopoverView` or Goal mark logic.
+3. MCP is disabled on fresh install and binds only to localhost when enabled.
+4. List/add/update/complete/delete operate on v0.7's live Goal store.
+5. Notes round-trip through MCP and remain visible in v0.7's existing detail
+   popover after restart.
+6. Invalid horizons, malformed arguments, and missing IDs return structured
+   errors without crashing Kaji.
+7. `swift test`, release build, bundle install, and real HTTP CRUD smoke pass.
+
+## Risk
+
+While enabled, any process running as the local user can access the endpoint.
+The Settings copy states this boundary. No remote interface is bound.
+
+## Rollback
+
+Turn MCP Off or reinstall the unchanged v0.7.0 release. Goal persistence keys
+and payload shape remain compatible with the release.


### PR DESCRIPTION
## Summary

- add an opt-in localhost-only MCP server at `127.0.0.1:37841/mcp`
- expose Goal list/add/update/complete/delete with note persistence
- add Settings lifecycle/status controls without changing the Goals or popover surfaces
- cover protocol, real HTTP CRUD, persistence, and structured errors

## Verification

- `swift test` (105 tests)
- `swift build -c release`
- `./scripts/build-app.sh`
- `codesign --verify --deep --strict --verbose=2 dist/Kaji.app`
- static diff: no `KajiPopoverView` or Goal graphics changes

Closes #33