### PR TITLE
fix popover height overshoot and move goal notes in-window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,29 @@ Start incremental — no multi-target rewrite:
 
 Primary files today: `Sources/Kaji/{AppDelegate,Prefs,KajiPopoverView,StatusItemView,SettingsView}.swift`.
 
+## Popover layout rules (learned from repeat regressions)
+
+1. **No hard-coded chrome heights.** `NSPopover.contentSize` is clamped to
+   `maxContentHeight` while the hosting view keeps its full SwiftUI height, so
+   any overshoot renders as a blank strip above the header — and only once a
+   list is long enough to hit the scroll cap, which is why short pages look
+   fine. The scroll budget must be derived from a measured chrome height
+   (`PopoverHeightBudget` + `PanelScrollHeightKey`), never from a constant.
+   Any change to the header, footer, dividers, stack spacing or outer padding
+   must keep `PopoverHeightBudgetTests` green.
+2. **Never nest a second `NSPopover` inside the status-item popover.** A text
+   field in a child popover resigns first responder in a window with no
+   successor, throwing `NSInternalInconsistencyException` from
+   `-[NSWindow _newFirstResponderAfterResigning]` during layout — the app
+   hangs or dies. Secondary surfaces (notes, details) belong in the parent
+   window as anchored overlays (`anchorPreference` +
+   `overlayPreferenceValue`).
+3. **Hover disclosure needs an explicit dismissal state machine.** An
+   in-window card has no system dismissal: pointer-out of trigger, pointer-out
+   of card, focus loss, page switch and horizon switch must all funnel through
+   one policy (`NoteCardHoverPolicy`), with an active edit as the only veto.
+   Timing comes from `HoverDisclosurePolicy`, not per-call-site constants.
+
 ## Non-goals (explicit)
 
 - Ice-style management of other status items

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -36,6 +36,41 @@ private struct PopoverContentSizeKey: PreferenceKey {
     }
 }
 
+/// Laid-out height of the scrollable panel, used to derive the chrome height
+/// that the scroll budget subtracts from `maxContentHeight`.
+private struct PanelScrollHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 { value = next }
+    }
+}
+
+/// Anchor of the hovered goal's note icon, resolved in the popover's own
+/// coordinate space so the note card can live in this window.
+private struct NoteAnchorKey: PreferenceKey {
+    static let defaultValue: Anchor<CGRect>? = nil
+
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = value ?? nextValue()
+    }
+}
+
+private struct NoteCardHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 { value = next }
+    }
+}
+
+private enum NoteCardMetrics {
+    static let width: CGFloat = 208
+    static let margin: CGFloat = 8
+}
+
 
 struct KajiPopoverView: View {
     @ObservedObject var store: QuotaStore
@@ -67,11 +102,30 @@ struct KajiPopoverView: View {
     @State private var goalCreationNote = ""
     @State private var hoveredNewsID: String?
     @State private var newsHoverGeneration = 0
+    @State private var hoveredNoteGoalID: UUID?
+    @State private var hoveredNoteHorizon: GoalHorizon = .today
+    @State private var noteHoverGeneration = 0
+    @State private var noteCardHeight: CGFloat = 96
+    @State private var isEditingNote = false
+    @State private var noteTriggerHovered = false
+    @State private var noteCardHovered = false
+    @State private var panelChromeHeight: CGFloat = 0
+    @State private var measuredTotalHeight: CGFloat = 0
+    @State private var measuredScrollHeight: CGFloat = 0
+    @FocusState private var noteFieldFocused: Bool
     @Environment(\.colorScheme) private var scheme
 
     private var t: KajiTheme { .resolve(scheme) }
     private var shown: [ProviderView] { store.providers.filter { prefs.isVisible($0.id) } }
-    private var panelScrollMaxHeight: CGFloat { max(180, maxContentHeight - 104) }
+    /// Measured, not assumed: an under-counted chrome estimate makes the
+    /// panel overshoot `maxContentHeight` and AppKit renders the overshoot as
+    /// a blank strip above the header.
+    private var panelScrollMaxHeight: CGFloat {
+        PopoverHeightBudget.scrollMaxHeight(
+            maxContentHeight: maxContentHeight,
+            measuredChrome: panelChromeHeight
+        )
+    }
     private var pages: [KajiModuleID] { prefs.popoverModulePages }
     private var panel: KajiModuleID {
         get { navigation.panel }
@@ -83,6 +137,9 @@ struct KajiPopoverView: View {
 
     var body: some View {
         mainSurface
+        .overlayPreferenceValue(NoteAnchorKey.self) { anchor in
+            noteOverlay(anchor)
+        }
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
@@ -91,7 +148,13 @@ struct KajiPopoverView: View {
             }
         )
         .onPreferenceChange(PopoverContentSizeKey.self) { size in
+            measuredTotalHeight = size.height
+            reconcileChromeHeight()
             onContentSizeChange?(size)
+        }
+        .onPreferenceChange(PanelScrollHeightKey.self) { height in
+            measuredScrollHeight = height
+            reconcileChromeHeight()
         }
         .onAppear { clampPanelToEnabledPages() }
         .onChange(of: prefs.enabledModules) { _ in
@@ -99,6 +162,8 @@ struct KajiPopoverView: View {
         }
         .onChange(of: panel) { _ in
             controls.onDismissDetail()
+            noteHoverGeneration += 1
+            dismissNoteCard()
         }
         .onChange(of: focusedGoalID) { newValue in
             if let previousFocusedGoalID,
@@ -111,6 +176,22 @@ struct KajiPopoverView: View {
         }
         .onChange(of: navigation.goalHorizon) { _ in
             focusedGoalID = nil
+            noteHoverGeneration += 1
+            dismissNoteCard()
+        }
+    }
+
+    /// Chrome is whatever the popover renders outside the scrollable panel.
+    /// Deriving it from the two measured heights keeps the scroll budget
+    /// exact when rows, fonts, footers or languages change the chrome.
+    private func reconcileChromeHeight() {
+        guard measuredTotalHeight > 0, measuredScrollHeight > 0 else { return }
+        let chrome = PopoverHeightBudget.chromeHeight(
+            totalHeight: measuredTotalHeight,
+            scrollHeight: measuredScrollHeight
+        )
+        if PopoverHeightBudget.isMeaningfulChange(chrome, panelChromeHeight) {
+            panelChromeHeight = chrome
         }
     }
 
@@ -123,6 +204,11 @@ struct KajiPopoverView: View {
                     panelBody
                 }
                 .frame(maxHeight: panelScrollMaxHeight)
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(key: PanelScrollHeightKey.self, value: proxy.size.height)
+                    }
+                )
             } else {
                 panelBody
             }
@@ -1200,16 +1286,7 @@ struct KajiPopoverView: View {
                     }
                     HStack(spacing: 4) {
                         if !vision.note.isEmpty {
-                            DetailPopoverButton(
-                                accessibilityIdentifier: "goal-detail-\(vision.id)",
-                                help: "查看详情"
-                            ) { sourceView in
-                                controls.onShowDetail(
-                                    sourceView,
-                                    goalDetailContent(vision, horizon: .longTerm)
-                                )
-                            }
-                            .frame(width: 18, height: 18)
+                            goalNoteAffordance(vision, horizon: .longTerm)
                         }
                         if index > 0 {
                             miniButton("chevron.up") {
@@ -1479,16 +1556,7 @@ struct KajiPopoverView: View {
             .accessibilityLabel(goal.isDone ? "撤回完成" : "完成")
             HStack(spacing: 4) {
                 if !goal.note.isEmpty {
-                    DetailPopoverButton(
-                        accessibilityIdentifier: "goal-detail-\(goal.id)",
-                        help: "查看详情"
-                    ) { sourceView in
-                        controls.onShowDetail(
-                            sourceView,
-                            goalDetailContent(goal, horizon: horizon)
-                        )
-                    }
-                    .frame(width: 18, height: 18)
+                    goalNoteAffordance(goal, horizon: horizon)
                 }
                 miniButton("trash") {
                     dailyGoals.delete(goal, in: horizon)
@@ -1527,26 +1595,157 @@ struct KajiPopoverView: View {
             .onTapGesture(perform: onEdit)
     }
 
-    func goalDetailContent(_ goal: DailyGoal, horizon: GoalHorizon) -> AnyView {
-        AnyView(goalNoteEditor(goal, horizon: horizon))
+    /// Hover-disclosed note affordance. The card is *not* a second
+    /// `NSPopover`: nesting one inside the status-item popover made the note
+    /// text view resign first responder in a window that had no successor,
+    /// which threw during layout and hung/killed the app. It is now a plain
+    /// overlay inside the same window, anchored to this icon.
+    private func goalNoteAffordance(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {
+        let active = hoveredNoteGoalID == goal.id
+        return Image(systemName: "text.alignleft")
+            .font(.system(size: 9.5, weight: .medium))
+            .foregroundColor(active ? t.cream : t.ash)
+            .frame(width: 18, height: 18)
+            .contentShape(Rectangle())
+            .help("说明")
+            .accessibilityLabel("说明")
+            .accessibilityIdentifier("goal-detail-\(goal.id)")
+            .onHover { updateNoteHover(goal.id, horizon: horizon, inside: $0) }
+            .anchorPreference(key: NoteAnchorKey.self, value: .bounds) { anchor in
+                active ? anchor : nil
+            }
     }
 
-    private func goalNoteEditor(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+    /// The card, rendered once in the root overlay so it can never be clipped
+    /// by a row and never needs a window of its own.
+    @ViewBuilder
+    private func noteOverlay(_ anchor: Anchor<CGRect>?) -> some View {
+        GeometryReader { proxy in
+            if let anchor,
+               let id = hoveredNoteGoalID,
+               let goal = dailyGoals.goals(for: hoveredNoteHorizon).first(where: { $0.id == id }) {
+                let rect = proxy[anchor]
+                let width = NoteCardMetrics.width
+                let x = min(max(NoteCardMetrics.margin, rect.minX - width - 6),
+                            max(NoteCardMetrics.margin, proxy.size.width - width - NoteCardMetrics.margin))
+                let maxY = max(NoteCardMetrics.margin,
+                               proxy.size.height - noteCardHeight - NoteCardMetrics.margin)
+                let y = min(max(NoteCardMetrics.margin, rect.minY - 6), maxY)
+                goalNoteCard(goal, horizon: hoveredNoteHorizon)
+                    .frame(width: width, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .background(
+                        GeometryReader { card in
+                            Color.clear.preference(key: NoteCardHeightKey.self, value: card.size.height)
+                        }
+                    )
+                    .offset(x: x, y: y)
+                    .onHover { updateNoteCardHover(inside: $0) }
+                    .transition(.opacity)
+            }
+        }
+        .onPreferenceChange(NoteCardHeightKey.self) { height in
+            if height > 0 { noteCardHeight = height }
+        }
+        .animation(.easeOut(duration: 0.12), value: hoveredNoteGoalID)
+    }
 
+    private func updateNoteHover(_ id: UUID, horizon: GoalHorizon, inside: Bool) {
+        noteTriggerHovered = inside
+        // Never yank the card away from an active edit; the focus change
+        // schedules the dismissal instead.
+        if !inside, isEditingNote { return }
+        let hadActive = hoveredNoteGoalID != nil
+        noteHoverGeneration += 1
+        let generation = noteHoverGeneration
+        let delay = inside
+            ? HoverDisclosurePolicy.openDelay(hasActiveTopic: hadActive)
+            : HoverDisclosurePolicy.closeDelay
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard generation == noteHoverGeneration else { return }
+            if inside {
+                hoveredNoteHorizon = horizon
+                hoveredNoteGoalID = id
+            } else if hoveredNoteGoalID == id {
+                dismissNoteCard()
+            }
+        }
+    }
+
+    private func updateNoteCardHover(inside: Bool) {
+        noteCardHovered = inside
+        noteHoverGeneration += 1
+        guard !inside, !isEditingNote else { return }
+        scheduleNoteDismissal()
+    }
+
+    /// Called when the note field gains or loses focus. Losing focus while the
+    /// pointer sits outside both the trigger and the card is the one path that
+    /// would otherwise leave the card stranded on screen.
+    private func noteFocusChanged(_ focused: Bool) {
+        isEditingNote = focused
+        guard !focused else { return }
+        noteHoverGeneration += 1
+        scheduleNoteDismissal()
+    }
+
+    private func scheduleNoteDismissal() {
+        let generation = noteHoverGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + HoverDisclosurePolicy.closeDelay) {
+            guard generation == noteHoverGeneration,
+                  NoteCardHoverPolicy.shouldDismiss(
+                      triggerHovered: noteTriggerHovered,
+                      cardHovered: noteCardHovered,
+                      editing: isEditingNote
+                  ) else { return }
+            dismissNoteCard()
+        }
+    }
+
+    private func dismissNoteCard() {
+        if isEditingNote {
+            noteFieldFocused = false
+            isEditingNote = false
+        }
+        noteTriggerHovered = false
+        noteCardHovered = false
+        hoveredNoteGoalID = nil
+    }
+
+    func goalNoteCard(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
             Text(goal.title)
-                .font(.system(size: 12, weight: .bold, design: .rounded))
-            TextField("说明（可选）", text: Binding(
+                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                .foregroundColor(t.cream)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Rectangle()
+                .fill(t.track)
+                .frame(height: 1)
+            TextField("说明", text: Binding(
                 get: { dailyGoals.goals(for: horizon).first(where: { $0.id == goal.id })?.note ?? "" },
                 set: { dailyGoals.updateNote(goal, note: $0, in: horizon) }
             ), axis: .vertical)
-            .textFieldStyle(.roundedBorder)
-            .lineLimit(3...8)
+            .textFieldStyle(.plain)
+            .font(.system(size: 11))
+            .foregroundColor(t.cream)
+            .lineLimit(2...10)
+            .fixedSize(horizontal: false, vertical: true)
+            .focused($noteFieldFocused)
+            .onChange(of: noteFieldFocused) { focused in
+                noteFocusChanged(focused)
+            }
         }
-        .padding(10)
-        .frame(width: 260)
-        .background(t.bg)
-        .foregroundColor(t.cream)
+        .padding(11)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(t.panel)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(t.track, lineWidth: 1)
+                )
+        )
     }
 
     private func goalTagMenu(_ goal: DailyGoal, horizon: GoalHorizon) -> some View {

--- a/Sources/KajiCore/AIHotRefreshPolicy.swift
+++ b/Sources/KajiCore/AIHotRefreshPolicy.swift
@@ -16,6 +16,52 @@ public enum HoverSelectionPolicy {
     }
 }
 
+/// Whether a hover-disclosed note card may close. The card lives inside the
+/// popover window, so nothing else dismisses it: every path (pointer leaves
+/// the trigger, pointer leaves the card, the note field loses focus) funnels
+/// through here, and an active edit is the only veto.
+public enum NoteCardHoverPolicy {
+    public static func shouldDismiss(
+        triggerHovered: Bool,
+        cardHovered: Bool,
+        editing: Bool
+    ) -> Bool {
+        !triggerHovered && !cardHovered && !editing
+    }
+}
+
+/// Height budget for the popover's scrollable panel.
+///
+/// The panel is `chrome + scrollable content`, and the popover may never be
+/// taller than `maxContentHeight`: `AppDelegate.resizePopoverContent` clamps
+/// `NSPopover.contentSize` there while the hosting view keeps its full,
+/// unclamped SwiftUI height, and the difference shows up as a blank strip at
+/// the top of the popover. A hard-coded chrome estimate is what caused that
+/// strip repeatedly (it read 104pt against a real 128pt), so the chrome is
+/// measured at runtime and only falls back to the estimate for the first
+/// layout pass.
+public enum PopoverHeightBudget {
+    public static let minimumScrollHeight: CGFloat = 180
+    public static let initialChromeEstimate: CGFloat = 128
+
+    /// Height the scrollable panel may occupy so that
+    /// `chrome + scroll <= maxContentHeight`.
+    public static func scrollMaxHeight(maxContentHeight: CGFloat, measuredChrome: CGFloat) -> CGFloat {
+        let chrome = measuredChrome > 0 ? measuredChrome : initialChromeEstimate
+        return max(minimumScrollHeight, maxContentHeight - chrome)
+    }
+
+    /// Everything that is not the scrollable panel: header, dividers, footer,
+    /// stack spacing and outer padding.
+    public static func chromeHeight(totalHeight: CGFloat, scrollHeight: CGFloat) -> CGFloat {
+        max(0, totalHeight - scrollHeight)
+    }
+
+    public static func isMeaningfulChange(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
+        abs(lhs - rhs) > 0.5
+    }
+}
+
 public enum GoalControlMetrics {
     public static let diameter: CGFloat = 9
     public static let rowIsCompletionTarget = true

--- a/Tests/KajiTests/NoteCardHoverPolicyTests.swift
+++ b/Tests/KajiTests/NoteCardHoverPolicyTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import KajiCore
+
+/// The goal note card lives inside the popover's own window, so nothing in the
+/// system dismisses it: if this policy says "keep", the card stays on screen
+/// until the popover closes. The stranded-card path was exactly that — the
+/// note field losing focus while the pointer already sat outside both the
+/// trigger icon and the card.
+final class NoteCardHoverPolicyTests: XCTestCase {
+    func testDismissesWhenPointerLeftBothSurfacesAndEditingEnded() {
+        XCTAssertTrue(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: false, cardHovered: false, editing: false)
+        )
+    }
+
+    func testKeepsCardWhilePointerRestsOnTrigger() {
+        XCTAssertFalse(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: true, cardHovered: false, editing: false)
+        )
+    }
+
+    func testKeepsCardWhilePointerRestsOnCard() {
+        XCTAssertFalse(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: false, cardHovered: true, editing: false)
+        )
+    }
+
+    func testEditingVetoesDismissalEvenWithPointerAway() {
+        XCTAssertFalse(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: false, cardHovered: false, editing: true)
+        )
+    }
+
+    /// Hover-out during an edit is deferred; the later focus loss re-evaluates
+    /// with the pointer still away, and the card must then go.
+    func testFocusLossAfterHoverOutDismisses() {
+        XCTAssertFalse(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: false, cardHovered: false, editing: true)
+        )
+        XCTAssertTrue(
+            NoteCardHoverPolicy.shouldDismiss(triggerHovered: false, cardHovered: false, editing: false)
+        )
+    }
+
+    func testAdjacentRowsSwitchInstantlyWhileFirstOpenIsDelayed() {
+        XCTAssertEqual(HoverDisclosurePolicy.openDelay(hasActiveTopic: true), 0)
+        XCTAssertGreaterThan(HoverDisclosurePolicy.openDelay(hasActiveTopic: false), 0)
+    }
+}

--- a/Tests/KajiTests/PopoverHeightBudgetTests.swift
+++ b/Tests/KajiTests/PopoverHeightBudgetTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import AppKit
+import SwiftUI
+import KajiCore
+@testable import Kaji
+
+/// Regression guard for the recurring "blank strip above the header" bug.
+///
+/// `AppDelegate.resizePopoverContent` clamps `NSPopover.contentSize` to
+/// `maxContentHeight`, but the hosting view keeps whatever height SwiftUI
+/// laid out. Any page whose laid-out height exceeds `maxContentHeight`
+/// therefore renders the overshoot as dead space at the top of the popover.
+/// The overshoot only appears once a list is long enough to hit the scroll
+/// cap, which is why short pages always looked fine.
+@MainActor
+final class PopoverHeightBudgetTests: XCTestCase {
+    private static let width = PanelSize.medium.frameSize.width
+
+    func testScrollBudgetSubtractsMeasuredChrome() {
+        XCTAssertEqual(
+            PopoverHeightBudget.scrollMaxHeight(maxContentHeight: 836, measuredChrome: 128),
+            708
+        )
+    }
+
+    func testScrollBudgetFallsBackToEstimateBeforeFirstMeasurement() {
+        XCTAssertEqual(
+            PopoverHeightBudget.scrollMaxHeight(maxContentHeight: 836, measuredChrome: 0),
+            836 - PopoverHeightBudget.initialChromeEstimate
+        )
+    }
+
+    func testScrollBudgetNeverCollapsesBelowMinimum() {
+        XCTAssertEqual(
+            PopoverHeightBudget.scrollMaxHeight(maxContentHeight: 200, measuredChrome: 128),
+            PopoverHeightBudget.minimumScrollHeight
+        )
+    }
+
+    func testChromeHeightIsTotalMinusScroll() {
+        XCTAssertEqual(PopoverHeightBudget.chromeHeight(totalHeight: 860, scrollHeight: 732), 128)
+        XCTAssertEqual(PopoverHeightBudget.chromeHeight(totalHeight: 100, scrollHeight: 200), 0)
+    }
+
+    /// The real layout check: a goals list long enough to hit the scroll cap
+    /// must still lay out within `maxContentHeight`. Before the fix this
+    /// measured 860 against a 836 limit — exactly the 24pt strip.
+    func testLongGoalsListNeverOvershootsMaxContentHeight() throws {
+        let fixture = PopoverRenderFixture()
+        defer { fixture.tearDown() }
+        for i in 2...40 {
+            _ = try? fixture.dailyGoals.addGoal(
+                title: "Stress goal \(i) with a title long enough to wrap onto a second line",
+                tag: GoalTag.personal.rawValue,
+                note: i % 3 == 0 ? "note \(i)" : "",
+                in: .today
+            )
+        }
+
+        for maxContentHeight in [CGFloat(320), 560, 836] {
+            let laidOut = try layoutHeight(fixture: fixture, page: .goals, maxContentHeight: maxContentHeight)
+            XCTAssertLessThanOrEqual(
+                laidOut, maxContentHeight,
+                "goals page laid out \(laidOut)pt against a \(maxContentHeight)pt limit — the overshoot renders as a blank strip above the header"
+            )
+        }
+    }
+
+    func testEveryPageStaysWithinMaxContentHeight() throws {
+        let fixture = PopoverRenderFixture()
+        defer { fixture.tearDown() }
+        for i in 2...24 {
+            _ = try? fixture.dailyGoals.addGoal(
+                title: "Stress goal \(i)", tag: GoalTag.personal.rawValue, note: "", in: .today
+            )
+        }
+
+        for page in KajiModuleID.allCases {
+            let laidOut = try layoutHeight(fixture: fixture, page: page, maxContentHeight: 560)
+            XCTAssertLessThanOrEqual(laidOut, 560, "\(page) overshoots the popover height limit")
+        }
+    }
+
+    /// Lays the page out exactly the way `AppDelegate` does: fixed width,
+    /// SwiftUI decides the height, and the measured height is what
+    /// `resizePopoverContent` would clamp.
+    private func layoutHeight(
+        fixture: PopoverRenderFixture,
+        page: KajiModuleID,
+        maxContentHeight: CGFloat
+    ) throws -> CGFloat {
+        var reported: CGSize = .zero
+        let view = KajiPopoverView(
+            store: fixture.store,
+            prefs: fixture.prefs,
+            workSession: fixture.workSession,
+            systemMonitor: fixture.systemMonitor,
+            dailyGoals: fixture.dailyGoals,
+            fixedPlanStore: fixture.fixedPlanStore,
+            aiNewsStore: fixture.aiNewsStore,
+            mailBriefStore: fixture.mailBriefStore,
+            navigation: fixture.navigation,
+            controls: KajiPopoverControls(
+                onOpenSettings: {}, onQuit: {},
+                onShowDetail: { _, _ in }, onDismissDetail: {}
+            ),
+            maxContentHeight: maxContentHeight,
+            onContentSizeChange: { reported = $0 }
+        )
+        fixture.navigation.panel = page
+        let host = NSHostingView(rootView: AnyView(view))
+        host.frame = NSRect(x: 0, y: 0, width: Self.width, height: 1)
+        host.layoutSubtreeIfNeeded()
+        // Chrome is measured on the first pass and fed back into the scroll
+        // budget on the next, so settle the layout before reading the height.
+        for _ in 0..<3 {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.15))
+            let height = host.fittingSize.height
+            host.frame = NSRect(x: 0, y: 0, width: Self.width, height: height)
+            host.layoutSubtreeIfNeeded()
+        }
+        RunLoop.main.run(until: Date().addingTimeInterval(0.15))
+        XCTAssertGreaterThan(reported.height, 0, "\(page) never reported a content size")
+        return max(host.fittingSize.height, reported.height)
+    }
+}

--- a/Tests/KajiTests/PopoverInteractionTests.swift
+++ b/Tests/KajiTests/PopoverInteractionTests.swift
@@ -76,12 +76,30 @@ final class PopoverInteractionTests: XCTestCase {
         }
     }
 
+    /// The goal note is no longer an AppKit affordance: nesting a second
+    /// `NSPopover` inside the status-item popover threw
+    /// `NSInternalInconsistencyException` from
+    /// `-[NSWindow _newFirstResponderAfterResigning]` when the note text view
+    /// resigned first responder, hanging/killing the app. The note card must
+    /// therefore render inside the popover's own window.
+    func testGoalNoteHasNoNestedAppKitPopoverAffordance() throws {
+        harness.clickStatusItem()
+        harness.appDelegate.popoverNavigation.panel = .goals
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertTrue(harness.detailAffordances(prefix: "goal-detail-").isEmpty,
+                      "goal notes must not be backed by an AppKit button that opens a child NSPopover")
+        XCTAssertNil(harness.appDelegate.detailPopover,
+                     "paging to goals must not create a child popover")
+        XCTAssertTrue(harness.appDelegate.popover.isShown)
+    }
+
     func testDetailAffordanceOpensChildWhileParentStaysShown() throws {
         harness.clickStatusItem()
         harness.appDelegate.popoverNavigation.panel = .goals
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
 
-        harness.clickDetailAffordance(prefix: "goal-detail-")
+        harness.clickDetailAffordance(prefix: "schedule-detail-")
 
         XCTAssertTrue(harness.appDelegate.popover.isShown, "opening a detail must not dismiss the main popover")
         XCTAssertTrue(try XCTUnwrap(harness.appDelegate.detailPopover).isShown)
@@ -91,7 +109,7 @@ final class PopoverInteractionTests: XCTestCase {
         harness.clickStatusItem()
         harness.appDelegate.popoverNavigation.panel = .goals
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
-        harness.clickDetailAffordance(prefix: "goal-detail-")
+        harness.clickDetailAffordance(prefix: "schedule-detail-")
         let child = try XCTUnwrap(harness.appDelegate.detailPopover)
         child.animates = false
 
@@ -107,11 +125,15 @@ final class PopoverInteractionTests: XCTestCase {
         harness.clickStatusItem()
         harness.appDelegate.popoverNavigation.panel = .goals
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
-        harness.clickDetailAffordance(prefix: "goal-detail-")
+        let affordances = harness.detailAffordances(prefix: "schedule-detail-")
+        XCTAssertGreaterThan(affordances.count, 1,
+                             "harness seeds two scheduled goals with notes; both must render a detail affordance")
+
+        harness.click(affordances[0])
         let first = try XCTUnwrap(harness.appDelegate.detailPopover)
         first.animates = false
 
-        harness.clickDetailAffordance(prefix: "schedule-detail-")
+        harness.click(affordances[1])
         let second = try XCTUnwrap(harness.appDelegate.detailPopover)
 
         XCTAssertFalse(first === second)

--- a/Tests/KajiTests/PopoverRenderTests.swift
+++ b/Tests/KajiTests/PopoverRenderTests.swift
@@ -55,14 +55,14 @@ final class PopoverRenderTests: XCTestCase {
     }
 
 
-    func testSecondaryDetailPopoverRendersNonBlank() throws {
+    func testGoalNoteCardRendersNonBlank() throws {
         let fixture = PopoverRenderFixture()
         defer { fixture.tearDown() }
         let page = fixture.view(page: .goals, maxContentHeight: Self.renderSize.height)
         let goal = try XCTUnwrap(fixture.dailyGoals.goals(for: .today).first)
-        let detail = page.goalDetailContent(goal, horizon: .today)
-        let rep = try XCTUnwrap(renderImage(detail, size: CGSize(width: 260, height: 180)))
-        let path = try XCTUnwrap(writePNG(rep, name: "popover-secondary-goal-detail"))
+        let card = page.goalNoteCard(goal, horizon: .today)
+        let rep = try XCTUnwrap(renderImage(card, size: CGSize(width: 208, height: 160)))
+        let path = try XCTUnwrap(writePNG(rep, name: "popover-goal-note-card"))
         XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
         assertNonBlank(rep, page: .goals)
     }

--- a/Tests/KajiTests/UITestHarness.swift
+++ b/Tests/KajiTests/UITestHarness.swift
@@ -112,10 +112,18 @@ final class KajiUIHarness {
             note: "Fixture note",
             in: .today
         )
+        // Two scheduled goals, both with notes: the re-anchoring test needs two
+        // distinct AppKit detail affordances to exist deterministically.
         _ = appDelegate.fixedPlanStore.add(
             title: "Fixture scheduled goal",
             tag: GoalTag.personal.rawValue,
             note: "Fixture schedule note",
+            weekdays: Set(1...7)
+        )
+        _ = appDelegate.fixedPlanStore.add(
+            title: "Second fixture scheduled goal",
+            tag: GoalTag.personal.rawValue,
+            note: "Second fixture schedule note",
             weekdays: Set(1...7)
         )
         appDelegate.applicationDidFinishLaunching(
@@ -174,26 +182,36 @@ final class KajiUIHarness {
     }
 
     func clickDetailAffordance(prefix: String) {
-        guard let root = appDelegate.popover.contentViewController?.view,
-              let button = findButton(prefix: prefix, in: root) else {
+        guard let button = detailAffordances(prefix: prefix).first else {
             XCTFail("detail affordance starting with \(prefix) not found in popover")
             return
         }
+        click(button)
+    }
+
+    func click(_ button: NSButton) {
         button.performClick(nil)
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
     }
 
-    private func findButton(prefix: String, in view: NSView) -> NSButton? {
+    /// Every AppKit-backed detail affordance currently in the popover tree,
+    /// in view order. Goal notes deliberately have none — they render inside
+    /// the popover's own window instead of a child `NSPopover`.
+    func detailAffordances(prefix: String) -> [NSButton] {
+        guard let root = appDelegate.popover.contentViewController?.view else { return [] }
+        var found: [NSButton] = []
+        collectButtons(prefix: prefix, in: root, into: &found)
+        return found
+    }
+
+    private func collectButtons(prefix: String, in view: NSView, into found: inout [NSButton]) {
         if let button = view as? NSButton,
            button.identifier?.rawValue.hasPrefix(prefix) == true {
-            return button
+            found.append(button)
         }
         for subview in view.subviews {
-            if let button = findButton(prefix: prefix, in: subview) {
-                return button
-            }
+            collectButtons(prefix: prefix, in: subview, into: &found)
         }
-        return nil
     }
 
 }


### PR DESCRIPTION
Stacked on #39 — both branches touch `KajiPopoverView.swift` and `PopoverRenderTests.swift`, so this targets `feat/goals-schedule-cli-ux` rather than `main`.

## 1. Blank strip above the header

The scroll budget subtracted a hard-coded `104`pt of chrome. The real chrome — header + two dividers + footer + 12/12 padding + 4×10 stack spacing — is **128**pt:

```
maxContentHeight = screen visible height - 64 = 836
scroll budget    = 836 - 104 (hard-coded) = 732
real chrome      = 128
laid out         = 732 + 128 = 860  >  836
```

`AppDelegate.resizePopoverContent` clamps `NSPopover.contentSize` to 836, but the hosting view keeps its full 860pt SwiftUI height, so the **24pt** overshoot renders as dead space at the top. Short lists never reach the scroll cap, which is why this only appeared once a page had a lot of content — and why it has regressed repeatedly: every header/footer/spacing change invalidates the constant.

`PopoverHeightBudget` (KajiCore) now derives the budget from a *measured* chrome height: `PanelScrollHeightKey` reports the laid-out scroll height, `chrome = total − scroll` feeds back into the budget, and the constant survives only as a first-frame estimate. Measured before/after at the same 836pt limit: `860` → `836`.

## 2. Goal note card was a nested NSPopover

A second `NSPopover` inside the status-item popover meant its text field resigned first responder in a window with no successor, throwing `NSInternalInconsistencyException` from `-[NSWindow _newFirstResponderAfterResigning]` during layout. The note is now an anchored in-window overlay (`anchorPreference` + `overlayPreferenceValue`). Since an in-window card has no system dismissal, every path — pointer out of trigger, pointer out of card, focus loss, page switch, horizon switch — funnels through `NoteCardHoverPolicy`, with an active edit as the only veto.

## Tests

- `PopoverHeightBudgetTests` — budget arithmetic plus real layout: a 40-goal stress list must lay out within `maxContentHeight` at 320/560/836, and every module page within 560. Fails at 860 vs 836 without the fix.
- `NoteCardHoverPolicyTests` — the dismissal state machine, including the focus-loss-after-hover-out gap.
- `PopoverInteractionTests` — asserts the goal note exposes no AppKit child-popover affordance; the three existing child-popover tests retarget schedule rows, which still use the AppKit path.
- `UITestHarness` — seeds two scheduled goals with notes so `testDifferentDetailAffordanceReanchorsSingleChildPopover` asserts its precondition instead of self-skipping via `XCTSkipUnless`. No `XCTSkip` remains anywhere in `Tests/`.

`swift test`: **179 executed, 0 failures, 0 skipped.** Release build installed and exercised locally; not cutting a release.

`AGENTS.md` records all three rules (no hard-coded chrome heights, no nested `NSPopover` in the status-item popover, hover overlays need a single dismissal state machine) so the next layout change does not reintroduce them.