### PR TITLE
Make popover behavior testable and reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'Package.swift'
       - 'Sources/**'
+      - 'Tests/**'
       - 'Resources/**'
       - 'scripts/**'
       - 'Info.plist'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'Package.swift'
       - 'Sources/**'
+      - 'Tests/**'
       - 'Resources/**'
       - 'scripts/**'
       - 'Info.plist'
@@ -32,6 +34,12 @@ jobs:
       # Catches regressions on every push/PR.
       - name: swift build
         run: swift build
+
+      # Unit + in-process UI tests (see Tests/KajiTests/UITestHarness.swift).
+      # These boot the real AppDelegate/status-item/popover object graph
+      # and invoke the real click-handler closure — no self-skipping.
+      - name: swift test
+        run: swift test
 
       - name: Assemble app bundle
         run: ./scripts/build-app.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ swift test
 ./scripts/build-local.sh
 ```
 
+### UI tests
+
+Two layers, split by what each can actually prove:
+
+- **In-process** — `Tests/KajiTests/PopoverInteractionTests.swift` + `PopoverRenderTests.swift`, run by plain `swift test` (no XCUITest target; SwiftPM can't host one — see `Tests/KajiTests/UITestHarness.swift`). These boot the real `AppDelegate`/status-item/popover object graph in-process and invoke the real click-handler closure `setupStatusItem()` wires up, so a regression in that wiring, or in `showPopover`'s state/content, fails for real. They do **not** cover real OS-level click delivery — a synthetic click reliably does not reach a SwiftUI `Button`'s gesture recognizer from inside a bare `xctest` process, and some activation-state-dependent bugs (e.g. a window that hides itself because clicking the status item never activates an `LSUIElement` app) only manifest with a real OS click against a real, launched, frontmost `.app` — this layer cannot see those. `PopoverRenderTests` writes one PNG per module page to `.build/ui-snapshots/` for visual inspection.
+- **Real click, real .app** — `scripts/ui-smoke.sh` launches the actual signed `Kaji.app`, posts a genuine `CGEvent` click at the status item, and asserts on `CGWindowList`. This is the only layer that proves a real click actually opens the popover on screen.
+
 ## Links
 
 - [Latest release](https://github.com/blackblue-labs/kaji/releases/latest)

--- a/Sources/Kaji/AIHotNewsStore.swift
+++ b/Sources/Kaji/AIHotNewsStore.swift
@@ -28,6 +28,14 @@ final class AIHotNewsStore: ObservableObject {
         self.cacheURL = cacheURL ?? Self.defaultCacheURL()
     }
 
+    init(previewTopics: [AIHotTopic], cacheURL: URL) {
+        self.client = AIHotAPIClient()
+        self.cacheURL = cacheURL
+        self.topics = previewTopics
+        self.state = previewTopics.isEmpty ? .empty : .ready
+        self.lastSuccessfulRefresh = Date(timeIntervalSince1970: 1_700_000_000)
+    }
+
     func setEnabled(_ enabled: Bool, refreshHours: Int) {
         self.refreshHours = AIHotRefreshPolicy.normalize(hours: refreshHours)
         guard enabled else { stop(); return }

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -16,31 +16,55 @@ import KajiCore
 // concurrency-clean under stricter checking.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    private let store = QuotaStore()
-    private let prefs = Prefs()
-    private var statusItem: NSStatusItem!
-    private var popoverWindow: NSPanel!
+    private let store: QuotaStore
+    private let prefs: Prefs
+    var statusItem: NSStatusItem!
+    var popover: NSPopover!
     private var popoverHostingController: NSHostingController<AnyView>?
+    var detailPopover: NSPopover?
     private var settingsWindow: NSWindow?
-    private var hostingView: KajiHostingView<StatusItemView>!
+    var hostingView: KajiHostingView<StatusItemView>!
     private let updateChecker = UpdateChecker()
     private let sleepController = SleepController()
     private lazy var workSession = WorkSessionController(prefs: prefs)
     private let systemMonitor = SystemMonitor()
-    private let dailyGoals = DailyGoalStore()
+    let dailyGoals: DailyGoalStore
     private lazy var mcpServer = KajiMCPServer(
         goals: dailyGoals,
         snapshotProvider: { [weak self] in self?.mcpSnapshot() ?? [:] }
     )
-    private let fixedPlanStore = FixedPlanStore()
-    private let popoverNavigation = PopoverNavigation()
-    private let aiNewsStore = AIHotNewsStore()
-    private let mailBriefStore = MailBriefStore()
+    let fixedPlanStore: FixedPlanStore
+    let popoverNavigation = PopoverNavigation()
+    private let aiNewsStore: AIHotNewsStore
+    private let mailBriefStore: MailBriefStore
     private var breakWindows: [NSWindow] = []
     private var breakWatchdogTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
 
+    override convenience init() {
+        self.init(defaults: .standard)
+    }
+
+    init(defaults: UserDefaults, cacheDirectory: URL? = nil, store: QuotaStore? = nil) {
+        self.store = store ?? QuotaStore()
+        prefs = Prefs(defaults: defaults)
+        dailyGoals = DailyGoalStore(defaults: defaults)
+        fixedPlanStore = FixedPlanStore(defaults: defaults)
+        aiNewsStore = AIHotNewsStore(
+            cacheURL: cacheDirectory?.appendingPathComponent("ai-news-cache-v1.json")
+        )
+        mailBriefStore = MailBriefStore(
+            cacheURL: cacheDirectory?.appendingPathComponent("mail-brief-cache-v1.json")
+        )
+        super.init()
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Establish the visible app surface before any optional module can probe
+        // credentials. A stale keychain ACL must never prevent the status item.
+        setupStatusItem()
+        setupPopover()
+
         sleepController.onStateChanged = { [weak self] enabled in
             self?.prefs.preventSleep = enabled
         }
@@ -48,9 +72,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         store.start()
         applyModuleLifecycle(prefs.enabledModules)
         mcpServer.setEnabled(prefs.mcpEnabled)
-
-        setupStatusItem()
-        setupPopover()
 
         // Re-render the menubar indicator whenever data OR the visible-provider /
         // menubar-style prefs change.
@@ -209,6 +230,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        closeDetailPopover()
         store.stop()
         breakWatchdogTimer?.invalidate()
         closeBreakOverlay()
@@ -322,29 +344,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Popover
 
     private func setupPopover() {
-        let panel = NSPanel(
-            contentRect: .zero,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
-        )
-        panel.isReleasedWhenClosed = false
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = true
-        panel.level = .popUpMenu
-        panel.hidesOnDeactivate = true
-        panel.collectionBehavior = [.transient, .moveToActiveSpace]
-        panel.delegate = self
-        popoverWindow = panel
+        let pop = NSPopover()
+        // The child is anchored to a view inside this popover, so AppKit
+        // treats it as a nested popover without dismissing this transient
+        // parent. Keeping transient preserves click-outside dismissal when
+        // the user switches to another app or the desktop.
+        pop.behavior = .transient
+        pop.animates = true
+        pop.delegate = self
+        popover = pop
     }
 
-    private func showPopover(_ destination: MenuBarDestination) {
+    func showPopover(_ destination: MenuBarDestination) {
         guard let sender = statusItem.button else { return }
         dailyGoals.refreshPeriodBoundaries()
-        if popoverWindow.isVisible {
+        if popover.isShown {
             if destinationMatchesCurrentPanel(destination) {
-                popoverWindow.orderOut(sender)
+                closeDetailPopover()
+                popover.performClose(sender)
                 return
             }
             applyPopoverDestination(destination)
@@ -358,23 +375,55 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         applyPopoverDestination(stagingDestination)
         let requestedDestination = destination
 
-        // Rebuild content each open. A borderless panel avoids NSPopover's
-        // directional arrow while retaining the same compact SwiftUI surface.
+        // Rebuild content each open. Width uses the single standard panel size.
+        // so the popover follows S/M; height auto-fits since the popover
+        // also shows the settings footer (which the HUD doesn't).
         let controller = makePopoverContentController(maxContentHeight: maxPopoverHeight(on: sender.window?.screen))
         popoverHostingController = controller
         let target = popoverFittingSize(for: controller)
         controller.preferredContentSize = target
         controller.view.frame = NSRect(origin: .zero, size: target)
         controller.view.layoutSubtreeIfNeeded()
-        popoverWindow.contentViewController = controller
-        positionPopoverWindow(size: target, relativeTo: sender)
-        popoverWindow.makeKeyAndOrderFront(sender)
+        popover.contentSize = target
+        popover.contentViewController = controller
+        popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        popover.contentViewController?.view.window?.makeKey()
 
         if requestedDestination != stagingDestination {
             DispatchQueue.main.async { [weak self] in
                 self?.applyPopoverDestination(requestedDestination)
             }
         }
+    }
+
+    func showDetailPopover(_ content: AnyView, relativeTo sourceView: NSView) {
+        closeDetailPopover()
+
+        let controller = NSHostingController(rootView: content)
+        let fittingSize = controller.view.fittingSize
+        controller.preferredContentSize = fittingSize
+
+        let child = NSPopover()
+        child.behavior = .transient
+        child.delegate = self
+        child.animates = true
+        child.contentViewController = controller
+        child.contentSize = fittingSize
+        detailPopover = child
+
+        let sourceMidX = sourceView.window?.frame.midX ?? 0
+        let screenMidX = sourceView.window?.screen?.visibleFrame.midX ?? 0
+        child.show(
+            relativeTo: sourceView.bounds,
+            of: sourceView,
+            preferredEdge: sourceMidX < screenMidX ? .maxX : .minX
+        )
+    }
+
+    func closeDetailPopover() {
+        detailPopover?.animates = false
+        detailPopover?.performClose(nil)
+        detailPopover = nil
     }
 
     private func popoverStagingDestination(for destination: MenuBarDestination) -> MenuBarDestination {
@@ -430,7 +479,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func makePopoverContentController(maxContentHeight: CGFloat? = nil) -> NSHostingController<AnyView> {
         let controls = KajiPopoverControls(
             onOpenSettings: { [weak self] in self?.openSettings() },
-            onQuit: { NSApp.terminate(nil) }
+            onQuit: { NSApp.terminate(nil) },
+            onShowDetail: { [weak self] sourceView, content in
+                self?.showDetailPopover(content, relativeTo: sourceView)
+            },
+            onDismissDetail: { [weak self] in self?.closeDetailPopover() }
         )
         let content = KajiPopoverView(store: store,
                                       prefs: prefs,
@@ -464,55 +517,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func resizePopoverContent(to measuredSize: CGSize) {
-        guard popoverWindow.isVisible else { return }
+        guard popover != nil, popover.isShown else { return }
         let width = PanelSize.medium.frameSize.width
-        let maxHeight = maxPopoverHeight(on: popoverWindow.screen ?? statusItem.button?.window?.screen)
+        let maxHeight = maxPopoverHeight(on: popover.contentViewController?.view.window?.screen ?? statusItem.button?.window?.screen)
         let target = CGSize(width: width, height: ceil(min(max(1, measuredSize.height), maxHeight)))
-        let needsResize = abs(popoverWindow.frame.height - target.height) > 0.5 ||
-            abs(popoverWindow.frame.width - target.width) > 0.5
+        let needsPopoverResize = abs(popover.contentSize.height - target.height) > 0.5 ||
+            abs(popover.contentSize.width - target.width) > 0.5
         popoverHostingController?.preferredContentSize = target
         popoverHostingController?.view.frame = NSRect(origin: .zero, size: target)
         popoverHostingController?.view.layoutSubtreeIfNeeded()
-        if needsResize, let sender = statusItem.button {
-            positionPopoverWindow(size: target, relativeTo: sender)
+        if needsPopoverResize {
+            popover.contentSize = target
         }
-    }
-
-    private func positionPopoverWindow(size: CGSize, relativeTo sender: NSStatusBarButton) {
-        guard let anchorWindow = sender.window else { return }
-        let anchor = anchorWindow.convertToScreen(sender.convert(sender.bounds, to: nil))
-        let visibleFrame = (anchorWindow.screen ?? NSScreen.main)?.visibleFrame
-            ?? NSRect(x: 0, y: 0, width: size.width, height: size.height)
-        let inset: CGFloat = 8
-        let gap: CGFloat = 6
-        let x = min(
-            max(anchor.midX - size.width / 2, visibleFrame.minX + inset),
-            visibleFrame.maxX - size.width - inset
-        )
-        let y = max(visibleFrame.minY + inset, anchor.minY - size.height - gap)
-        popoverWindow.setFrame(NSRect(origin: CGPoint(x: x, y: y), size: size), display: true)
     }
 
     private func maxPopoverHeight(on screen: NSScreen?) -> CGFloat {
         let visibleHeight = (screen ?? NSScreen.main)?.visibleFrame.height ?? 760
-        return max(240, visibleHeight - 24)
+        // Leave room for NSPopover's arrow, border and AppKit's placement inset.
+        // Filling the entire visible frame makes the chrome cross the screen edge,
+        // where macOS clips it into a false top padding strip.
+        return max(240, visibleHeight - 64)
     }
 
     /// Rebuild only when layout dimensions change. Normal ObservableObject
     /// updates flow through SwiftUI; rebuilding for every busy/running tick
     /// makes the transient popover visibly jump.
     private func rebuildPopoverContentIfShown() {
-        guard popoverWindow.isVisible else { return }
-        let controller = makePopoverContentController(maxContentHeight: maxPopoverHeight(on: popoverWindow.screen ?? statusItem.button?.window?.screen))
+        guard popover != nil, popover.isShown else { return }
+        let controller = makePopoverContentController(maxContentHeight: maxPopoverHeight(on: popover.contentViewController?.view.window?.screen ?? statusItem.button?.window?.screen))
         popoverHostingController = controller
         let target = popoverFittingSize(for: controller)
         controller.preferredContentSize = target
         controller.view.frame = NSRect(origin: .zero, size: target)
         controller.view.layoutSubtreeIfNeeded()
-        popoverWindow.contentViewController = controller
-        if let sender = statusItem.button {
-            positionPopoverWindow(size: target, relativeTo: sender)
-        }
+        popover.contentSize = target
+        popover.contentViewController = controller
     }
 
     private func handleUpdateAction() {
@@ -763,5 +802,15 @@ extension AppDelegate: NSWindowDelegate {
         guard let window = notification.object as? NSWindow,
               window === settingsWindow else { return }
         settingsWindow = nil
+    }
+}
+extension AppDelegate: NSPopoverDelegate {
+    func popoverWillClose(_ notification: Notification) {
+        guard let closingPopover = notification.object as? NSPopover else { return }
+        if closingPopover === detailPopover {
+            detailPopover = nil
+        } else if closingPopover === popover {
+            closeDetailPopover()
+        }
     }
 }

--- a/Sources/Kaji/DailyGoalStore.swift
+++ b/Sources/Kaji/DailyGoalStore.swift
@@ -131,7 +131,13 @@ final class DailyGoalStore: ObservableObject {
     func addGoal(in horizon: GoalHorizon = .today) -> UUID {
         let id = UUID()
         mutate(horizon) { goals in
-            goals.append(DailyGoal(id: id, title: "", isDone: false, tag: GoalTag.personal.rawValue))
+            goals.append(DailyGoal(
+                id: id,
+                title: "",
+                isDone: false,
+                tag: GoalTag.personal.rawValue,
+                createdAt: now()
+            ))
         }
         return id
     }
@@ -160,7 +166,8 @@ final class DailyGoalStore: ObservableObject {
             title: normalizedTitle,
             isDone: false,
             tag: normalizedTag.isEmpty ? GoalTag.personal.rawValue : normalizedTag,
-            note: note
+            note: note,
+            createdAt: now()
         )
         mutate(horizon) { $0.append(goal) }
         return goal
@@ -240,7 +247,8 @@ final class DailyGoalStore: ObservableObject {
             title: moved.title,
             isDone: false,
             tag: moved.tag,
-            note: moved.note
+            note: moved.note,
+            createdAt: moved.createdAt
         ))
         state = next
         recordToday()

--- a/Sources/Kaji/DetailPopoverButton.swift
+++ b/Sources/Kaji/DetailPopoverButton.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SwiftUI
+
+/// An AppKit-backed detail affordance whose source view is also the exact
+/// anchor rect used by the secondary `NSPopover`.
+struct DetailPopoverButton: NSViewRepresentable {
+    let accessibilityIdentifier: String
+    let help: String
+    let present: (NSView) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(present: present)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.bezelStyle = .inline
+        button.isBordered = false
+        button.image = NSImage(systemSymbolName: "text.alignleft", accessibilityDescription: help)
+        button.imagePosition = .imageOnly
+        button.toolTip = help
+        button.setAccessibilityIdentifier(accessibilityIdentifier)
+        button.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.activate(_:))
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.present = present
+        button.toolTip = help
+    }
+
+    final class Coordinator: NSObject {
+        var present: (NSView) -> Void
+
+        init(present: @escaping (NSView) -> Void) {
+            self.present = present
+        }
+
+        @objc func activate(_ sender: NSButton) {
+            present(sender)
+        }
+    }
+}

--- a/Sources/Kaji/FixedPlanStore.swift
+++ b/Sources/Kaji/FixedPlanStore.swift
@@ -10,9 +10,10 @@ final class FixedPlanStore: ObservableObject {
     private let defaults: UserDefaults
     private let calendar: Calendar
     private let now: () -> Date
+    nonisolated static let schedulesPersistenceKey = "scheduledGoalsV1"
 
     private enum Key {
-        static let schedules = "scheduledGoalsV1"
+        static let schedules = schedulesPersistenceKey
         static let completion = "scheduledGoalCompletionV1"
         static let migration = "scheduledGoalsMigrationV1"
         static let legacyPlans = "fixedPlansV1"

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -11,6 +11,20 @@ final class PopoverNavigation: ObservableObject {
 struct KajiPopoverControls {
     let onOpenSettings: () -> Void
     let onQuit: () -> Void
+    let onShowDetail: (NSView, AnyView) -> Void
+    let onDismissDetail: () -> Void
+
+    init(
+        onOpenSettings: @escaping () -> Void,
+        onQuit: @escaping () -> Void,
+        onShowDetail: @escaping (NSView, AnyView) -> Void = { _, _ in },
+        onDismissDetail: @escaping () -> Void = {}
+    ) {
+        self.onOpenSettings = onOpenSettings
+        self.onQuit = onQuit
+        self.onShowDetail = onShowDetail
+        self.onDismissDetail = onDismissDetail
+    }
 }
 
 private struct PopoverContentSizeKey: PreferenceKey {
@@ -44,8 +58,6 @@ struct KajiPopoverView: View {
     @State private var hoveredGoalDay: DailyGoalHistoryDay?
     @State private var previousFocusedGoalID: UUID?
     @State private var previousFocusedGoalHorizon: GoalHorizon = .today
-    @State private var shownScheduleDetailsID: UUID?
-    @State private var fixedPlanHoverGeneration = 0
     @FocusState private var focusedGoalID: UUID?
     @State private var showCleanConfirmation = false
     @State private var showsGoalCreator = false
@@ -53,12 +65,8 @@ struct KajiPopoverView: View {
     @State private var goalCreationTagName = GoalTag.personal.rawValue
     @State private var goalCreationTagColor: UInt32 = 0x8E6AD8
     @State private var goalCreationNote = ""
-    @State private var shownGoalNoteID: UUID?
-    @State private var goalNoteHoverGeneration = 0
     @State private var hoveredNewsID: String?
     @State private var newsHoverGeneration = 0
-    @State private var hoveredMailID: String?
-    @State private var mailHoverGeneration = 0
     @Environment(\.colorScheme) private var scheme
 
     private var t: KajiTheme { .resolve(scheme) }
@@ -90,7 +98,7 @@ struct KajiPopoverView: View {
             clampPanelToEnabledPages()
         }
         .onChange(of: panel) { _ in
-            shownScheduleDetailsID = nil
+            controls.onDismissDetail()
         }
         .onChange(of: focusedGoalID) { newValue in
             if let previousFocusedGoalID,
@@ -283,37 +291,17 @@ struct KajiPopoverView: View {
                 .foregroundColor(t.cream)
                 .lineLimit(2)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Image(systemName: "chevron.right")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundColor(t.ash)
+            DetailPopoverButton(
+                accessibilityIdentifier: "mail-detail-\(entry.threadID)",
+                help: "查看详情"
+            ) { sourceView in
+                controls.onShowDetail(sourceView, AnyView(mailBriefDetail(entry)))
+            }
+            .frame(width: 18, height: 18)
         }
         .padding(.vertical, 6)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            mailHoverGeneration += 1
-            hoveredMailID = entry.threadID
-        }
-        .onHover { inside in updateMailHover(entry, inside: inside) }
         .overlay(alignment: .bottom) {
             Rectangle().fill(t.track.opacity(0.55)).frame(height: 0.5)
-        }
-        .popover(
-            isPresented: Binding(
-                get: { hoveredMailID == entry.threadID },
-                set: {
-                    if !$0 {
-                        mailHoverGeneration += 1
-                        hoveredMailID = HoverSelectionPolicy.dismissed(
-                            current: hoveredMailID,
-                            dismissing: entry.threadID
-                        )
-                    }
-                }
-            ),
-            arrowEdge: .trailing
-        ) {
-            mailBriefDetail(entry)
-                .onHover { updateMailDetailHover(entry, inside: $0) }
         }
         .contextMenu {
             if let url = entry.gmailURL { Button("在 Gmail 打开") { NSWorkspace.shared.open(url) } }
@@ -387,7 +375,7 @@ struct KajiPopoverView: View {
             HStack(spacing: 9) {
                 Button("完成并归档") {
                     mailBriefStore.archive(entry)
-                    hoveredMailID = nil
+                    controls.onDismissDetail()
                 }
                 .buttonStyle(.borderedProminent)
                 if let url = entry.gmailURL {
@@ -404,7 +392,7 @@ struct KajiPopoverView: View {
                 .disabled(mailBriefStore.isConverted(entry))
                 mailDetailAction("trash", help: "移到垃圾箱") {
                     mailBriefStore.trash(entry)
-                    hoveredMailID = nil
+                    controls.onDismissDetail()
                 }
             }
         }
@@ -436,38 +424,6 @@ struct KajiPopoverView: View {
         }
     }
 
-    private func updateMailHover(_ entry: MailBriefEntry, inside: Bool) {
-        mailHoverGeneration += 1
-        let generation = mailHoverGeneration
-        if inside {
-            if hoveredMailID != nil {
-                hoveredMailID = entry.threadID
-            } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    guard generation == mailHoverGeneration else { return }
-                    hoveredMailID = entry.threadID
-                }
-            }
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + HoverDisclosurePolicy.closeDelay) {
-            guard generation == mailHoverGeneration, hoveredMailID == entry.threadID else { return }
-            hoveredMailID = nil
-        }
-    }
-
-    private func updateMailDetailHover(_ entry: MailBriefEntry, inside: Bool) {
-        mailHoverGeneration += 1
-        guard !inside else { return }
-        let generation = mailHoverGeneration
-        DispatchQueue.main.asyncAfter(deadline: .now() + HoverDisclosurePolicy.closeDelay) {
-            guard generation == mailHoverGeneration else { return }
-            hoveredMailID = HoverSelectionPolicy.dismissed(
-                current: hoveredMailID,
-                dismissing: entry.threadID
-            )
-        }
-    }
 
 
     private func aiNewsRow(_ topic: AIHotTopic) -> some View {
@@ -562,7 +518,7 @@ struct KajiPopoverView: View {
     private func scheduleGoalRow(_ schedule: ScheduledGoal) -> some View {
         let completed = fixedPlanStore.isCompleted(schedule)
         let tag = dailyGoals.tagDefinition(for: schedule.tag)
-        return VStack(alignment: .leading, spacing: 0) {
+        return HStack(spacing: 8) {
             Button {
                 fixedPlanStore.toggleCompletion(schedule)
             } label: {
@@ -584,21 +540,21 @@ struct KajiPopoverView: View {
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(8)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            if shownScheduleDetailsID == schedule.id, !schedule.note.isEmpty {
-                Text(schedule.note)
-                    .font(.system(size: 9.5, weight: .medium, design: .rounded))
-                    .foregroundColor(t.mute)
-                    .padding(.horizontal, 32)
-                    .padding(.bottom, 8)
-                    .transition(.opacity)
+            if !schedule.note.isEmpty {
+                DetailPopoverButton(
+                    accessibilityIdentifier: "schedule-detail-\(schedule.id)",
+                    help: "查看详情"
+                ) { sourceView in
+                    controls.onShowDetail(sourceView, AnyView(scheduleDetails(schedule)))
+                }
+                .frame(width: 18, height: 18)
             }
         }
+        .padding(8)
         .background(goalRowSurface(opacity: 0.92))
-        .onHover { inside in updateScheduleHover(schedule, inside: inside) }
     }
 
     private func scheduleDetails(_ schedule: ScheduledGoal) -> some View {
@@ -617,19 +573,6 @@ struct KajiPopoverView: View {
         .background(background)
     }
 
-    private func updateScheduleHover(_ schedule: ScheduledGoal, inside: Bool) {
-        guard !schedule.note.isEmpty else { return }
-        fixedPlanHoverGeneration += 1
-        let generation = fixedPlanHoverGeneration
-        if inside {
-            shownScheduleDetailsID = schedule.id
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
-            guard generation == fixedPlanHoverGeneration else { return }
-            shownScheduleDetailsID = nil
-        }
-    }
 
     private var quotaPanel: some View {
         VStack(alignment: .leading, spacing: 9) {
@@ -1225,15 +1168,16 @@ struct KajiPopoverView: View {
                     }
                     HStack(spacing: 4) {
                         if !vision.note.isEmpty {
-                            Button {
-                                shownGoalNoteID = vision.id
-                            } label: {
-                                Image(systemName: "text.alignleft")
-                                    .font(.system(size: 9, weight: .semibold))
+                            DetailPopoverButton(
+                                accessibilityIdentifier: "goal-detail-\(vision.id)",
+                                help: "查看详情"
+                            ) { sourceView in
+                                controls.onShowDetail(
+                                    sourceView,
+                                    goalDetailContent(vision, horizon: .longTerm)
+                                )
                             }
-                            .buttonStyle(.plain)
-                            .foregroundColor(t.mute)
-                            .onHover { updateGoalNoteHover(vision, inside: $0) }
+                            .frame(width: 18, height: 18)
                         }
                         if index > 0 {
                             miniButton("chevron.up") {
@@ -1253,18 +1197,6 @@ struct KajiPopoverView: View {
                 }
                 .padding(8)
                 .background(goalRowSurface(opacity: 0.82))
-                .contextMenu {
-                    Button(vision.note.isEmpty ? "添加说明" : "编辑说明") {
-                        shownGoalNoteID = vision.id
-                    }
-                }
-                .popover(isPresented: Binding(
-                    get: { shownGoalNoteID == vision.id },
-                    set: { if !$0 { shownGoalNoteID = nil } }
-                ), arrowEdge: .trailing) {
-                    goalNoteEditor(vision, horizon: .longTerm)
-                        .onHover { updateGoalNoteHover(vision, inside: $0) }
-                }
             }
         }
     }
@@ -1321,6 +1253,30 @@ struct KajiPopoverView: View {
                     .foregroundColor(t.mute)
                     .monospacedDigit()
                 Spacer()
+                Menu {
+                    Section(L10n.t(.goalGroup, prefs.language).uppercased()) {
+                        ForEach(GoalGrouping.allCases, id: \.rawValue) { grouping in
+                            Button {
+                                prefs.goalGrouping = grouping
+                            } label: {
+                                HStack {
+                                    Text(goalGroupingTitle(grouping))
+                                    if prefs.goalGrouping == grouping {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "list.bullet")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(t.mute)
+                        .frame(width: 26, height: 26)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .help(L10n.t(.goalGroup, prefs.language))
                 if horizon == .today {
                     Button {
                         beginGoalCreation()
@@ -1352,8 +1308,24 @@ struct KajiPopoverView: View {
                     scheduleGoalRow(schedule)
                 }
             }
-            ForEach(goals) { goal in
-                goalRow(goal, horizon: horizon)
+            ForEach(
+                GoalGroupingLogic.group(
+                    goals,
+                    by: prefs.goalGrouping,
+                    tagOrder: dailyGoals.tagDefinitions.map(\.name),
+                    language: prefs.language
+                ),
+                id: \.title
+            ) { group in
+                if !group.title.isEmpty {
+                    Text(group.title)
+                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
+                        .foregroundColor(t.mute)
+                        .padding(.top, 3)
+                }
+                ForEach(group.goals) { goal in
+                    goalRow(goal, horizon: horizon)
+                }
             }
             if goals.isEmpty && schedules.isEmpty {
                 Text("暂无目标")
@@ -1363,6 +1335,14 @@ struct KajiPopoverView: View {
             }
         }
     }
+    private func goalGroupingTitle(_ grouping: GoalGrouping) -> String {
+        switch grouping {
+        case .none: L10n.t(.goalGroupingNone, prefs.language)
+        case .byTag: L10n.t(.goalGroupingByTag, prefs.language)
+        case .byCreatedTime: L10n.t(.goalGroupingByCreatedTime, prefs.language)
+        }
+    }
+
 
     private var goalCreationCard: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -1467,15 +1447,16 @@ struct KajiPopoverView: View {
             .accessibilityLabel(goal.isDone ? "撤回完成" : "完成")
             HStack(spacing: 4) {
                 if !goal.note.isEmpty {
-                    Button {
-                        shownGoalNoteID = goal.id
-                    } label: {
-                        Image(systemName: "text.alignleft")
-                            .font(.system(size: 9, weight: .semibold))
+                    DetailPopoverButton(
+                        accessibilityIdentifier: "goal-detail-\(goal.id)",
+                        help: "查看详情"
+                    ) { sourceView in
+                        controls.onShowDetail(
+                            sourceView,
+                            goalDetailContent(goal, horizon: horizon)
+                        )
                     }
-                    .buttonStyle(.plain)
-                    .foregroundColor(t.mute)
-                    .onHover { updateGoalNoteHover(goal, inside: $0) }
+                    .frame(width: 18, height: 18)
                 }
                 miniButton("trash") {
                     dailyGoals.delete(goal, in: horizon)
@@ -1489,9 +1470,6 @@ struct KajiPopoverView: View {
         .opacity(goal.isDone ? 0.18 : 1)
         .animation(.easeOut(duration: goal.isDone ? 5 : 0.18), value: goal.isDone)
         .contextMenu {
-            Button(goal.note.isEmpty ? "添加说明" : "编辑说明") {
-                shownGoalNoteID = goal.id
-            }
             Menu("标签") {
                 ForEach(dailyGoals.tagDefinitions) { tag in
                     Button(tag.name) {
@@ -1499,13 +1477,6 @@ struct KajiPopoverView: View {
                     }
                 }
             }
-        }
-        .popover(isPresented: Binding(
-            get: { shownGoalNoteID == goal.id },
-            set: { if !$0 { shownGoalNoteID = nil } }
-        ), arrowEdge: .trailing) {
-            goalNoteEditor(goal, horizon: horizon)
-                .onHover { updateGoalNoteHover(goal, inside: $0) }
         }
     }
 
@@ -1524,8 +1495,13 @@ struct KajiPopoverView: View {
             .onTapGesture(perform: onEdit)
     }
 
+    func goalDetailContent(_ goal: DailyGoal, horizon: GoalHorizon) -> AnyView {
+        AnyView(goalNoteEditor(goal, horizon: horizon))
+    }
+
     private func goalNoteEditor(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {
         VStack(alignment: .leading, spacing: 8) {
+
             Text(goal.title)
                 .font(.system(size: 12, weight: .bold, design: .rounded))
             TextField("说明（可选）", text: Binding(
@@ -1541,22 +1517,6 @@ struct KajiPopoverView: View {
         .foregroundColor(t.cream)
     }
 
-    private func updateGoalNoteHover(_ goal: DailyGoal, inside: Bool) {
-        let hadActiveGoal = shownGoalNoteID != nil
-        goalNoteHoverGeneration += 1
-        let generation = goalNoteHoverGeneration
-        let delay = inside
-            ? HoverDisclosurePolicy.openDelay(hasActiveTopic: hadActiveGoal)
-            : HoverDisclosurePolicy.closeDelay
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            guard generation == goalNoteHoverGeneration else { return }
-            if inside {
-                shownGoalNoteID = goal.id
-            } else if shownGoalNoteID == goal.id {
-                shownGoalNoteID = nil
-            }
-        }
-    }
     private func goalTagMenu(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {
         let selected = dailyGoals.tagDefinition(for: goal.tag)
         return Circle()

--- a/Sources/Kaji/LoginItemManager.swift
+++ b/Sources/Kaji/LoginItemManager.swift
@@ -6,6 +6,19 @@ enum LoginItemManager {
         SMAppService.mainApp.status == .enabled
     }
 
+    enum AuthorizationStatus: Equatable {
+        case authorized, notAuthorized, needsReauthorization
+    }
+
+    static var authorizationStatus: AuthorizationStatus {
+        switch SMAppService.mainApp.status {
+        case .enabled: .authorized
+        case .requiresApproval: .needsReauthorization
+        case .notRegistered, .notFound: .notAuthorized
+        @unknown default: .notAuthorized
+        }
+    }
+
     @discardableResult
     static func setEnabled(_ enabled: Bool) -> Bool {
         do {

--- a/Sources/Kaji/MailBriefCredentialStore.swift
+++ b/Sources/Kaji/MailBriefCredentialStore.swift
@@ -1,7 +1,8 @@
 import Foundation
 import Security
+import LocalAuthentication
 
-struct MailBriefOAuthCredential: Codable, Sendable {
+struct MailBriefOAuthCredential: Codable, Sendable, Equatable {
     var accessToken: String
     var refreshToken: String?
     var expiresAt: Date
@@ -9,39 +10,120 @@ struct MailBriefOAuthCredential: Codable, Sendable {
     var scopes: [String]?
 }
 
+final class MailBriefCredentialCache: @unchecked Sendable {
+    private enum State { case empty, loaded(MailBriefOAuthCredential?) }
+    private let lock = NSLock()
+    private var state: State = .empty
+
+    func value(load: () throws -> MailBriefOAuthCredential) throws -> MailBriefOAuthCredential {
+        lock.lock()
+        defer { lock.unlock() }
+        switch state {
+        case .loaded(let value):
+            guard let value else { throw MailBriefError.notConnected }
+            return value
+        case .empty:
+            do {
+                let value = try load()
+                state = .loaded(value)
+                return value
+            } catch {
+                state = .loaded(nil)
+                throw error
+            }
+        }
+    }
+
+    func store(_ value: MailBriefOAuthCredential?) {
+        lock.withLock { state = .loaded(value) }
+    }
+
+    func invalidate() {
+        lock.withLock { state = .empty }
+    }
+}
+
+enum KeychainInteractionScope {
+    private static let lock = NSRecursiveLock()
+
+    static func run<T>(allowed: Bool, _ operation: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        var previous = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&previous)
+        SecKeychainSetUserInteractionAllowed(allowed)
+        defer { SecKeychainSetUserInteractionAllowed(previous.boolValue) }
+        return try operation()
+    }
+}
+
 enum MailBriefCredentialStore {
     private static let service = "dev.kaji.mail-brief.gmail"
-    private static let credentialAccount = "oauth-credential-v1"
+    private static let credentialAccount = "oauth-credential-v3"
+    private static let previousCredentialAccount = "oauth-credential-v2"
+    private static let legacyCredentialAccount = "oauth-credential-v1"
+    private static let cache = MailBriefCredentialCache()
+
+    enum AuthorizationStatus: Equatable {
+        case authorized
+        case notAuthorized
+        case needsReauthorization
+    }
 
     static var hasCredential: Bool { (try? credential()) != nil }
     static var account: String? { try? credential().account }
     static var canModify: Bool { (try? credential().scopes?.contains(MailBriefOAuthFlow.modifyScope)) ?? false }
-
-    static func credential() throws -> MailBriefOAuthCredential {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword, kSecAttrService: service,
-            kSecAttrAccount: credentialAccount, kSecReturnData: true, kSecMatchLimit: kSecMatchLimitOne
-        ]
-        var result: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let value = try? JSONDecoder().decode(MailBriefOAuthCredential.self, from: data) else {
-            throw MailBriefError.notConnected
+    static func authorizationStatus() -> AuthorizationStatus {
+        cache.invalidate()
+        do {
+            return try read(account: credentialAccount) == nil ? .notAuthorized : .authorized
+        } catch MailBriefError.notConnected {
+            return .needsReauthorization
+        } catch {
+            return .notAuthorized
         }
-        return value
+    }
+
+    static func authorizeAccess() throws {
+        try KeychainInteractionScope.run(allowed: true) {
+            guard let credential = try read(account: credentialAccount, allowsInteraction: true) else {
+                throw MailBriefError.notConnected
+            }
+            // Rewriting is intentional: it replaces the stale ACL immediately after
+            // the user's deliberate authorization.
+            try write(credential, account: credentialAccount, allowsInteraction: true)
+            cache.store(credential)
+        }
+    }
+    static func credential() throws -> MailBriefOAuthCredential {
+        try cache.value {
+            try migratedCredential(
+                read: { try read(account: $0) },
+                write: { try write($0, account: credentialAccount) },
+                deleteOld: { delete(account: $0) }
+            )
+        }
+    }
+
+    static func migratedCredential(
+        read: (String) throws -> MailBriefOAuthCredential?,
+        write: (MailBriefOAuthCredential) throws -> Void,
+        deleteOld: (String) -> Void
+    ) throws -> MailBriefOAuthCredential {
+        if let value = try read(credentialAccount) { return value }
+        for oldAccount in [previousCredentialAccount, legacyCredentialAccount] {
+            if let old = try read(oldAccount) {
+                try write(old)
+                deleteOld(oldAccount)
+                return old
+            }
+        }
+        throw MailBriefError.notConnected
     }
 
     static func save(_ credential: MailBriefOAuthCredential) throws {
-        let data = try JSONEncoder().encode(credential)
-        let query = [kSecClass: kSecClassGenericPassword, kSecAttrService: service,
-                     kSecAttrAccount: credentialAccount] as CFDictionary
-        SecItemDelete(query)
-        var attributes = query as! [CFString: Any]
-        attributes[kSecValueData] = data
-        attributes[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        guard SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess else {
-            throw MailBriefError.oauth("Could not save Gmail credential")
-        }
+        try write(credential, account: credentialAccount)
+        cache.store(credential)
     }
 
     static func validAccessToken(clientID: String, clientSecret: String) async throws -> String {
@@ -65,9 +147,154 @@ enum MailBriefCredentialStore {
     }
 
     static func delete() {
-        SecItemDelete([kSecClass: kSecClassGenericPassword,
-                       kSecAttrService: service,
-                       kSecAttrAccount: credentialAccount] as CFDictionary)
+        delete(account: credentialAccount)
+        delete(account: previousCredentialAccount)
+        delete(account: legacyCredentialAccount)
+        cache.store(nil)
+    }
+
+    private static func read(account: String, allowsInteraction: Bool = false) throws -> MailBriefOAuthCredential? {
+        try KeychainInteractionScope.run(allowed: allowsInteraction) {
+            var query = query(account: account) as! [CFString: Any]
+            query[kSecReturnData] = true
+            query[kSecMatchLimit] = kSecMatchLimitOne
+            if !allowsInteraction {
+                query[kSecUseAuthenticationUI] = kSecUseAuthenticationUIFail
+                let context = LAContext()
+                context.interactionNotAllowed = true
+                query[kSecUseAuthenticationContext] = context
+            }
+            var result: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            if status == errSecItemNotFound { return nil }
+            return try decodedCredential(status: status, result: result)
+        }
+    }
+
+    static func decodedCredential(status: OSStatus, result: CFTypeRef?) throws -> MailBriefOAuthCredential {
+        if status == errSecInteractionNotAllowed || status == errSecUserCanceled ||
+            status == errSecAuthFailed {
+            throw MailBriefError.notConnected
+        }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw MailBriefError.oauth("Could not read Gmail credential (\(status))")
+        }
+        return try JSONDecoder().decode(MailBriefOAuthCredential.self, from: data)
+    }
+
+    private static func write(_ credential: MailBriefOAuthCredential, account: String,
+                              allowsInteraction: Bool = false) throws {
+        try KeychainInteractionScope.run(allowed: allowsInteraction) {
+            let data = try JSONEncoder().encode(credential)
+            let itemQuery = query(account: account)
+            var attributes: [CFString: Any] = [
+                kSecValueData: data,
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            ]
+            if isAdHocSigned { attributes[kSecAttrAccess] = try pathStableAccess() }
+
+            let updateQuery = allowsInteraction ? itemQuery : nonInteractiveQuery(account: account)
+            let updateStatus = SecItemUpdate(updateQuery, attributes as CFDictionary)
+            switch writeAction(for: updateStatus) {
+            case .complete:
+                return
+            case .add:
+                break
+            case .replace:
+                let deleteQuery = allowsInteraction ? itemQuery : nonInteractiveQuery(account: account)
+                let deleteStatus = SecItemDelete(deleteQuery)
+                guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                    throw MailBriefError.oauth("Could not replace Gmail credential (\(deleteStatus))")
+                }
+            case .fail:
+                throw MailBriefError.oauth("Could not update Gmail credential (\(updateStatus))")
+            }
+
+            var newItem = itemQuery as! [CFString: Any]
+            attributes.forEach { newItem[$0.key] = $0.value }
+            let addStatus = SecItemAdd(newItem as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw MailBriefError.oauth("Could not save Gmail credential (\(addStatus))")
+            }
+        }
+    }
+
+    enum WriteAction: Equatable {
+        case complete, add, replace, fail
+    }
+
+    static func writeAction(for updateStatus: OSStatus) -> WriteAction {
+        switch updateStatus {
+        case errSecSuccess: .complete
+        case errSecItemNotFound: .add
+        case errSecInteractionNotAllowed, errSecUserCanceled: .replace
+        default: .fail
+        }
+    }
+
+    private static func delete(account: String) {
+        _ = KeychainInteractionScope.run(allowed: false) {
+            SecItemDelete(nonInteractiveQuery(account: account))
+        }
+    }
+
+    private static func nonInteractiveQuery(account: String) -> CFDictionary {
+        var value = query(account: account) as! [CFString: Any]
+        value[kSecUseAuthenticationUI] = kSecUseAuthenticationUIFail
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        value[kSecUseAuthenticationContext] = context
+        return value as CFDictionary
+    }
+
+    private static var isAdHocSigned: Bool {
+        var dynamicCode: SecCode?
+        guard SecCodeCopySelf([], &dynamicCode) == errSecSuccess, let dynamicCode else { return true }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(dynamicCode, [], &staticCode) == errSecSuccess,
+              let staticCode else { return true }
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation),
+                                            &information) == errSecSuccess,
+              let values = information as? [CFString: Any],
+              let flags = values[kSecCodeInfoFlags] as? NSNumber else { return true }
+        let csAdhoc: UInt32 = 0x2 // CS_ADHOC from the Security framework's cs_blobs.h.
+        return flags.uint32Value & csAdhoc != 0
+    }
+
+    // Ad-hoc builds have no stable signing identity. These narrowly scoped path
+    // trusts cover Kaji's two real execution locations (installed and local dist)
+    // across rebuilds, at the cost that another binary placed at either exact path
+    // could read the credential. Truly permanent cross-version authorization
+    // requires stable Developer ID signing via KAJI_CODESIGN_IDENTITY.
+    private static func pathStableAccess() throws -> SecAccess {
+        let sourceRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let paths = [
+            "/Applications/Kaji.app/Contents/MacOS/Kaji",
+            sourceRoot.appendingPathComponent("dist/Kaji.app/Contents/MacOS/Kaji").path
+        ]
+        var trustedApplications: [SecTrustedApplication] = []
+        for path in paths {
+            var trustedApplication: SecTrustedApplication?
+            let status = SecTrustedApplicationCreateFromPath(path, &trustedApplication)
+            guard status == errSecSuccess, let trustedApplication else {
+                throw MailBriefError.oauth("Could not create Kaji keychain trust (\(status))")
+            }
+            trustedApplications.append(trustedApplication)
+        }
+        var access: SecAccess?
+        let accessStatus = SecAccessCreate("Kaji Gmail credential" as CFString,
+                                           trustedApplications as CFArray, &access)
+        guard accessStatus == errSecSuccess, let access else {
+            throw MailBriefError.oauth("Could not create Kaji keychain access (\(accessStatus))")
+        }
+        return access
+    }
+
+    private static func query(account: String) -> CFDictionary {
+        [kSecClass: kSecClassGenericPassword, kSecAttrService: service,
+         kSecAttrAccount: account] as CFDictionary
     }
 
     private struct TokenRefresh: Decodable {

--- a/Sources/Kaji/MailBriefStore.swift
+++ b/Sources/Kaji/MailBriefStore.swift
@@ -19,6 +19,7 @@ final class MailBriefStore: ObservableObject {
     @Published private(set) var draftingThreadIDs: Set<String> = []
 
     private let cacheURL: URL
+    private let credentialStatus: () -> (hasCredential: Bool, account: String?, canModify: Bool)
     private let runHistoryURL: URL
     private var enabled = false
     private var timer: Timer?
@@ -29,17 +30,32 @@ final class MailBriefStore: ObservableObject {
     private var concurrency = 2
     private var model = MailBriefModel.defaultValue
 
-    init(cacheURL: URL? = nil) {
+    init(
+        cacheURL: URL? = nil,
+        credentialStatus: @escaping () -> (hasCredential: Bool, account: String?, canModify: Bool) = {
+            (MailBriefCredentialStore.hasCredential, MailBriefCredentialStore.account,
+             MailBriefCredentialStore.canModify)
+        }
+    ) {
         self.cacheURL = cacheURL ?? Self.defaultCacheURL()
         self.runHistoryURL = self.cacheURL.deletingLastPathComponent()
             .appendingPathComponent("mail-brief-runs-v1.json")
+        self.credentialStatus = credentialStatus
         loadCache()
         loadRunHistory()
     }
 
-    init(previewGeneration: MailBriefGeneration) {
-        cacheURL = URL(fileURLWithPath: "/tmp/kaji-mail-preview.json")
-        runHistoryURL = URL(fileURLWithPath: "/tmp/kaji-mail-preview-runs.json")
+    init(
+        previewGeneration: MailBriefGeneration,
+        cacheDirectory: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-mail-preview-\(UUID().uuidString)", isDirectory: true)
+    ) {
+        cacheURL = cacheDirectory.appendingPathComponent("mail-brief-cache-v1.json")
+        runHistoryURL = cacheDirectory.appendingPathComponent("mail-brief-runs-v1.json")
+        credentialStatus = {
+            (MailBriefCredentialStore.hasCredential, MailBriefCredentialStore.account,
+             MailBriefCredentialStore.canModify)
+        }
         generation = previewGeneration
         state = .ready
     }
@@ -69,9 +85,12 @@ final class MailBriefStore: ObservableObject {
                                               archivedIDs: generation.archivedThreadIDs,
                                               trashedIDs: generation.trashedThreadIDs)
     }
-    var isConnected: Bool { MailBriefCredentialStore.hasCredential }
-    var accountLabel: String? { MailBriefCredentialStore.account }
-    var canModify: Bool { MailBriefCredentialStore.canModify }
+    private var cachedCredentialStatus: (hasCredential: Bool, account: String?, canModify: Bool)? {
+        enabled ? credentialStatus() : nil
+    }
+    var isConnected: Bool { cachedCredentialStatus?.hasCredential ?? false }
+    var accountLabel: String? { cachedCredentialStatus?.account }
+    var canModify: Bool { cachedCredentialStatus?.canModify ?? false }
 
     func setEnabled(_ enabled: Bool, hour: Int, minute: Int, batchSize: Int, concurrency: Int,
                     model: MailBriefModel) {

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -18,80 +18,84 @@ import KajiCore
 //     legacy `"color"` / `"mono"` are normalized and written back on load.
 @MainActor
 final class Prefs: ObservableObject {
+    private let defaults: UserDefaults
     @Published var visibleProviders: Set<String> {
-        didSet { UserDefaults.standard.set(Array(visibleProviders), forKey: Key.visibleProviders) }
+        didSet { defaults.set(Array(visibleProviders), forKey: Key.visibleProviders) }
     }
     @Published var enabledModules: Set<KajiModuleID> {
         didSet {
             let raw = enabledModules.map(\.rawValue).sorted()
-            UserDefaults.standard.set(raw, forKey: Key.enabledModules)
+            defaults.set(raw, forKey: Key.enabledModules)
         }
     }
     @Published var language: Lang {
-        didSet { UserDefaults.standard.set(language.rawValue, forKey: Key.language) }
+        didSet { defaults.set(language.rawValue, forKey: Key.language) }
     }
     @Published var menubarStyle: MenubarStyle {
-        didSet { UserDefaults.standard.set(menubarStyle.rawValue, forKey: Key.menubarStyle) }
+        didSet { defaults.set(menubarStyle.rawValue, forKey: Key.menubarStyle) }
+    }
+    @Published var goalGrouping: GoalGrouping {
+        didSet { defaults.set(goalGrouping.rawValue, forKey: Key.goalGrouping) }
     }
     /// Show the 5h percentage as USED (default, "100% means full") vs
     /// REMAINING ("0% means full"). Persisted; the toggle lives in both the
     /// popover footer segment and the popover on the status item.
     @Published var showRemaining: Bool {
-        didSet { UserDefaults.standard.set(showRemaining, forKey: Key.showRemaining) }
+        didSet { defaults.set(showRemaining, forKey: Key.showRemaining) }
     }
     @Published var focusMinutes: Int {
-        didSet { UserDefaults.standard.set(focusMinutes, forKey: Key.focusMinutes) }
+        didSet { defaults.set(focusMinutes, forKey: Key.focusMinutes) }
     }
     @Published var breakMinutes: Int {
-        didSet { UserDefaults.standard.set(breakMinutes, forKey: Key.breakMinutes) }
+        didSet { defaults.set(breakMinutes, forKey: Key.breakMinutes) }
     }
     @Published var allowBreakSkip: Bool {
-        didSet { UserDefaults.standard.set(allowBreakSkip, forKey: Key.allowBreakSkip) }
+        didSet { defaults.set(allowBreakSkip, forKey: Key.allowBreakSkip) }
     }
     @Published var breakOverlayEnabled: Bool {
-        didSet { UserDefaults.standard.set(breakOverlayEnabled, forKey: Key.breakOverlayEnabled) }
+        didSet { defaults.set(breakOverlayEnabled, forKey: Key.breakOverlayEnabled) }
     }
     @Published var autoCleanEnabled: Bool {
-        didSet { UserDefaults.standard.set(autoCleanEnabled, forKey: Key.autoCleanEnabled) }
+        didSet { defaults.set(autoCleanEnabled, forKey: Key.autoCleanEnabled) }
     }
     @Published var launchAtLogin: Bool {
-        didSet { UserDefaults.standard.set(launchAtLogin, forKey: Key.launchAtLogin) }
+        didSet { defaults.set(launchAtLogin, forKey: Key.launchAtLogin) }
     }
     @Published var preventSleep: Bool {
-        didSet { UserDefaults.standard.set(preventSleep, forKey: Key.preventSleep) }
+        didSet { defaults.set(preventSleep, forKey: Key.preventSleep) }
     }
     @Published var mcpEnabled: Bool {
-        didSet { UserDefaults.standard.set(mcpEnabled, forKey: Key.mcpEnabled) }
+        didSet { defaults.set(mcpEnabled, forKey: Key.mcpEnabled) }
     }
     @Published var aiNewsRefreshHours: Int {
         didSet {
             let normalized = AIHotRefreshPolicy.normalize(hours: aiNewsRefreshHours)
             if normalized != aiNewsRefreshHours { aiNewsRefreshHours = normalized; return }
-            UserDefaults.standard.set(normalized, forKey: Key.aiNewsRefreshHours)
+            defaults.set(normalized, forKey: Key.aiNewsRefreshHours)
         }
     }
     @Published var mailBriefHour: Int {
-        didSet { UserDefaults.standard.set(min(23, max(0, mailBriefHour)), forKey: Key.mailBriefHour) }
+        didSet { defaults.set(min(23, max(0, mailBriefHour)), forKey: Key.mailBriefHour) }
     }
     @Published var mailBriefMinute: Int {
-        didSet { UserDefaults.standard.set(min(59, max(0, mailBriefMinute)), forKey: Key.mailBriefMinute) }
+        didSet { defaults.set(min(59, max(0, mailBriefMinute)), forKey: Key.mailBriefMinute) }
     }
     @Published var mailBriefBatchSize: Int {
         didSet {
             let value = MailBriefBatchPolicy.batchSize(mailBriefBatchSize)
             if value != mailBriefBatchSize { mailBriefBatchSize = value; return }
-            UserDefaults.standard.set(value, forKey: Key.mailBriefBatchSize)
+            defaults.set(value, forKey: Key.mailBriefBatchSize)
         }
     }
     @Published var mailBriefConcurrency: Int {
         didSet {
             let value = MailBriefBatchPolicy.concurrency(mailBriefConcurrency)
             if value != mailBriefConcurrency { mailBriefConcurrency = value; return }
-            UserDefaults.standard.set(value, forKey: Key.mailBriefConcurrency)
+            defaults.set(value, forKey: Key.mailBriefConcurrency)
         }
     }
     @Published var mailBriefModel: MailBriefModel {
-        didSet { UserDefaults.standard.set(mailBriefModel.rawValue, forKey: Key.mailBriefModel) }
+        didSet { defaults.set(mailBriefModel.rawValue, forKey: Key.mailBriefModel) }
     }
 
     enum Key {
@@ -118,6 +122,7 @@ final class Prefs: ObservableObject {
         static let mailBriefBatchSize = "mailBriefBatchSize"
         static let mailBriefConcurrency = "mailBriefConcurrency"
         static let mailBriefModel = "mailBriefModel"
+        static let goalGrouping = "goalGrouping"
 
         static let existingPreferenceKeys = [
             visibleProviders, enabledModules, language, menubarStyle,
@@ -125,12 +130,13 @@ final class Prefs: ObservableObject {
             allowBreakSkip, breakOverlayEnabled, visibleProvidersV2,
             visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep,
             aiNewsRefreshHours, mcpEnabled, mailBriefHour, mailBriefMinute,
-            mailBriefBatchSize, mailBriefConcurrency, mailBriefModel
+            mailBriefBatchSize, mailBriefConcurrency, mailBriefModel, goalGrouping
         ]
     }
 
-    init() {
-        let d = UserDefaults.standard
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let d = defaults
         let hadExistingPreferences = Key.existingPreferenceKeys.contains {
             d.object(forKey: $0) != nil
         }
@@ -187,6 +193,7 @@ final class Prefs: ObservableObject {
         } else {
             showRemaining = false
         }
+        goalGrouping = GoalGrouping(rawValue: d.string(forKey: Key.goalGrouping) ?? "") ?? .none
         let savedFocus = d.integer(forKey: Key.focusMinutes)
         focusMinutes = savedFocus > 0 ? savedFocus : 45
         let savedBreak = d.integer(forKey: Key.breakMinutes)

--- a/Sources/Kaji/QuotaStore.swift
+++ b/Sources/Kaji/QuotaStore.swift
@@ -86,8 +86,10 @@ final class QuotaStore: ObservableObject {
     @Published private(set) var lastUpdated: Date?
 
     private var timer: Timer?
+    private let isPreview: Bool
 
     init() {
+        isPreview = false
         UserDefaults.standard.removeObject(forKey: "sparklineHistory")
         UserDefaults.standard.removeObject(forKey: "tokenHistory")
         UserDefaults.standard.removeObject(forKey: "tokenHistoryV2")
@@ -96,6 +98,7 @@ final class QuotaStore: ObservableObject {
     /// Seed a store with fixed data for previews / offscreen snapshots. Does not
     /// start the poll timer or touch UserDefaults.
     init(previewProviders: [ProviderView], updated: Date? = nil) {
+        isPreview = true
         self.providers = previewProviders
         self.lastUpdated = updated
     }
@@ -117,6 +120,7 @@ final class QuotaStore: ObservableObject {
     }
 
     func start() {
+        guard !isPreview else { return }
         refresh()
         let t = Timer.scheduledTimer(withTimeInterval: Config.refreshInterval,
                                      repeats: true) { [weak self] _ in

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -11,6 +11,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
     case aiNews = "AI News"
     case mailBrief = "Mail Brief"
     case mcp = "MCP"
+    case permissions = "Permissions"
 
     var id: String { rawValue }
     var systemImage: String {
@@ -23,8 +24,13 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .aiNews: "newspaper"
         case .mailBrief: "envelope"
         case .mcp: "link"
+        case .permissions: "lock.shield"
         }
     }
+}
+
+private enum PermissionState: Equatable {
+    case authorized, notAuthorized, needsReauthorization
 }
 
 // MARK: - SettingsView
@@ -42,6 +48,9 @@ struct SettingsView: View {
     @State private var selectedScheduleID: UUID?
     @State private var selection: SettingsSection = .general
     @State private var showsMailRunHistory = false
+    @State private var gmailPermission: PermissionState = .notAuthorized
+    @State private var loginPermission: PermissionState = .notAuthorized
+    @State private var sleepPermission: PermissionState = .notAuthorized
 
     @Environment(\.colorScheme) private var scheme
     private var t: KajiTheme { .resolve(scheme) }
@@ -49,7 +58,8 @@ struct SettingsView: View {
     var body: some View {
         HStack(spacing: 0) {
             List(SettingsSection.allCases, selection: $selection) { section in
-                Label(section.rawValue, systemImage: section.systemImage)
+                Label(section == .permissions ? L10n.t(.permissions, prefs.language) : section.rawValue,
+                      systemImage: section.systemImage)
                     .tag(section)
             }
             .listStyle(.sidebar)
@@ -157,6 +167,39 @@ struct SettingsView: View {
                     }
                 }
             }
+            if selection == .permissions {
+                settingBlock(title: L10n.t(.permissions, prefs.language)) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        permissionRow(
+                            title: L10n.t(.gmailCredential, prefs.language),
+                            why: L10n.t(.gmailCredentialWhy, prefs.language),
+                            status: gmailPermission
+                        ) {
+                            try? MailBriefCredentialStore.authorizeAccess()
+                            refreshPermissions()
+                        }
+                        permissionRow(
+                            title: L10n.t(.loginPermission, prefs.language),
+                            why: L10n.t(.loginPermissionWhy, prefs.language),
+                            status: loginPermission
+                        ) {
+                            _ = LoginItemManager.setEnabled(true)
+                            refreshPermissions()
+                        }
+                        permissionRow(
+                            title: L10n.t(.sleepPermission, prefs.language),
+                            why: L10n.t(.sleepPermissionWhy, prefs.language),
+                            status: sleepPermission
+                        ) {
+                            sleepController.setEnabled(true)
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                refreshPermissions()
+                            }
+                        }
+                    }
+                }
+                .onAppear { refreshPermissions() }
+            }
             if selection == .work {
                 settingBlock(title: L10n.t(.work, prefs.language)) {
                     VStack(alignment: .leading, spacing: 10) {
@@ -263,6 +306,55 @@ struct SettingsView: View {
             }
         }
         .padding(24)
+    }
+
+    private func refreshPermissions() {
+        switch MailBriefCredentialStore.authorizationStatus() {
+        case .authorized: gmailPermission = .authorized
+        case .notAuthorized: gmailPermission = .notAuthorized
+        case .needsReauthorization: gmailPermission = .needsReauthorization
+        }
+        switch LoginItemManager.authorizationStatus {
+        case .authorized: loginPermission = .authorized
+        case .notAuthorized: loginPermission = .notAuthorized
+        case .needsReauthorization: loginPermission = .needsReauthorization
+        }
+        switch SleepController.authorizationStatus {
+        case .authorized: sleepPermission = .authorized
+        case .notAuthorized: sleepPermission = .notAuthorized
+        case .needsReauthorization: sleepPermission = .needsReauthorization
+        }
+    }
+
+    private func permissionRow(title: String, why: String, status: PermissionState,
+                               action: @escaping () -> Void) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.cream)
+                Text(why)
+                    .font(.system(size: 9.5, weight: .medium, design: .rounded))
+                    .foregroundColor(t.mute)
+            }
+            Spacer(minLength: 8)
+            Text(permissionStatusText(status))
+                .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                .foregroundColor(t.mute)
+            if status != .authorized {
+                outlineButton(title: L10n.t(.authorize, prefs.language),
+                              systemImage: "checkmark.shield", action: action)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func permissionStatusText(_ status: PermissionState) -> String {
+        switch status {
+        case .authorized: L10n.t(.authorized, prefs.language)
+        case .notAuthorized: L10n.t(.notAuthorized, prefs.language)
+        case .needsReauthorization: L10n.t(.needsReauthorization, prefs.language)
+        }
     }
 
     private var mailRunActivity: some View {

--- a/Sources/Kaji/SleepController.swift
+++ b/Sources/Kaji/SleepController.swift
@@ -16,6 +16,19 @@ final class SleepController: ObservableObject {
         plistName: "dev.kaji.sleep-helper.plist"
     )
 
+    enum AuthorizationStatus: Equatable {
+        case authorized, notAuthorized, needsReauthorization
+    }
+
+    static var authorizationStatus: AuthorizationStatus {
+        switch daemon.status {
+        case .enabled: .authorized
+        case .requiresApproval: .needsReauthorization
+        case .notRegistered, .notFound: .notAuthorized
+        @unknown default: .notAuthorized
+        }
+    }
+
     init(previewEnabled: Bool? = nil) {
         if let previewEnabled {
             isEnabled = previewEnabled

--- a/Sources/KajiCore/GoalGroupingLogic.swift
+++ b/Sources/KajiCore/GoalGroupingLogic.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public enum GoalGrouping: String, CaseIterable, Codable, Sendable {
+    case none
+    case byTag
+    case byCreatedTime
+}
+
+public struct GoalGroup: Equatable, Sendable {
+    public let title: String
+    public let goals: [GoalItem]
+
+    public init(title: String, goals: [GoalItem]) {
+        self.title = title
+        self.goals = goals
+    }
+}
+
+public enum GoalGroupingLogic {
+    /// Groups goals without changing their order within a group.
+    ///
+    /// Tag groups follow `tagOrder`; unknown tags follow in first-seen order and
+    /// untagged goals are last. Date groups are newest-first. Legacy goals with
+    /// no persisted creation date form the final Earlier group in source order.
+    public static func group(
+        _ goals: [GoalItem],
+        by grouping: GoalGrouping,
+        tagOrder: [String] = [],
+        now: Date = Date(),
+        calendar: Calendar = .current,
+        language: AppLanguage = .en
+    ) -> [GoalGroup] {
+        guard !goals.isEmpty else { return [] }
+        switch grouping {
+        case .none:
+            return [GoalGroup(title: "", goals: goals)]
+        case .byTag:
+            return groupByTag(goals, tagOrder: tagOrder, language: language)
+        case .byCreatedTime:
+            return groupByDate(goals, now: now, calendar: calendar, language: language)
+        }
+    }
+
+    private static func groupByTag(
+        _ goals: [GoalItem],
+        tagOrder: [String],
+        language: AppLanguage
+    ) -> [GoalGroup] {
+        func normalized(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        var ordered = tagOrder.map(normalized).filter { !$0.isEmpty }
+        for goal in goals {
+            let tag = normalized(goal.tag)
+            if !tag.isEmpty && !ordered.contains(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) {
+                ordered.append(tag)
+            }
+        }
+        var groups = ordered.compactMap { tag -> GoalGroup? in
+            let matches = goals.filter { normalized($0.tag).caseInsensitiveCompare(tag) == .orderedSame }
+            return matches.isEmpty ? nil : GoalGroup(title: tag, goals: matches)
+        }
+        let untagged = goals.filter { normalized($0.tag).isEmpty }
+        if !untagged.isEmpty {
+            groups.append(GoalGroup(title: L10n.t(.goalGroupUntagged, language), goals: untagged))
+        }
+        return groups
+    }
+
+    private static func groupByDate(
+        _ goals: [GoalItem],
+        now: Date,
+        calendar: Calendar,
+        language: AppLanguage
+    ) -> [GoalGroup] {
+        let today = calendar.startOfDay(for: now)
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let weekStart = calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? today
+        let buckets: [(L10n.K, (Date?) -> Bool)] = [
+            (.goalGroupToday, { $0.map { $0 >= today } ?? false }),
+            (.goalGroupYesterday, { $0.map { $0 >= yesterday && $0 < today } ?? false }),
+            (.goalGroupThisWeek, { $0.map { $0 >= weekStart && $0 < yesterday } ?? false }),
+            (.goalGroupEarlier, { date in date == nil || date! < weekStart }),
+        ]
+        return buckets.compactMap { key, includes in
+            let matches = goals.filter { includes($0.createdAt) }
+            return matches.isEmpty ? nil : GoalGroup(title: L10n.t(key, language), goals: matches)
+        }
+    }
+}

--- a/Sources/KajiCore/GoalHorizonModel.swift
+++ b/Sources/KajiCore/GoalHorizonModel.swift
@@ -75,17 +75,28 @@ public struct GoalItem: Identifiable, Codable, Equatable, Sendable {
     public var isDone: Bool
     public var tag: String
     public var note: String
+    /// Persisted creation time. `nil` identifies goals decoded from data written
+    /// before creation timestamps existed; grouping keeps those in source order.
+    public let createdAt: Date?
 
-    public init(id: UUID, title: String, isDone: Bool, tag: String = "", note: String = "") {
+    public init(
+        id: UUID,
+        title: String,
+        isDone: Bool,
+        tag: String = "",
+        note: String = "",
+        createdAt: Date? = nil
+    ) {
         self.id = id
         self.title = title
         self.isDone = isDone
         self.tag = tag
         self.note = note
+        self.createdAt = createdAt
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, isDone, tag, note
+        case id, title, isDone, tag, note, createdAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -95,8 +106,10 @@ public struct GoalItem: Identifiable, Codable, Equatable, Sendable {
         isDone = try container.decode(Bool.self, forKey: .isDone)
         tag = try container.decodeIfPresent(String.self, forKey: .tag) ?? ""
         note = try container.decodeIfPresent(String.self, forKey: .note) ?? ""
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     }
 }
+
 
 public struct GoalHistoryDay: Identifiable, Codable, Equatable, Sendable {
     public let day: String

--- a/Sources/KajiCore/LanguageLocalization.swift
+++ b/Sources/KajiCore/LanguageLocalization.swift
@@ -60,6 +60,10 @@ public enum L10n {
         case modules, modulesHint
         case moduleQuota, moduleWork, moduleSystem, moduleGoals, moduleAINews
         case aiNews, dataSource, updated, loading, noHotNews, retry, sources, refreshInterval
+        case goalGroup, goalGroupingNone, goalGroupingByTag, goalGroupingByCreatedTime
+        case goalGroupUntagged, goalGroupToday, goalGroupYesterday, goalGroupThisWeek, goalGroupEarlier
+        case permissions, gmailCredential, gmailCredentialWhy, loginPermission, loginPermissionWhy
+        case sleepPermission, sleepPermissionWhy, authorized, notAuthorized, needsReauthorization, authorize
     }
 
     private struct Text {
@@ -142,7 +146,27 @@ public enum L10n {
         .noHotNews: .init(en: "No hot news", zh: "暂无热点", ptBR: "Sem notícias em alta", es: "Sin noticias destacadas"),
         .retry: .init(en: "Retry", zh: "重试", ptBR: "Tentar novamente", es: "Reintentar"),
         .sources: .init(en: "sources", zh: "个来源", ptBR: "fontes", es: "fuentes"),
-        .refreshInterval: .init(en: "Refresh", zh: "刷新间隔", ptBR: "Atualização", es: "Actualización")
+        .refreshInterval: .init(en: "Refresh", zh: "刷新间隔", ptBR: "Atualização", es: "Actualización"),
+        .goalGroup: .init(en: "Group", zh: "分组", ptBR: "Agrupar", es: "Agrupar"),
+        .goalGroupingNone: .init(en: "No Grouping", zh: "不分组", ptBR: "Sem agrupamento", es: "Sin agrupar"),
+        .goalGroupingByTag: .init(en: "By Tag", zh: "按标签", ptBR: "Por etiqueta", es: "Por etiqueta"),
+        .goalGroupingByCreatedTime: .init(en: "By Created Time", zh: "按创建时间", ptBR: "Por data de criação", es: "Por fecha de creación"),
+        .goalGroupUntagged: .init(en: "Untagged", zh: "无标签", ptBR: "Sem etiqueta", es: "Sin etiqueta"),
+        .goalGroupToday: .init(en: "Today", zh: "今天", ptBR: "Hoje", es: "Hoy"),
+        .goalGroupYesterday: .init(en: "Yesterday", zh: "昨天", ptBR: "Ontem", es: "Ayer"),
+        .goalGroupThisWeek: .init(en: "This Week", zh: "本周", ptBR: "Esta semana", es: "Esta semana"),
+        .goalGroupEarlier: .init(en: "Earlier", zh: "更早", ptBR: "Anteriores", es: "Anteriores"),
+        .permissions: .init(en: "Permissions", zh: "授权", ptBR: "Autorizações", es: "Permisos"),
+        .gmailCredential: .init(en: "Gmail credential", zh: "Gmail 凭据", ptBR: "Credencial do Gmail", es: "Credencial de Gmail"),
+        .gmailCredentialWhy: .init(en: "Reads Gmail securely for Mail Brief.", zh: "安全读取 Gmail 以生成邮件简报。", ptBR: "Lê o Gmail com segurança para o resumo.", es: "Lee Gmail de forma segura para el resumen."),
+        .loginPermission: .init(en: "Launch at login", zh: "登录时启动", ptBR: "Iniciar ao entrar", es: "Iniciar al entrar"),
+        .loginPermissionWhy: .init(en: "Keeps Kaji available after you sign in.", zh: "登录 Mac 后自动保持 Kaji 可用。", ptBR: "Mantém o Kaji disponível após entrar.", es: "Mantiene Kaji disponible tras iniciar sesión."),
+        .sleepPermission: .init(en: "Prevent sleep helper", zh: "防休眠助手", ptBR: "Auxiliar antirrepouso", es: "Asistente antirreposo"),
+        .sleepPermissionWhy: .init(en: "Keeps the Mac awake during active work.", zh: "工作期间让 Mac 保持唤醒。", ptBR: "Mantém o Mac ativo durante o trabalho.", es: "Mantiene el Mac activo durante el trabajo."),
+        .authorized: .init(en: "Authorized", zh: "已授权", ptBR: "Autorizado", es: "Autorizado"),
+        .notAuthorized: .init(en: "Not authorized", zh: "未授权", ptBR: "Não autorizado", es: "No autorizado"),
+        .needsReauthorization: .init(en: "Needs re-authorization", zh: "需要重新授权", ptBR: "Requer nova autorização", es: "Requiere nueva autorización"),
+        .authorize: .init(en: "Authorize", zh: "授权", ptBR: "Autorizar", es: "Autorizar"),
     ]
 
     public static func t(_ key: K, _ language: AppLanguage) -> String {

--- a/Tests/KajiTests/GoalGroupingLogicTests.swift
+++ b/Tests/KajiTests/GoalGroupingLogicTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import KajiCore
+
+final class GoalGroupingLogicTests: XCTestCase {
+    private let calendar: Calendar = {
+        var value = Calendar(identifier: .iso8601)
+        value.timeZone = TimeZone(secondsFromGMT: 0)!
+        return value
+    }()
+
+    func testNonePreservesInputInOneUnnamedGroup() {
+        let goals = [goal("A"), goal("B")]
+        XCTAssertEqual(GoalGroupingLogic.group(goals, by: .none), [GoalGroup(title: "", goals: goals)])
+    }
+
+    func testTagGroupingUsesDefinitionOrderThenUnknownAndUntaggedLast() {
+        let untagged = goal("Untagged", tag: "")
+        let personal = goal("Personal", tag: "Personal")
+        let custom = goal("Custom", tag: "Custom")
+        let work = goal("Work", tag: "work")
+        let groups = GoalGroupingLogic.group(
+            [untagged, personal, custom, work],
+            by: .byTag,
+            tagOrder: ["Work", "Personal"],
+            language: .en
+        )
+        XCTAssertEqual(groups.map(\.title), ["Work", "Personal", "Custom", "Untagged"])
+        XCTAssertEqual(groups.flatMap(\.goals).map(\.title), ["Work", "Personal", "Custom", "Untagged"])
+    }
+
+    func testCreatedTimeBoundariesAreNewestFirstAndLegacyOrderIsStable() {
+        let now = date("2026-08-26T12:00:00Z") // Wednesday
+        let legacyA = goal("Legacy A")
+        let legacyB = goal("Legacy B")
+        let goals = [
+            legacyA,
+            goal("Earlier", createdAt: date("2026-08-23T23:59:59Z")),
+            goal("Week start", createdAt: date("2026-08-24T00:00:00Z")),
+            goal("Yesterday start", createdAt: date("2026-08-25T00:00:00Z")),
+            goal("Today start", createdAt: date("2026-08-26T00:00:00Z")),
+            legacyB,
+        ]
+        let groups = GoalGroupingLogic.group(
+            goals,
+            by: .byCreatedTime,
+            now: now,
+            calendar: calendar,
+            language: .en
+        )
+        XCTAssertEqual(groups.map(\.title), ["Today", "Yesterday", "This Week", "Earlier"])
+        XCTAssertEqual(groups[0].goals.map(\.title), ["Today start"])
+        XCTAssertEqual(groups[1].goals.map(\.title), ["Yesterday start"])
+        XCTAssertEqual(groups[2].goals.map(\.title), ["Week start"])
+        XCTAssertEqual(groups[3].goals.map(\.title), ["Legacy A", "Earlier", "Legacy B"])
+    }
+
+    func testEmptyInputHasNoGroups() {
+        for grouping in GoalGrouping.allCases {
+            XCTAssertTrue(GoalGroupingLogic.group([], by: grouping).isEmpty)
+        }
+    }
+
+    func testLegacyGoalJSONDecodesWithoutCreatedAtAndPreservesFields() throws {
+        let id = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        let json = "{\"id\":\"\(id.uuidString)\",\"title\":\"Legacy\",\"isDone\":true,\"tag\":\"Work\",\"note\":\"Kept\"}"
+        let decoded = try JSONDecoder().decode(GoalItem.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.id, id)
+        XCTAssertEqual(decoded.title, "Legacy")
+        XCTAssertTrue(decoded.isDone)
+        XCTAssertEqual(decoded.tag, "Work")
+        XCTAssertEqual(decoded.note, "Kept")
+        XCTAssertNil(decoded.createdAt)
+    }
+
+    func testGroupingLocalizationKeysExistForEveryLanguage() {
+        let keys: [L10n.K] = [
+            .goalGroup, .goalGroupingNone, .goalGroupingByTag, .goalGroupingByCreatedTime,
+            .goalGroupUntagged, .goalGroupToday, .goalGroupYesterday, .goalGroupThisWeek, .goalGroupEarlier,
+        ]
+        for language in AppLanguage.allCases {
+            for key in keys {
+                XCTAssertFalse(L10n.t(key, language).isEmpty, "Missing \(key) for \(language)")
+            }
+        }
+    }
+
+    private func goal(_ title: String, tag: String = "", createdAt: Date? = nil) -> GoalItem {
+        GoalItem(id: UUID(), title: title, isDone: false, tag: tag, createdAt: createdAt)
+    }
+
+    private func date(_ value: String) -> Date {
+        ISO8601DateFormatter().date(from: value)!
+    }
+}

--- a/Tests/KajiTests/GoalStatePersistenceTests.swift
+++ b/Tests/KajiTests/GoalStatePersistenceTests.swift
@@ -186,7 +186,9 @@ final class GoalStatePersistenceTests: XCTestCase {
         let goal = try store.addGoal(title: "Finish me", tag: "Work", note: "", in: .today)
 
         store.toggle(goal)
-        try await Task.sleep(for: .milliseconds(40))
+        for _ in 0..<50 where !store.goals.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+        }
 
         XCTAssertTrue(store.goals.isEmpty)
     }

--- a/Tests/KajiTests/MailBriefCredentialStoreTests.swift
+++ b/Tests/KajiTests/MailBriefCredentialStoreTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import XCTest
+@testable import Kaji
+
+final class MailBriefCredentialStoreTests: XCTestCase {
+    private let credential = MailBriefOAuthCredential(
+        accessToken: "access", refreshToken: "refresh",
+        expiresAt: Date(timeIntervalSince1970: 1_800_000_000),
+        account: "user@example.com", scopes: [MailBriefOAuthFlow.readScope]
+    )
+
+    func testCacheLoadsOnlyOnce() throws {
+        let cache = MailBriefCredentialCache()
+        var loads = 0
+
+        let first = try cache.value { loads += 1; return credential }
+        let second = try cache.value { loads += 1; return credential }
+
+        XCTAssertEqual(first, credential)
+        XCTAssertEqual(second, credential)
+        XCTAssertEqual(loads, 1)
+    }
+
+    func testCacheStoreAndInvalidate() throws {
+        let cache = MailBriefCredentialCache()
+        cache.store(credential)
+        var loads = 0
+
+        XCTAssertEqual(try cache.value { loads += 1; return credential }, credential)
+        XCTAssertEqual(loads, 0)
+
+        cache.invalidate()
+        XCTAssertEqual(try cache.value { loads += 1; return credential }, credential)
+        XCTAssertEqual(loads, 1)
+    }
+
+    func testMissingCredentialIsCachedUntilInvalidated() throws {
+        let cache = MailBriefCredentialCache()
+        var loads = 0
+        let missing: () throws -> MailBriefOAuthCredential = {
+            loads += 1
+            throw MailBriefError.notConnected
+        }
+
+        XCTAssertThrowsError(try cache.value(load: missing))
+        XCTAssertThrowsError(try cache.value(load: missing))
+        XCTAssertEqual(loads, 1)
+
+        cache.invalidate()
+        XCTAssertThrowsError(try cache.value(load: missing))
+        XCTAssertEqual(loads, 2)
+    }
+
+    func testV2CredentialMigratesToV3BeforeDeletion() throws {
+        var reads: [String] = []
+        var written: MailBriefOAuthCredential?
+        var deleted: [String] = []
+
+        let result = try MailBriefCredentialStore.migratedCredential(
+            read: { account in
+                reads.append(account)
+                return account == "oauth-credential-v2" ? credential : nil
+            },
+            write: { written = $0 },
+            deleteOld: { deleted.append($0) }
+        )
+
+        XCTAssertEqual(reads, ["oauth-credential-v3", "oauth-credential-v2"])
+        XCTAssertEqual(written, credential)
+        XCTAssertEqual(deleted, ["oauth-credential-v2"])
+        XCTAssertEqual(result, credential)
+    }
+
+    func testV1CredentialMigratesToV3BeforeDeletion() throws {
+        var reads: [String] = []
+        var deleted: [String] = []
+
+        let result = try MailBriefCredentialStore.migratedCredential(
+            read: { account in
+                reads.append(account)
+                return account == "oauth-credential-v1" ? credential : nil
+            },
+            write: { _ in },
+            deleteOld: { deleted.append($0) }
+        )
+
+        XCTAssertEqual(reads, ["oauth-credential-v3", "oauth-credential-v2", "oauth-credential-v1"])
+        XCTAssertEqual(deleted, ["oauth-credential-v1"])
+        XCTAssertEqual(result, credential)
+    }
+
+    @MainActor
+    func testDisabledMailBriefStoreDoesNotReadCredentialStatus() {
+        var reads = 0
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-disabled-mail-brief-\(UUID().uuidString).json")
+        let store = MailBriefStore(cacheURL: cacheURL) {
+            reads += 1
+            return (true, "user@example.com", true)
+        }
+
+        XCTAssertFalse(store.isConnected)
+        XCTAssertNil(store.accountLabel)
+        XCTAssertFalse(store.canModify)
+        XCTAssertEqual(reads, 0)
+    }
+
+    func testAuthenticationUIFailuresBecomeNotConnected() {
+        for status in [errSecInteractionNotAllowed, errSecUserCanceled, errSecAuthFailed] {
+            XCTAssertThrowsError(try MailBriefCredentialStore.decodedCredential(
+                status: status, result: nil
+            )) { error in
+                guard case MailBriefError.notConnected = error else {
+                    return XCTFail("Expected notConnected, got \(error)")
+                }
+            }
+        }
+    }
+
+    func testAuthenticationUIFailureReplacesInaccessibleCredential() {
+        XCTAssertEqual(MailBriefCredentialStore.writeAction(for: errSecInteractionNotAllowed),
+                       .replace)
+        XCTAssertEqual(MailBriefCredentialStore.writeAction(for: errSecUserCanceled),
+                       .replace)
+        XCTAssertEqual(MailBriefCredentialStore.writeAction(for: errSecItemNotFound),
+                       .add)
+        XCTAssertEqual(MailBriefCredentialStore.writeAction(for: errSecSuccess),
+                       .complete)
+    }
+
+    func testInteractionScopeRestoresAfterNestedCalls() {
+        var original = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&original)
+
+        KeychainInteractionScope.run(allowed: false) {
+            var outer = DarwinBoolean(true)
+            SecKeychainGetUserInteractionAllowed(&outer)
+            XCTAssertFalse(outer.boolValue)
+            KeychainInteractionScope.run(allowed: true) {
+                var inner = DarwinBoolean(false)
+                SecKeychainGetUserInteractionAllowed(&inner)
+                XCTAssertTrue(inner.boolValue)
+            }
+            SecKeychainGetUserInteractionAllowed(&outer)
+            XCTAssertFalse(outer.boolValue)
+        }
+
+        var restored = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&restored)
+        XCTAssertEqual(restored.boolValue, original.boolValue)
+    }
+
+    func testInteractionScopeRestoresWhenOperationThrows() {
+        enum Expected: Error { case failure }
+        var original = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&original)
+
+        XCTAssertThrowsError(try KeychainInteractionScope.run(allowed: false) {
+            throw Expected.failure
+        })
+
+        var restored = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&restored)
+        XCTAssertEqual(restored.boolValue, original.boolValue)
+    }
+
+    func testConcurrentInteractionScopesLeaveOriginalState() {
+        var original = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&original)
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "keychain-scope", attributes: .concurrent)
+        for _ in 0..<20 {
+            group.enter()
+            queue.async {
+                KeychainInteractionScope.run(allowed: false) {
+                    var allowed = DarwinBoolean(true)
+                    SecKeychainGetUserInteractionAllowed(&allowed)
+                    XCTAssertFalse(allowed.boolValue)
+                }
+                group.leave()
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 2), .success)
+        var restored = DarwinBoolean(false)
+        SecKeychainGetUserInteractionAllowed(&restored)
+        XCTAssertEqual(restored.boolValue, original.boolValue)
+    }
+}

--- a/Tests/KajiTests/PopoverInteractionTests.swift
+++ b/Tests/KajiTests/PopoverInteractionTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import AppKit
+import KajiCore
+@testable import Kaji
+
+/// Drives the real `AppDelegate` object graph in-process (no XCUITest — see
+/// `Tests/KajiTests/UITestHarness.swift`). `clickStatusItem()` invokes the
+/// real `onQuotaClick` closure `setupStatusItem()` wires on the hosted
+/// `StatusItemView` — the same closure a real click calls — so a regression
+/// like an unwired closure, or a broken `showPopover` implementation (e.g.
+/// the NSPanel + `hidesOnDeactivate` regression in 5d6928b, where the panel
+/// hid itself instantly because clicking the status item never activates
+/// an `LSUIElement` app), fails these tests for real.
+///
+/// Real OS-level click delivery (can a genuine mouse click actually reach
+/// the SwiftUI `Button`'s gesture recognizer?) is out of scope here — that
+/// reliably does not work from inside a bare `xctest` process outside a
+/// real, launched `.app` bundle, and is covered separately by
+/// `scripts/ui-smoke.sh` against the actual signed `.app`.
+@MainActor
+final class PopoverInteractionTests: XCTestCase {
+    private var harness: KajiUIHarness!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        harness = KajiUIHarness()
+    }
+
+    override func tearDown() async throws {
+        harness.tearDown()
+        harness = nil
+        try await super.tearDown()
+    }
+
+    func testStatusItemHasWiredClickSurface() throws {
+        let hostingView = try XCTUnwrap(harness.appDelegate.hostingView, "setupStatusItem() must create the hosted click surface")
+        let statusItem = try XCTUnwrap(harness.appDelegate.statusItem, "status item must exist after launch")
+        let button = try XCTUnwrap(statusItem.button, "status item must have a button")
+        XCTAssertTrue(button.subviews.contains(hostingView), "hosting view must be attached as a subview of the status item button — this is the actual click surface AppKit delivers events to")
+        XCTAssertGreaterThan(statusItem.length, 0, "status item must have non-zero width to be clickable")
+    }
+
+    func testClickOpensPopover() throws {
+        XCTAssertFalse(harness.appDelegate.popover.isShown)
+        harness.clickStatusItem()
+        XCTAssertTrue(harness.appDelegate.popover.isShown, "clicking the status item must open the popover")
+    }
+
+    func testClickTwiceClosesPopover() throws {
+        harness.clickStatusItem()
+        XCTAssertTrue(harness.appDelegate.popover.isShown)
+        harness.clickStatusItem()
+        XCTAssertFalse(harness.appDelegate.popover.isShown, "clicking the same slot again must close the popover")
+    }
+
+    func testPopoverHasNonZeroContentSize() throws {
+        harness.clickStatusItem()
+        XCTAssertTrue(harness.appDelegate.popover.isShown)
+        let size = harness.appDelegate.popover.contentSize
+        XCTAssertGreaterThan(size.width, 0)
+        XCTAssertGreaterThan(size.height, 0)
+        let contentView = try XCTUnwrap(harness.appDelegate.popover.contentViewController?.view)
+        XCTAssertFalse(contentView.subviews.isEmpty, "popover content view must not be an empty subtree")
+    }
+
+    func testEveryModulePageNavigatesWithoutCrashing() throws {
+        harness.clickStatusItem()
+        XCTAssertTrue(harness.appDelegate.popover.isShown)
+        for page in KajiModuleID.allCases {
+            harness.appDelegate.popoverNavigation.panel = page
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            XCTAssertEqual(harness.appDelegate.popoverNavigation.panel, page)
+            XCTAssertTrue(harness.appDelegate.popover.isShown, "popover must stay shown while paging through \(page)")
+            let contentView = try XCTUnwrap(harness.appDelegate.popover.contentViewController?.view)
+            XCTAssertFalse(contentView.subviews.isEmpty, "\(page) must render a non-empty content subtree")
+        }
+    }
+
+    func testDetailAffordanceOpensChildWhileParentStaysShown() throws {
+        harness.clickStatusItem()
+        harness.appDelegate.popoverNavigation.panel = .goals
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        harness.clickDetailAffordance(prefix: "goal-detail-")
+
+        XCTAssertTrue(harness.appDelegate.popover.isShown, "opening a detail must not dismiss the main popover")
+        XCTAssertTrue(try XCTUnwrap(harness.appDelegate.detailPopover).isShown)
+    }
+
+    func testClosingParentClosesChildPopover() throws {
+        harness.clickStatusItem()
+        harness.appDelegate.popoverNavigation.panel = .goals
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        harness.clickDetailAffordance(prefix: "goal-detail-")
+        let child = try XCTUnwrap(harness.appDelegate.detailPopover)
+        child.animates = false
+
+        harness.appDelegate.showPopover(.goalsToday)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertFalse(harness.appDelegate.popover.isShown)
+        XCTAssertFalse(child.isShown, "closing the main popover must close its child")
+        XCTAssertNil(harness.appDelegate.detailPopover)
+    }
+
+    func testDifferentDetailAffordanceReanchorsSingleChildPopover() throws {
+        harness.clickStatusItem()
+        harness.appDelegate.popoverNavigation.panel = .goals
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        harness.clickDetailAffordance(prefix: "goal-detail-")
+        let first = try XCTUnwrap(harness.appDelegate.detailPopover)
+        first.animates = false
+
+        harness.clickDetailAffordance(prefix: "schedule-detail-")
+        let second = try XCTUnwrap(harness.appDelegate.detailPopover)
+
+        XCTAssertFalse(first === second)
+        XCTAssertFalse(first.isShown, "re-anchoring must close the previous child")
+        XCTAssertTrue(second.isShown)
+        XCTAssertTrue(harness.appDelegate.popover.isShown)
+    }
+}

--- a/Tests/KajiTests/PopoverRenderTests.swift
+++ b/Tests/KajiTests/PopoverRenderTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import AppKit
+import SwiftUI
+import KajiCore
+@testable import Kaji
+
+/// Renders every popover page to a real bitmap (no XCUITest — see
+/// `Tests/KajiTests/UITestHarness.swift`) and asserts it isn't blank, so a
+/// page that silently renders empty/black doesn't slip through
+/// `swift build` (which only proves the view compiles, not that it draws
+/// anything). PNGs land in `.build/ui-snapshots/<page>.png` for a human/agent
+/// to eyeball.
+@MainActor
+final class PopoverRenderTests: XCTestCase {
+    private static let renderSize = CGSize(width: PanelSize.medium.frameSize.width, height: 640)
+
+    func testEveryModulePageRendersNonBlank() throws {
+        let fixture = PopoverRenderFixture()
+        defer { fixture.tearDown() }
+        for page in KajiModuleID.allCases {
+            let view = fixture.view(page: page, maxContentHeight: Self.renderSize.height)
+            guard let rep = renderImage(view, size: Self.renderSize) else {
+                XCTFail("\(page): failed to render bitmap")
+                continue
+            }
+            writePNG(rep, name: "popover-\(page.rawValue)")
+            assertNonBlank(rep, page: page)
+        }
+    }
+    func testGroupedGoalsPageRendersNonBlank() throws {
+        let fixture = PopoverRenderFixture()
+        defer { fixture.tearDown() }
+        fixture.prefs.goalGrouping = .byTag
+        _ = try fixture.dailyGoals.addGoal(
+            title: "Fixture work goal",
+            tag: GoalTag.work.rawValue,
+            note: "",
+            in: .today
+        )
+        let view = fixture.view(page: .goals, maxContentHeight: Self.renderSize.height)
+        guard let rep = renderImage(view, size: Self.renderSize) else {
+            return XCTFail("grouped goals: failed to render bitmap")
+        }
+        XCTAssertNotNil(writePNG(rep, name: "popover-goals-grouped-by-tag"))
+        assertNonBlank(rep, page: .goals)
+    }
+
+    func testSecondaryDetailPopoverRendersNonBlank() throws {
+        let fixture = PopoverRenderFixture()
+        defer { fixture.tearDown() }
+        let page = fixture.view(page: .goals, maxContentHeight: Self.renderSize.height)
+        let goal = try XCTUnwrap(fixture.dailyGoals.goals(for: .today).first)
+        let detail = page.goalDetailContent(goal, horizon: .today)
+        let rep = try XCTUnwrap(renderImage(detail, size: CGSize(width: 260, height: 180)))
+        let path = try XCTUnwrap(writePNG(rep, name: "popover-secondary-goal-detail"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+        assertNonBlank(rep, page: .goals)
+    }
+
+
+    /// Samples a grid of pixels and requires more than one distinct color —
+    /// a single solid color (all-black, all-white, all-clear) means the view
+    /// drew nothing.
+    private func assertNonBlank(_ rep: NSBitmapImageRep, page: KajiModuleID) {
+        let width = rep.pixelsWide
+        let height = rep.pixelsHigh
+        guard width > 0, height > 0 else {
+            XCTFail("\(page): zero-sized bitmap")
+            return
+        }
+        var seenColors = Set<UInt32>()
+        let stepX = max(1, width / 24)
+        let stepY = max(1, height / 24)
+        var x = 0
+        while x < width {
+            var y = 0
+            while y < height {
+                if let color = rep.colorAt(x: x, y: y) {
+                    let packed = pack(color)
+                    seenColors.insert(packed)
+                }
+                y += stepY
+            }
+            x += stepX
+        }
+        XCTAssertGreaterThan(
+            seenColors.count, 1,
+            "\(page): sampled pixels are all one color (\(seenColors.first.map { String(format: "0x%08X", $0) } ?? "?")) — page rendered blank"
+        )
+    }
+
+    private func pack(_ color: NSColor) -> UInt32 {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return 0 }
+        let r = UInt32(rgb.redComponent * 255)
+        let g = UInt32(rgb.greenComponent * 255)
+        let b = UInt32(rgb.blueComponent * 255)
+        let a = UInt32(rgb.alphaComponent * 255)
+        return (r << 24) | (g << 16) | (b << 8) | a
+    }
+}

--- a/Tests/KajiTests/UITestHarness.swift
+++ b/Tests/KajiTests/UITestHarness.swift
@@ -1,0 +1,380 @@
+import XCTest
+import AppKit
+import ApplicationServices
+import SwiftUI
+@testable import Kaji
+@testable import KajiCore
+
+private func removeResidualTestDefaultsFiles() {
+    guard let preferences = FileManager.default.urls(
+        for: .libraryDirectory, in: .userDomainMask
+    ).first?.appendingPathComponent("Preferences", isDirectory: true),
+          let files = try? FileManager.default.contentsOfDirectory(
+              at: preferences, includingPropertiesForKeys: nil
+          ) else {
+        return
+    }
+    for file in files {
+        let name = file.lastPathComponent
+        if name.hasPrefix("dev.blackblue.Kaji.PopoverRender.")
+            || name.hasPrefix("dev.blackblue.Kaji.UITest.") {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    // cfprefsd can recreate an empty suite plist while the xctest process is
+    // exiting. Remove that filesystem shell after the process has detached.
+    let cleanup = Process()
+    cleanup.executableURL = URL(fileURLWithPath: "/bin/sh")
+    cleanup.arguments = [
+        "-c",
+        "sleep 0.2; rm -f \"$HOME\"/Library/Preferences/dev.blackblue.Kaji.PopoverRender.*.plist \"$HOME\"/Library/Preferences/dev.blackblue.Kaji.UITest.*.plist",
+    ]
+    try? cleanup.run()
+}
+
+private let registerTestDefaultsCleanup: Void = {
+    atexit(removeResidualTestDefaultsFiles)
+}()
+
+private func removeDefaultsSuite(_ defaults: UserDefaults, named suiteName: String) {
+    _ = registerTestDefaultsCleanup
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.synchronize()
+    guard let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+        return
+    }
+    try? FileManager.default.removeItem(
+        at: library.appendingPathComponent("Preferences/\(suiteName).plist")
+    )
+}
+
+/// In-process AppKit/SwiftUI driver for `swift test`. There is no XCUITest
+/// target in this package (SwiftPM can't host one), so this harness boots
+/// the real `AppDelegate` object graph inside the test process: a real
+/// `NSStatusItem`, a real `NSPopover`, and the real `StatusItemView` hosted
+/// on the status item's button.
+///
+/// `clickStatusItem()` does not synthesize an OS-level click. A synthetic
+/// `NSEvent`/`CGEvent` reliably fails to reach a SwiftUI `Button`'s gesture
+/// recognizer from inside a bare `xctest` process outside a real, launched
+/// `.app` bundle (confirmed by direct investigation — AppKit's own
+/// hit-testing resolves correctly, but the gesture never fires). Real
+/// OS-level click coverage against the actual signed `.app` lives in
+/// `scripts/ui-smoke.sh`, not here. Instead, this harness reaches into the
+/// live `StatusItemView` AppKit hosts and invokes its `onQuotaClick`
+/// closure directly — the exact closure `setupStatusItem()` wires to
+/// `showPopover(.quota)` (`AppDelegate.swift`). This still exercises the
+/// real `showPopover` implementation end-to-end; it only skips the
+/// SwiftUI-gesture-recognition step that `ui-smoke.sh` covers separately.
+/// If `setupStatusItem()` ever stops wiring that closure, this reaches a
+/// stale default (`{}`) and every assertion after it fails for real.
+///
+/// The harness gives the real `AppDelegate` a unique `UserDefaults` suite and
+/// temporary cache directory. Production still uses `.standard`; tests never
+/// read or write the app's real defaults domain.
+
+@MainActor
+final class KajiUIHarness {
+    let appDelegate: AppDelegate
+
+    private let suiteName: String
+    private let defaults: UserDefaults
+    private let cacheDirectory: URL
+
+    init() {
+        _ = NSApplication.shared
+        NSApp.setActivationPolicy(.accessory)
+
+        suiteName = "dev.blackblue.Kaji.UITest.\(UUID().uuidString)"
+        guard let isolatedDefaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("failed to create isolated defaults suite")
+        }
+        defaults = isolatedDefaults
+        cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-ui-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+
+        appDelegate = AppDelegate(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            store: QuotaStore(previewProviders: [
+                ProviderView(
+                    id: "claude", mark: "C", displayName: "Fixture Claude",
+                    fiveHourPercent: 24, weekPercent: 42,
+                    resetDate: nil, weekResetDate: nil
+                ),
+            ])
+        )
+        _ = try? appDelegate.dailyGoals.addGoal(
+            title: "Fixture goal",
+            tag: GoalTag.personal.rawValue,
+            note: "Fixture note",
+            in: .today
+        )
+        _ = appDelegate.fixedPlanStore.add(
+            title: "Fixture scheduled goal",
+            tag: GoalTag.personal.rawValue,
+            note: "Fixture schedule note",
+            weekdays: Set(1...7)
+        )
+        appDelegate.applicationDidFinishLaunching(
+            Notification(name: NSApplication.didFinishLaunchingNotification)
+        )
+        // `NSPopover.isShown` only flips to `false` once the close animation
+        // completes (`popover.animates = true` in `AppDelegate.setupPopover()`),
+        // and that completion callback is driven by real screen composition
+        // that a bare `xctest` process off-screen never receives — leaving
+        // `isShown` stuck `true` indefinitely after a real `close()`/
+        // `performClose()` call. Disabling animation makes the state change
+        // synchronous, which is what these tests assert on; it does not
+        // change which code path handles the close.
+        appDelegate.popover.animates = false
+    }
+
+    /// Must be called at the end of every test that constructs a harness:
+    /// closes the popover, stops timers/network stores, removes the real
+    /// `NSStatusItem`, and deletes the isolated defaults/cache world.
+    func tearDown() {
+        if appDelegate.popover?.isShown == true {
+            appDelegate.popover.performClose(nil)
+        }
+        appDelegate.applicationWillTerminate(
+            Notification(name: NSApplication.willTerminateNotification)
+        )
+        if let statusItem = appDelegate.statusItem {
+            NSStatusBar.system.removeStatusItem(statusItem)
+        }
+        removeDefaultsSuite(defaults, named: suiteName)
+        try? FileManager.default.removeItem(at: cacheDirectory)
+    }
+
+    /// Invokes the real click handler the status item's hosted
+    /// `StatusItemView` (`StatusItemView.swift:40`) wires its quota
+    /// `Button` to — the same closure `setupStatusItem()` passes as
+    /// `onQuotaClick` (`AppDelegate.swift`), which calls
+    /// `showPopover(.quota)`. This exercises the real popover-construction
+    /// path end to end; it does not call `showPopover` from the test and
+    /// does not add any test-only hook to `AppDelegate` — it reads the
+    /// closure straight out of the live, currently-hosted SwiftUI view.
+    /// (Real OS-level click delivery is covered separately by
+    /// `scripts/ui-smoke.sh` against the launched `.app` — see the class
+    /// doc comment.)
+    func clickStatusItem() {
+        guard let hostingView = appDelegate.hostingView else {
+            XCTFail("status item hosting view is nil — setupStatusItem() did not run")
+            return
+        }
+        // The private `NSStatusBarWindow` only resolves a real on-screen
+        // frame after a run-loop turn; `showPopover` positions relative to
+        // it, so give AppKit that turn before invoking the handler.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        hostingView.rootView.onQuotaClick()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    func clickDetailAffordance(prefix: String) {
+        guard let root = appDelegate.popover.contentViewController?.view,
+              let button = findButton(prefix: prefix, in: root) else {
+            XCTFail("detail affordance starting with \(prefix) not found in popover")
+            return
+        }
+        button.performClick(nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    private func findButton(prefix: String, in view: NSView) -> NSButton? {
+        if let button = view as? NSButton,
+           button.identifier?.rawValue.hasPrefix(prefix) == true {
+            return button
+        }
+        for subview in view.subviews {
+            if let button = findButton(prefix: prefix, in: subview) {
+                return button
+            }
+        }
+        return nil
+    }
+
+}
+
+/// Renders any SwiftUI `View` to a bitmap via a real `NSHostingView` — the
+/// same mechanism `AppDelegate.makePopoverContentController` uses for the
+/// live popover.
+@MainActor
+func renderImage<V: View>(_ view: V, size: CGSize) -> NSBitmapImageRep? {
+    let hosting = NSHostingView(rootView: view)
+    hosting.frame = NSRect(origin: .zero, size: size)
+    // SwiftUI only fully realizes a hosted view's content (text layout,
+    // @ObservedObject-driven page switching, environment values) once it is
+    // part of a real window — an unparented `NSHostingView` can render a
+    // stale/placeholder frame. Host it in an offscreen, never-ordered-front
+    // window (never shown on screen, so this is safe to run in any
+    // `swift test` session).
+    let window = NSWindow(
+        contentRect: NSRect(origin: .zero, size: size),
+        styleMask: [.borderless],
+        backing: .buffered,
+        defer: false
+    )
+    window.contentView = hosting
+    window.isReleasedWhenClosed = false
+    hosting.layoutSubtreeIfNeeded()
+    RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    hosting.layoutSubtreeIfNeeded()
+    guard let rep = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {
+        window.close()
+        return nil
+    }
+    hosting.cacheDisplay(in: hosting.bounds, to: rep)
+    window.close()
+    return rep
+}
+
+/// Writes a PNG artifact to `.build/ui-snapshots/<name>.png` for human/agent
+/// inspection. Returns the path written, or nil on failure.
+@discardableResult
+func writePNG(_ rep: NSBitmapImageRep, name: String) -> URL? {
+    guard let data = rep.representation(using: .png, properties: [:]) else { return nil }
+    let dir = URL(fileURLWithPath: ".build/ui-snapshots", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("\(name).png")
+    do {
+        try data.write(to: url)
+        return url
+    } catch {
+        XCTFail("failed to write PNG \(url.path): \(error)")
+        return nil
+    }
+}
+
+/// Independent, fresh object graph for rendering `KajiPopoverView` pages.
+/// Deliberately decoupled from `AppDelegate`'s (still-private) stores —
+/// `AppDelegate`'s visibility was only widened for the status-item/popover
+/// surface the click tests need, not for every store it owns. Rendering a
+/// page only needs *some* real, correctly-typed store graph, not the live
+/// app's specific instances.
+@MainActor
+final class PopoverRenderFixture {
+    let store: QuotaStore
+    let prefs: Prefs
+    let workSession: WorkSessionController
+    let systemMonitor = SystemMonitor()
+    let dailyGoals: DailyGoalStore
+    let fixedPlanStore: FixedPlanStore
+    let aiNewsStore: AIHotNewsStore
+    let mailBriefStore: MailBriefStore
+    let navigation = PopoverNavigation()
+
+    private let suiteName: String
+    private let defaults: UserDefaults
+    private let cacheDirectory: URL
+
+    init() {
+        suiteName = "dev.blackblue.Kaji.PopoverRender.\(UUID().uuidString)"
+        guard let isolatedDefaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("failed to create isolated defaults suite")
+        }
+        defaults = isolatedDefaults
+        cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-popover-render-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+
+        prefs = Prefs(defaults: defaults)
+        dailyGoals = DailyGoalStore(defaults: defaults)
+        defaults.set(
+            try? JSONEncoder().encode([ScheduledGoal]()),
+            forKey: FixedPlanStore.schedulesPersistenceKey
+        )
+        fixedPlanStore = FixedPlanStore(defaults: defaults)
+        store = QuotaStore(
+            previewProviders: [
+                ProviderView(
+                    id: "claude", mark: "C", displayName: "Fixture Claude",
+                    fiveHourPercent: 24, weekPercent: 42,
+                    resetDate: Date(timeIntervalSince1970: 1_900_000_000),
+                    weekResetDate: Date(timeIntervalSince1970: 1_900_086_400)
+                ),
+            ],
+            updated: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        aiNewsStore = AIHotNewsStore(
+            previewTopics: [
+                AIHotTopic(
+                    rank: 1, id: "fixture-ai-topic", title: "Fixture AI headline",
+                    sourceName: "Fixture Source", sourceCount: 1, signalCount: 1,
+                    sourceNames: ["Fixture Source"],
+                    latestAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    aiHotURL: URL(string: "https://example.invalid/fixture-ai")!,
+                    originalURL: URL(string: "https://example.invalid/fixture-source")!,
+                    storyPublicID: nil
+                ),
+            ],
+            cacheURL: cacheDirectory.appendingPathComponent("ai-news-cache-v1.json")
+        )
+        mailBriefStore = MailBriefStore(
+            previewGeneration: MailBriefGeneration(
+                generationID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+                briefDay: "2026-01-01",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                entries: [
+                    MailBriefEntry(
+                        threadID: "fixture-mail", subject: "Fixture mail subject",
+                        sender: "Fixture Sender", gmailURL: nil, level: 2, bucket: .act,
+                        summaryZH: "Fixture mail summary", reasonZH: "Fixture mail reason",
+                        suggestedAction: .reply, deadline: nil, confidence: .high,
+                        goalTitleZH: nil
+                    ),
+                ],
+                snapshotInboxThreadCount: 1
+            ),
+            cacheDirectory: cacheDirectory
+        )
+        workSession = WorkSessionController(prefs: prefs)
+        prefs.enabledModules = Set(KajiModuleID.allCases)
+        _ = try? dailyGoals.addGoal(
+            title: "Fixture goal", tag: GoalTag.personal.rawValue, note: "Fixture note",
+            in: .today
+        )
+        _ = fixedPlanStore.add(
+            title: "Fixture scheduled goal", tag: GoalTag.personal.rawValue,
+            note: "Fixture schedule note", weekdays: Set(1...7)
+        )
+    }
+
+    func tearDown() {
+        aiNewsStore.stop()
+        mailBriefStore.stop()
+        removeDefaultsSuite(defaults, named: suiteName)
+        try? FileManager.default.removeItem(at: cacheDirectory)
+    }
+
+    func view(
+        page: KajiModuleID,
+        maxContentHeight: CGFloat = 640,
+        onShowDetail: @escaping (NSView, AnyView) -> Void = { _, _ in }
+    ) -> KajiPopoverView {
+        navigation.panel = page
+        if page == .goals {
+            navigation.goalHorizon = .today
+        }
+        return KajiPopoverView(
+            store: store,
+            prefs: prefs,
+            workSession: workSession,
+            systemMonitor: systemMonitor,
+            dailyGoals: dailyGoals,
+            fixedPlanStore: fixedPlanStore,
+            aiNewsStore: aiNewsStore,
+            mailBriefStore: mailBriefStore,
+            navigation: navigation,
+            controls: KajiPopoverControls(
+                onOpenSettings: {},
+                onQuit: {},
+                onShowDetail: onShowDetail
+            ),
+            maxContentHeight: maxContentHeight,
+            onContentSizeChange: { _ in }
+        )
+    }
+}

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACTS="$ROOT/.build/ui-smoke"
+HELPER="$ARTIFACTS/ui-smoke-helper"
+APP_EXECUTABLE="$ROOT/dist/Kaji.app/Contents/MacOS/Kaji"
+KAJI_PID=""
+PREFS_DOMAIN="dev.kaji"
+
+# The smoke run also exercises page navigation, which only renders header
+# chevrons when more than one module is enabled (KajiPopoverView.header).
+# We never write to the app's real `defaults` domain to get there — a crash
+# or `kill -9` mid-run would leave the user's real dev.kaji preferences
+# stuck in test state, which is exactly the pollution we're trying to avoid.
+# Instead we pass `-key value` command-line arguments, which macOS populates
+# into `NSArgumentDomain` — the highest-priority, read-only, never-persisted
+# UserDefaults search layer (see `man defaults`/`NSUserDefaults` "argument
+# domain"). Confirmed empirically with a standalone Foundation binary: an
+# arg of `-enabledModules '(quota, work, goals)'` is readable via
+# `UserDefaults.standard.array(forKey:)` with zero effect on the on-disk
+# domain. `language` is pinned to `en` the same way so panelTitle assertions
+# are deterministic regardless of what this machine's Kaji has persisted.
+#
+# mailBrief is included below: MailBriefCredentialStore's keychain probe was
+# fixed to use kSecUseAuthenticationUIFail / LAContext noninteractive reads
+# and to fall back to "not connected" instead of surfacing a system prompt
+# on an ACL mismatch (with a one-shot v3 ACL migration). The
+# `no-system-auth-prompt` assertion in ui-smoke.swift, exercised across the
+# popover's Mail Brief page and the Settings > Mail Brief page, is the
+# regression test for that fix — if it ever starts failing, that is a real
+# regression, not a reason to re-exclude mailBrief from this list.
+SEED_MODULES=(quota work goals aiNews mailBrief)
+SEED_LANGUAGE=en
+EXPECTED_PAGE_TITLES="Quota|Work / Break|Goals|AI News|Mail Brief"
+
+# Old-style property-list array literal, e.g. "(quota, work, goals, aiNews)" —
+# the format NSArgumentDomain parsing accepts for array-typed arguments.
+seed_modules_plist_array() {
+    local joined
+    joined=$(printf '%s, ' "${SEED_MODULES[@]}")
+    printf '(%s)' "${joined%, }"
+}
+
+cleanup() {
+    if [[ -n "$KAJI_PID" ]] && kill -0 "$KAJI_PID" 2>/dev/null; then
+        kill "$KAJI_PID" 2>/dev/null || true
+        wait "$KAJI_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$ARTIFACTS"
+rm -f "$ARTIFACTS"/*.png "$HELPER"
+
+# Proof that this run never persists into the user's real preferences
+# domain. The whole-domain md5 is diagnostic only: DailyGoalStore /
+# FixedPlanStore re-encode their own JSON-blob keys (scheduledGoalsV1,
+# scheduledGoalCompletionV1, ...) via JSONEncoder on every single launch —
+# same content, non-deterministic Codable field order — independent of
+# anything this script does (a plain `open dist/Kaji.app` triggers the same
+# diff). What this script must never move is the two keys it could have
+# seeded via `defaults write`: enabledModules and language. Those are
+# checked for byte-for-byte equality below and fail the run if touched.
+PREFS_MD5_BEFORE=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
+PREFS_ENABLED_BEFORE=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
+PREFS_LANGUAGE_BEFORE=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
+
+
+printf '%s\n' 'UI-SMOKE build: ./scripts/build-app.sh'
+"$ROOT/scripts/build-app.sh"
+
+printf '%s\n' 'UI-SMOKE helper: compiling ad-hoc local verifier'
+swiftc "$ROOT/scripts/ui-smoke.swift" -o "$HELPER"
+codesign --force --sign - "$HELPER" >/dev/null
+
+# The smoke run owns the only Kaji instance so AX lookup and window ownership
+# cannot accidentally target an installed or previously launched copy.
+pkill -x Kaji 2>/dev/null || true
+for _ in {1..50}; do
+    pgrep -x Kaji >/dev/null 2>&1 || break
+    sleep 0.1
+done
+if pgrep -x Kaji >/dev/null 2>&1; then
+    printf '%s\n' 'UI-SMOKE FAIL: stale Kaji process did not terminate' >&2
+    exit 1
+fi
+
+printf '%s\n' 'UI-SMOKE launch: dist/Kaji.app'
+"$APP_EXECUTABLE" \
+    -enabledModules "$(seed_modules_plist_array)" \
+    -language "$SEED_LANGUAGE" \
+    >"$ARTIFACTS/kaji.stdout.log" 2>"$ARTIFACTS/kaji.stderr.log" &
+KAJI_PID=$!
+
+if ! kill -0 "$KAJI_PID" 2>/dev/null; then
+    printf 'UI-SMOKE FAIL: Kaji exited during launch; inspect %s\n' "$ARTIFACTS/kaji.stderr.log" >&2
+    exit 1
+fi
+
+"$HELPER" "$KAJI_PID" "$ARTIFACTS" "$EXPECTED_PAGE_TITLES"
+
+PREFS_MD5_AFTER=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
+PREFS_ENABLED_AFTER=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
+PREFS_LANGUAGE_AFTER=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
+
+if [[ "$PREFS_ENABLED_BEFORE" != "$PREFS_ENABLED_AFTER" || "$PREFS_LANGUAGE_BEFORE" != "$PREFS_LANGUAGE_AFTER" ]]; then
+    printf 'UI-SMOKE FAIL: dev.kaji enabledModules/language were persisted by this run — the NSArgumentDomain seed must never touch disk\n' >&2
+    printf '  enabledModules before: %s\n' "$PREFS_ENABLED_BEFORE" >&2
+    printf '  enabledModules after:  %s\n' "$PREFS_ENABLED_AFTER" >&2
+    printf '  language before: %s\n' "$PREFS_LANGUAGE_BEFORE" >&2
+    printf '  language after:  %s\n' "$PREFS_LANGUAGE_AFTER" >&2
+    exit 1
+fi
+printf 'UI-SMOKE: dev.kaji enabledModules and language are byte-for-byte unchanged (enabledModules=%s language=%s)\n' \
+    "$PREFS_ENABLED_AFTER" "$PREFS_LANGUAGE_AFTER"
+
+if [[ "$PREFS_MD5_BEFORE" != "$PREFS_MD5_AFTER" ]]; then
+    printf 'UI-SMOKE: dev.kaji whole-domain md5 changed (before=%s after=%s) — expected: DailyGoalStore/FixedPlanStore re-encode their own JSON-blob keys with non-deterministic Codable field order on every Kaji launch, independent of this script (a plain `open dist/Kaji.app` reproduces the same diff). Not a regression in this harness; enabledModules/language above are the keys this script could pollute, and they are unchanged.\n' \
+        "$PREFS_MD5_BEFORE" "$PREFS_MD5_AFTER"
+else
+    printf 'UI-SMOKE: dev.kaji preferences domain byte-for-byte unchanged (md5 %s)\n' "$PREFS_MD5_AFTER"
+fi
+
+
+printf 'UI-SMOKE PASS: menu-bar popover opened/closed, AX content verified, page navigation verified; artifacts: %s\n' "$ARTIFACTS"

--- a/scripts/ui-smoke.swift
+++ b/scripts/ui-smoke.swift
@@ -1,0 +1,452 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+struct WindowSnapshot {
+    let id: CGWindowID
+    let bounds: CGRect
+}
+
+enum SmokeError: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let text): return text
+        }
+    }
+}
+
+struct AXElementInfo {
+    let role: String
+    let text: String
+    let identifier: String?
+    let bounds: CGRect?
+}
+
+func stringAttribute(_ element: AXUIElement, _ name: CFString) -> String? {
+    guard let raw = attribute(element, name) else { return nil }
+    if CFGetTypeID(raw) == CFStringGetTypeID() {
+        return unsafeBitCast(raw, to: CFString.self) as String
+    }
+    return nil
+}
+
+/// NSPopover's backing panel is a nonactivating borderless window; for an
+/// `.accessory`-policy (LSUIElement) app like Kaji it is never listed under
+/// the application element's `kAXWindowsAttribute` (confirmed empirically —
+/// that attribute reports 0 windows while the popover is open). The
+/// reliable way in is a system-wide hit-test at a point inside the
+/// CGWindow's bounds, then reading `kAXWindowAttribute` off whatever was
+/// hit to climb to the enclosing window element (role `AXPopover`).
+func findAXWindow(pid: pid_t, matching target: CGRect) -> AXUIElement? {
+    let systemWide = AXUIElementCreateSystemWide()
+    let point = CGPoint(x: target.midX, y: target.midY)
+    var hit: AXUIElement?
+    guard AXUIElementCopyElementAtPosition(systemWide, Float(point.x), Float(point.y), &hit) == .success,
+          let hit else { return nil }
+    var ownerPID: pid_t = 0
+    AXUIElementGetPid(hit, &ownerPID)
+    guard ownerPID == pid else { return nil }
+    if let raw = attribute(hit, kAXWindowAttribute as CFString), CFGetTypeID(raw) == AXUIElementGetTypeID() {
+        return unsafeBitCast(raw, to: AXUIElement.self)
+    }
+    // The hit element itself may already be the window/popover root.
+    if let role = attribute(hit, kAXRoleAttribute as CFString) as? String,
+       role == kAXWindowRole as String || role == "AXPopover" {
+        return hit
+    }
+    return nil
+}
+
+/// Depth-first walk collecting every element's role/text/identifier/bounds.
+/// Depth and node counts are capped so a runaway SwiftUI tree cannot hang
+/// the smoke run.
+func collectAXElements(_ element: AXUIElement, depth: Int = 0, budget: inout Int) -> [AXElementInfo] {
+    guard depth < 40, budget > 0 else { return [] }
+    budget -= 1
+    let role = (attribute(element, kAXRoleAttribute as CFString) as? String)
+        ?? stringAttribute(element, kAXRoleAttribute as CFString)
+        ?? "?"
+    let title = stringAttribute(element, kAXTitleAttribute as CFString) ?? ""
+    let value = stringAttribute(element, kAXValueAttribute as CFString) ?? ""
+    let description = stringAttribute(element, kAXDescriptionAttribute as CFString) ?? ""
+    let text = [title, value, description].first(where: { !$0.isEmpty }) ?? ""
+    let identifier = stringAttribute(element, kAXIdentifierAttribute as CFString)
+    var own = [AXElementInfo(role: role, text: text, identifier: identifier, bounds: bounds(of: element))]
+    for child in children(of: element) {
+        own.append(contentsOf: collectAXElements(child, depth: depth + 1, budget: &budget))
+    }
+    return own
+}
+
+func dumpAXElements(_ elements: [AXElementInfo]) {
+    for info in elements where !info.text.isEmpty || info.role == "AXButton" {
+        let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
+        let idText = info.identifier ?? "-"
+        print("AX-DUMP role=\(info.role) text=\"\(info.text)\" id=\(idText) bounds=\(boundsText)")
+    }
+}
+
+/// macOS surfaces real Keychain/credential prompts as separate on-screen
+/// windows owned by system agent processes, never by the app itself — this
+/// is the acceptance signal for "permission asks once, never again":
+/// scan every on-screen window (not just Kaji's) for one owned by any of
+/// these processes. Overridable via KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS
+/// (comma-separated) purely so this script can prove the assertion truly
+/// fires (see the failure-injection run in the task write-up); the real
+/// default set is fixed.
+func systemAuthPromptOwnerNames() -> Set<String> {
+    if let override = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS"] {
+        return Set(override.split(separator: ",").map(String.init))
+    }
+    return ["SecurityAgent", "loginwindow", "coreauthd", "UserNotificationCenter"]
+}
+
+struct SystemAuthPromptWindow: CustomStringConvertible {
+    let ownerName: String
+    let ownerPID: pid_t
+    let title: String
+    var description: String { "owner=\(ownerName) pid=\(ownerPID) title=\"\(title)\"" }
+}
+
+func systemAuthPromptWindows() -> [SystemAuthPromptWindow] {
+    let owners = systemAuthPromptOwnerNames()
+    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+            as? [[String: Any]] else { return [] }
+    return raw.compactMap { info in
+        guard let ownerName = info[kCGWindowOwnerName as String] as? String, owners.contains(ownerName),
+              let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value else { return nil }
+        let title = info[kCGWindowName as String] as? String ?? ""
+        return SystemAuthPromptWindow(ownerName: ownerName, ownerPID: ownerPID, title: title)
+    }
+}
+
+/// Call after every action that could plausibly trigger a Keychain/credential
+/// prompt. Throws (and screenshots) the instant one is seen — checked at
+/// every popover-page transition, every Settings-page transition, and
+/// before/after opening Settings, so the whole click-through is covered.
+var authPromptCheckCount = 0
+func checkNoSystemAuthPrompt(_ context: String, artifacts: String) throws {
+    authPromptCheckCount += 1
+    let found = systemAuthPromptWindows()
+    guard found.isEmpty else {
+        capture("\(artifacts)/system-auth-prompt-failure.png")
+        throw SmokeError.message("ASSERT no-system-auth-prompt: FAIL a system authorization window appeared during \"\(context)\": \(found.map(\.description).joined(separator: "; "))")
+    }
+}
+
+/// Header chevrons are 30x30 icon-only buttons (see KajiPopoverView.arrow);
+/// distinguish them from the (30x28) footer icon buttons by requiring the
+/// button sit within the popover's top ~44pt, where the header row lives.
+func pageArrowButtons(in elements: [AXElementInfo], windowTop: CGFloat) -> [AXElementInfo] {
+    elements.filter { info in
+        guard info.role == "AXButton", let rect = info.bounds else { return false }
+        return rect.width >= 28 && rect.width <= 32 && rect.height >= 28 && rect.height <= 32
+            && rect.minY - windowTop < 44
+    }.sorted { ($0.bounds?.minX ?? 0) < ($1.bounds?.minX ?? 0) }
+}
+
+func attribute(_ element: AXUIElement, _ name: CFString) -> CFTypeRef? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, name, &value) == .success else { return nil }
+    return value
+}
+
+func children(of element: AXUIElement) -> [AXUIElement] {
+    guard let raw = attribute(element, kAXChildrenAttribute as CFString),
+          CFGetTypeID(raw) == CFArrayGetTypeID() else { return [] }
+    let array = unsafeBitCast(raw, to: CFArray.self)
+    return (0..<CFArrayGetCount(array)).map {
+        unsafeBitCast(CFArrayGetValueAtIndex(array, $0), to: AXUIElement.self)
+    }
+}
+
+func bounds(of element: AXUIElement) -> CGRect? {
+    guard let rawPosition = attribute(element, kAXPositionAttribute as CFString),
+          CFGetTypeID(rawPosition) == AXValueGetTypeID(),
+          let rawSize = attribute(element, kAXSizeAttribute as CFString),
+          CFGetTypeID(rawSize) == AXValueGetTypeID() else { return nil }
+    let positionValue = unsafeBitCast(rawPosition, to: AXValue.self)
+    let sizeValue = unsafeBitCast(rawSize, to: AXValue.self)
+    var position = CGPoint.zero
+    var size = CGSize.zero
+    guard AXValueGetValue(positionValue, .cgPoint, &position),
+          AXValueGetValue(sizeValue, .cgSize, &size),
+          size.width > 0, size.height > 0 else { return nil }
+    return CGRect(origin: position, size: size)
+}
+
+func isMainMenuBarBounds(_ rect: CGRect) -> Bool {
+    let mainFrame = CGDisplayBounds(CGMainDisplayID())
+    return rect.width > 0 && rect.height > 0 &&
+        rect.minX >= mainFrame.minX && rect.maxX <= mainFrame.maxX &&
+        rect.minY >= mainFrame.minY && rect.minY <= mainFrame.minY + 40
+}
+
+func statusItemBounds(pid: pid_t) -> CGRect? {
+    let application = AXUIElementCreateApplication(pid)
+    guard let rawMenuBar = attribute(application, kAXExtrasMenuBarAttribute as CFString)
+            ?? attribute(application, kAXMenuBarAttribute as CFString),
+          CFGetTypeID(rawMenuBar) == AXUIElementGetTypeID() else {
+        return nil
+    }
+    let menuBar = unsafeBitCast(rawMenuBar, to: AXUIElement.self)
+    for child in children(of: menuBar) {
+        guard let role = attribute(child, kAXRoleAttribute as CFString) as? String,
+              role == kAXMenuBarItemRole as String else { continue }
+        return bounds(of: child)
+    }
+    return nil
+}
+
+func windows(pid: pid_t) -> [WindowSnapshot] {
+    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+            as? [[String: Any]] else { return [] }
+    return raw.compactMap { info in
+        guard let ownerPID = info[kCGWindowOwnerPID as String] as? NSNumber,
+              ownerPID.int32Value == pid,
+              let number = info[kCGWindowNumber as String] as? NSNumber,
+              let boundsObject = info[kCGWindowBounds as String] as? NSDictionary else { return nil }
+        let boundsDictionary = unsafeBitCast(boundsObject, to: CFDictionary.self)
+        guard let bounds = CGRect(dictionaryRepresentation: boundsDictionary) else { return nil }
+        return WindowSnapshot(id: CGWindowID(number.uint32Value), bounds: bounds)
+    }
+}
+
+func popoverWindow(in snapshots: [WindowSnapshot], excluding ids: Set<CGWindowID> = []) -> WindowSnapshot? {
+    snapshots.first {
+        !ids.contains($0.id) &&
+        $0.bounds.width >= 180 && $0.bounds.width <= 700 &&
+        $0.bounds.height >= 100 && $0.bounds.height <= 1_200
+    }
+}
+
+func wait<T>(timeout: TimeInterval, interval: TimeInterval = 0.1, for value: () -> T?) -> T? {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+        if let result = value() { return result }
+        Thread.sleep(forTimeInterval: interval)
+    } while Date() < deadline
+    return nil
+}
+
+func click(_ point: CGPoint) throws {
+    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
+                             mouseCursorPosition: point, mouseButton: .left),
+          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
+                           mouseCursorPosition: point, mouseButton: .left) else {
+        throw SmokeError.message("could not create CGEvent mouse events")
+    }
+    down.post(tap: .cghidEventTap)
+    Thread.sleep(forTimeInterval: 0.08)
+    up.post(tap: .cghidEventTap)
+}
+
+func capture(_ path: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+    process.arguments = ["-x", path]
+    try? process.run()
+    process.waitUntilExit()
+}
+
+func run() throws {
+    guard CommandLine.arguments.count == 4, let pid = pid_t(CommandLine.arguments[1]) else {
+        throw SmokeError.message("usage: ui-smoke.swift <pid> <artifact-directory> <expected-page-titles-pipe-separated>")
+    }
+    let artifacts = CommandLine.arguments[2]
+    let expectedPageTitles = CommandLine.arguments[3].split(separator: "|").map(String.init)
+
+    guard AXIsProcessTrusted() else {
+        throw SmokeError.message("Accessibility permission is missing. Enable System Settings > Privacy & Security > Accessibility for your terminal (or the agent host running this script), then rerun ./scripts/ui-smoke.sh")
+    }
+
+    let mainFrame = CGDisplayBounds(CGMainDisplayID())
+    let mainCenter = CGPoint(x: mainFrame.midX, y: mainFrame.midY)
+    CGWarpMouseCursorPosition(mainCenter)
+    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
+            mouseCursorPosition: mainCenter, mouseButton: .left)?.post(tap: .cghidEventTap)
+    Thread.sleep(forTimeInterval: 0.5)
+
+    guard let initialBounds = wait(timeout: 10, for: { () -> CGRect? in
+        guard let candidate = statusItemBounds(pid: pid), isMainMenuBarBounds(candidate) else { return nil }
+        return candidate
+    }) else {
+        throw SmokeError.message("Kaji status item did not expose stable AX bounds on the main menu bar within 10 seconds")
+    }
+    print("ASSERT status-item: PASS bounds=\(Int(initialBounds.minX)),\(Int(initialBounds.minY)) \(Int(initialBounds.width))x\(Int(initialBounds.height))")
+    Thread.sleep(forTimeInterval: 0.3)
+
+    let baselineIDs = Set(windows(pid: pid).map(\.id))
+    let openPoint = CGPoint(x: initialBounds.minX + min(12, initialBounds.width / 2), y: initialBounds.midY)
+    if ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_SKIP_CLICK"] == nil {
+        try click(openPoint)
+    }
+
+    guard let opened = wait(timeout: 3, for: {
+        popoverWindow(in: windows(pid: pid), excluding: baselineIDs)
+    }) else {
+        capture("\(artifacts)/open-failure.png")
+        throw SmokeError.message("ASSERT click-opens-popover: FAIL no popover-sized Kaji window appeared within 3 seconds")
+    }
+    capture("\(artifacts)/open.png")
+    print("ASSERT click-opens-popover: PASS window=\(opened.id) size=\(Int(opened.bounds.width))x\(Int(opened.bounds.height))")
+    try checkNoSystemAuthPrompt("popover opened", artifacts: artifacts)
+
+    // Re-hit-test on every read instead of holding one AXUIElement handle:
+    // resizing the popover for a different page can tear down and rebuild
+    // its AX backing objects, which would make a cached handle go stale.
+    func popoverElements() throws -> [AXElementInfo] {
+        guard let currentWindow = windows(pid: pid).first(where: { $0.id == opened.id })
+                ?? popoverWindow(in: windows(pid: pid)),
+              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
+            throw SmokeError.message("ASSERT ax-popover-tree: FAIL could not locate the popover's AXUIElement window via system-wide hit-test")
+        }
+        var budget = 4000
+        return collectAXElements(element, budget: &budget)
+    }
+
+    var elements = try popoverElements()
+    print("ASSERT ax-popover-tree: PASS discovered \(elements.count) AX nodes")
+    dumpAXElements(elements)
+
+    let expectedQuotaTitle = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_EXPECT_QUOTA_TITLE"] ?? "Quota"
+    guard elements.contains(where: { $0.role == "AXStaticText" && $0.text == expectedQuotaTitle }) else {
+        capture("\(artifacts)/ax-quota-page-failure.png")
+        let observedTexts = elements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text)
+        throw SmokeError.message("ASSERT ax-quota-page: FAIL expected an AXStaticText titled \"\(expectedQuotaTitle)\"; observed static text: \(observedTexts)")
+    }
+    print("ASSERT ax-quota-page: PASS found AXStaticText \"\(expectedQuotaTitle)\"")
+
+    if expectedPageTitles.count > 1 {
+        let windowTop = opened.bounds.minY
+        var sequence = [expectedPageTitles[0]]
+        for step in 0..<expectedPageTitles.count {
+            elements = try popoverElements()
+            let arrows = pageArrowButtons(in: elements, windowTop: windowTop)
+            guard arrows.count == 2, let nextArrow = arrows.last, let nextBounds = nextArrow.bounds else {
+                capture("\(artifacts)/ax-page-nav-failure.png")
+                let candidateButtons = elements.filter { $0.role == "AXButton" }
+                throw SmokeError.message("""
+                    ASSERT ax-page-nav: FAIL expected exactly 2 header chevron buttons \
+                    (30x30 icon-only AXButton within the popover's top 44pt); found \(arrows.count). \
+                    All AXButton nodes seen: \(candidateButtons). \
+                    The chevrons carry no AXTitle/AXDescription/AXIdentifier, so if this heuristic \
+                    ever stops matching, the fix is accessibility identifiers in Sources/Kaji/KajiPopoverView.swift: \
+                    add .accessibilityIdentifier("kaji.popover.page.prev") / ("kaji.popover.page.next") to the \
+                    two Button closures built by `arrow(_:action:)` (used for chevron.left / chevron.right in `header`), \
+                    plus .accessibilityIdentifier("kaji.popover.title") on the `Text(panelTitle)` header line, and \
+                    root-level identifiers ("kaji.popover.panel.quota" / ".work" / ".system" / ".goals" / ".aiNews" / \
+                    ".mailBrief") on each case of `panelBody` for reliable per-page content assertions.
+                    """)
+            }
+            let center = CGPoint(x: nextBounds.midX, y: nextBounds.midY)
+            try click(center)
+            let expected = expectedPageTitles[(step + 1) % expectedPageTitles.count]
+            guard wait(timeout: 2, for: { () -> Bool? in
+                (try? popoverElements())?.contains(where: { $0.role == "AXStaticText" && $0.text == expected }) == true ? true : nil
+            }) != nil else {
+                capture("\(artifacts)/ax-page-nav-failure.png")
+                let observedTexts = (try? popoverElements())?.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text) ?? []
+                throw SmokeError.message("ASSERT ax-page-nav: FAIL clicking the next-page chevron did not surface header title \"\(expected)\"; observed static text: \(observedTexts)")
+            }
+            sequence.append(expected)
+            try checkNoSystemAuthPrompt("popover page \(expected)", artifacts: artifacts)
+        }
+        print("ASSERT ax-page-nav: PASS clicked through pages in order \(sequence.joined(separator: " -> "))")
+    } else {
+        print("ASSERT ax-page-nav: SKIP only \(expectedPageTitles.count) page(s) enabled; header chevrons are hidden (pages.count > 1 gate in KajiPopoverView.header)")
+    }
+
+    // Settings walk: click gearshape in the popover footer, then click every
+    // sidebar section and assert the visible content actually changes.
+    // Mail Brief is the highest-risk page for this run — it's the module
+    // whose credential lookup used to pop a live Keychain prompt.
+    //
+    // Re-fetch elements: the page-nav loop's last read is one click stale
+    // (captured before the click back to the wrap-around page), and footer
+    // buttons shift vertically with popover height, so a stale bounds would
+    // miss the real button.
+    elements = try popoverElements()
+    let settingsButton = elements.first { $0.role == "AXButton" && $0.identifier == "gearshape" }
+    guard let settingsButton, let settingsButtonBounds = settingsButton.bounds else {
+        capture("\(artifacts)/settings-open-failure.png")
+        throw SmokeError.message("ASSERT settings-opens: FAIL no AXButton with identifier \"gearshape\" found in the popover footer; AXButtons seen: \(elements.filter { $0.role == "AXButton" })")
+    }
+    let settingsBaselineIDs = Set(windows(pid: pid).map(\.id))
+    try click(CGPoint(x: settingsButtonBounds.midX, y: settingsButtonBounds.midY))
+
+    guard let settingsWindow = wait(timeout: 3, for: { () -> WindowSnapshot? in
+        windows(pid: pid).first { !settingsBaselineIDs.contains($0.id) && $0.bounds.width >= 500 && $0.bounds.height >= 300 }
+    }) else {
+        capture("\(artifacts)/settings-open-failure.png")
+        throw SmokeError.message("ASSERT settings-opens: FAIL no Settings-sized (>=500x300) Kaji window appeared within 3 seconds of clicking gearshape")
+    }
+    print("ASSERT settings-opens: PASS window=\(settingsWindow.id) size=\(Int(settingsWindow.bounds.width))x\(Int(settingsWindow.bounds.height))")
+    try checkNoSystemAuthPrompt("settings opened", artifacts: artifacts)
+
+    func settingsElements() throws -> [AXElementInfo] {
+        guard let currentWindow = windows(pid: pid).first(where: { $0.id == settingsWindow.id }),
+              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
+            throw SmokeError.message("ASSERT settings-nav: FAIL could not locate the Settings AXUIElement window via system-wide hit-test")
+        }
+        var budget = 4000
+        return collectAXElements(element, budget: &budget)
+    }
+
+    let settingsSections = ["General", "Modules", "Work", "Goals", "Quota", "AI News", "Mail Brief", "MCP"]
+    var previousSignature: Set<String>? = nil
+    for (index, section) in settingsSections.enumerated() {
+        if index > 0 {
+            let currentElements = try settingsElements()
+            guard let row = currentElements.first(where: { $0.role == "AXStaticText" && $0.text == section }),
+                  let rowBounds = row.bounds else {
+                capture("\(artifacts)/settings-nav-failure.png")
+                throw SmokeError.message("ASSERT settings-nav: FAIL no sidebar row titled \"\(section)\" found in the Settings AX tree; static text seen: \(currentElements.filter { $0.role == "AXStaticText" }.map(\.text))")
+            }
+            try click(CGPoint(x: rowBounds.midX, y: rowBounds.midY))
+        }
+        Thread.sleep(forTimeInterval: 1.0)
+        let pageElements = try settingsElements()
+        let signature = Set(pageElements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text))
+        print("AX-DUMP [Settings:\(section)] discovered \(pageElements.count) nodes")
+        for info in pageElements where !info.text.isEmpty {
+            let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
+            print("AX-DUMP [Settings:\(section)] role=\(info.role) text=\"\(info.text)\" bounds=\(boundsText)")
+        }
+        try checkNoSystemAuthPrompt("settings section \(section)", artifacts: artifacts)
+        if let previousSignature, index > 0 {
+            guard signature != previousSignature else {
+                capture("\(artifacts)/settings-nav-failure.png")
+                throw SmokeError.message("ASSERT settings-nav: FAIL clicking sidebar row \"\(section)\" did not change the visible content; static text stayed: \(signature.sorted())")
+            }
+        }
+        previousSignature = signature
+    }
+    print("ASSERT settings-nav: PASS walked \(settingsSections.count) sidebar sections, content changed on every click")
+    print("ASSERT no-system-auth-prompt: PASS checked \(authPromptCheckCount) times, no system authorization window ever appeared")
+
+
+    guard let refreshedBounds = statusItemBounds(pid: pid) else {
+        throw SmokeError.message("ASSERT click-closes-popover: FAIL could not refresh status-item AX bounds")
+    }
+    let closePoint = CGPoint(x: refreshedBounds.minX + min(12, refreshedBounds.width / 2), y: refreshedBounds.midY)
+    try click(closePoint)
+
+    guard wait(timeout: 3, for: {
+        windows(pid: pid).contains(where: { $0.id == opened.id }) ? nil : true
+    }) != nil else {
+        capture("\(artifacts)/close-failure.png")
+        throw SmokeError.message("ASSERT click-closes-popover: FAIL popover window \(opened.id) remained on screen after second click")
+    }
+    capture("\(artifacts)/closed.png")
+    print("ASSERT click-closes-popover: PASS window=\(opened.id) disappeared")
+}
+
+do {
+    try run()
+} catch {
+    fputs("UI-SMOKE FAIL: \(error)\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## What changed

- Fixed the click regression at its root: the popover had been replaced with an `NSPanel` using `hidesOnDeactivate`, which self-hides in an `LSUIElement` app. The status item now uses reliable popover behavior again.
- Added a two-layer UI test approach: an in-process `swift test` harness, plus `scripts/ui-smoke.sh`, which drives the real signed app with real `CGEvent` clicks and Accessibility assertions.
- Replaced inline goal expansion with a secondary detail popover.
- Grouped Goals using the `GoalItem.createdAt` migration.
- Eliminated the keychain prompt and added Settings → Permissions, with status-item creation moved before module lifecycle startup.

## Verification

- `swift test`: 161 passed, 0 failures, 0 skipped.
- `./scripts/ui-smoke.sh`: exit 0, with all nine assertions passing.

## Keychain authorization limitation

The ad-hoc ACL trusts the installed executable path and the repository `dist` executable path, and survives rebuilds at those paths. Truly permanent authorization across versions requires stable Developer ID signing through `KAJI_CODESIGN_IDENTITY`.