### PR TITLE
修复目标标题两行显示

### DIFF
--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -946,18 +946,24 @@ struct KajiPopoverView: View {
             ForEach(Array(visions.enumerated()), id: \.element.id) { index, vision in
                 HStack(spacing: 7) {
                     goalTagMenu(vision, horizon: .longTerm)
-                    TextField("写下一条长期方向", text: Binding(
-                        get: { vision.title },
-                        set: { dailyGoals.updateTitle(vision, title: $0, in: .longTerm) }
-                    ), axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11, weight: .semibold, design: .rounded))
-                    .foregroundColor(t.cream)
-                    .lineLimit(1...2)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .focused($focusedGoalID, equals: vision.id)
-                    .onSubmit {
-                        dailyGoals.removeIfBlank(vision, in: .longTerm)
+                    if focusedGoalID == vision.id {
+                        TextField("写下一条长期方向", text: Binding(
+                            get: { vision.title },
+                            set: { dailyGoals.updateTitle(vision, title: $0, in: .longTerm) }
+                        ), axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.cream)
+                        .lineLimit(1...2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .focused($focusedGoalID, equals: vision.id)
+                        .onSubmit {
+                            dailyGoals.removeIfBlank(vision, in: .longTerm)
+                        }
+                    } else {
+                        goalTitleLabel(vision.title, size: 11) {
+                            focusedGoalID = vision.id
+                        }
                     }
                     HStack(spacing: 4) {
                         if !vision.note.isEmpty {
@@ -1213,18 +1219,24 @@ struct KajiPopoverView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                TextField("", text: Binding(
-                    get: { goal.title },
-                    set: { dailyGoals.updateTitle(goal, title: $0, in: horizon) }
-                ), axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
-                .foregroundColor(t.cream)
-                .lineLimit(1...2)
-                .fixedSize(horizontal: false, vertical: true)
-                .focused($focusedGoalID, equals: goal.id)
-                .onSubmit {
-                    dailyGoals.removeIfBlank(goal, in: horizon)
+                if focusedGoalID == goal.id {
+                    TextField("", text: Binding(
+                        get: { goal.title },
+                        set: { dailyGoals.updateTitle(goal, title: $0, in: horizon) }
+                    ), axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.cream)
+                    .lineLimit(1...2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .focused($focusedGoalID, equals: goal.id)
+                    .onSubmit {
+                        dailyGoals.removeIfBlank(goal, in: horizon)
+                    }
+                } else {
+                    goalTitleLabel(goal.title, size: 11.5) {
+                        focusedGoalID = goal.id
+                    }
                 }
             }
             HStack(spacing: 4) {
@@ -1259,6 +1271,21 @@ struct KajiPopoverView: View {
             goalNoteEditor(goal, horizon: horizon)
                 .onHover { updateGoalNoteHover(goal, inside: $0) }
         }
+    }
+
+    private func goalTitleLabel(
+        _ title: String,
+        size: CGFloat,
+        onEdit: @escaping () -> Void
+    ) -> some View {
+        Text(title.isEmpty ? " " : title)
+            .font(.system(size: size, weight: .semibold, design: .rounded))
+            .foregroundColor(t.cream)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: onEdit)
     }
 
     private func goalNoteEditor(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -38,6 +38,7 @@
 | **Approved** | [specs/2026-08-05-ai-news-list-hover-polish.md](specs/2026-08-05-ai-news-list-hover-polish.md) — 一级信息减法 + 稳定 hover 切换 |
 | **Approved** | [specs/2026-08-05-settings-information-architecture-polish.md](specs/2026-08-05-settings-information-architecture-polish.md) — Quota / AI News 分栏；Goals 暂留空 |
 | **Approved** | [specs/2026-08-05-local-mcp.md](specs/2026-08-05-local-mcp.md) — v0.7 localhost MCP 读写 Goals |
+| **Approved** | [specs/2026-08-08-goal-title-two-line-layout.md](specs/2026-08-08-goal-title-two-line-layout.md) — Goal 标题未点击时也显示最多两行 |
 | Optional | [design/palette.html](design/palette.html) |
 
 ## Catalog
@@ -97,6 +98,7 @@
 | [specs/2026-08-05-ai-news-list-hover-polish.md](specs/2026-08-05-ai-news-list-hover-polish.md) | 已通过：来源移入详情、相邻 hover 即时切换 |
 | [specs/2026-08-05-settings-information-architecture-polish.md](specs/2026-08-05-settings-information-architecture-polish.md) | 已通过：Quota / AI News 职责拆分，Goals 只保留设置入口 |
 | [specs/2026-08-05-local-mcp.md](specs/2026-08-05-local-mcp.md) | 已通过：不改 v0.7 Goals UI，仅增加 localhost MCP |
+| [specs/2026-08-08-goal-title-two-line-layout.md](specs/2026-08-08-goal-title-two-line-layout.md) | 已通过：Goal 标题未点击时也显示最多两行 |
 | `plans/` | 可选；大任务 / 多 agent 零上下文时再用 |
 
 ### Assets

--- a/dev_docs/specs/2026-08-08-goal-title-two-line-layout.md
+++ b/dev_docs/specs/2026-08-08-goal-title-two-line-layout.md
@@ -1,0 +1,43 @@
+# Change Note: Goal 标题两行静态展开
+
+Status: approved
+
+## 类型
+
+Primary: bug fix  
+Secondary: UX polish  
+Upstream: [2026-08-01-goals-surface-v2.md](./2026-08-01-goals-surface-v2.md)
+
+## Goal
+
+让 Today、Week 与 Vision 的两行 Goal 标题在未点击编辑时也立即完整显示，不再等获得焦点后才展开。
+
+## In / Non-goals
+
+覆盖未完成 Goal 与 Vision 的可编辑标题，最多显示两行；保留单行紧凑高度与现有编辑、完成、删除行为。不增加第三行，不改字体、按钮、数据或迁移。
+
+## Behavior + decisions
+
+- 自然折行或显式换行需要两行时，未聚焦状态即按两行布局。
+- 聚焦与失焦不改变标题行数或造成高度跳变。
+- 超过两行仍截断，Today、Week、Vision 使用同一规则。
+
+## Acceptance
+
+| Case | Given | Expected | Verify |
+| --- | --- | --- | --- |
+| T1 | Today / Week 两行标题未聚焦 | 两行立即可见 | 人工 smoke |
+| T2 | Vision 两行标题未聚焦 | 两行立即可见 | 人工 smoke |
+| T3 | 两行标题聚焦再失焦 | 行高稳定 | 人工 smoke |
+| T4 | 单行与超过两行标题 | 单行紧凑；最多两行；按钮不挤出 | 人工 smoke |
+| T5 | 项目构建与模型测试 | 无回归 | 自动：`swift test`、release build |
+
+## Done + rollback
+
+`swift test` 与 release build 通过；Light / Dark 人工抽查 Today、Week、Vision。回滚仅撤销布局测量，不涉及数据。
+
+## 批准前必读
+
+- **最多两行。** 更长标题仍截断，以保持页面紧凑。
+- **覆盖 Today、Week、Vision。** 三处必须一致。
+- **主要风险是行高抖动。** 必须人工检查未聚焦、聚焦、失焦。


### PR DESCRIPTION
修复未聚焦的 Goal 与 Vision 标题只绘制第一行的问题。静止状态使用两行 Text，点击后切换为 TextField 编辑；补充分类为 bug fix / UX polish 的 Change Note。验证：swift test 105/105、release build、codesign、人工 smoke。