### PR TITLE
Add background task visibility module

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -331,10 +331,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private var launchdStatus: LaunchdMenuBarStatus? {
-        MenuBarSlotLogic.launchdStatus(
+        let summary = launchdJobStore.snapshot.installedSummary
+        return MenuBarSlotLogic.launchdStatus(
             enabled: prefs.isModuleEnabled(.launchd),
-            runningCount: launchdJobStore.snapshot.runningCount,
-            failedCount: launchdJobStore.snapshot.failedCount
+            runningCount: summary.runningCount,
+            failedCount: summary.failedCount
         )
     }
 

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -37,6 +37,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let popoverNavigation = PopoverNavigation()
     private let aiNewsStore: AIHotNewsStore
     private let mailBriefStore: MailBriefStore
+    private let launchdJobStore = LaunchdJobStore()
     private var breakWindows: [NSWindow] = []
     private var breakWatchdogTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
@@ -214,6 +215,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mailBriefStore.setEnabled(modules.contains(.mailBrief), hour: prefs.mailBriefHour, minute: prefs.mailBriefMinute,
                                   batchSize: prefs.mailBriefBatchSize, concurrency: prefs.mailBriefConcurrency,
                                   model: prefs.mailBriefModel)
+        launchdJobStore.setEnabled(modules.contains(.launchd))
     }
 
     /// Providers the user has chosen to show, in display order — drives both the
@@ -229,6 +231,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         closeBreakOverlay()
         aiNewsStore.stop()
         mailBriefStore.stop()
+        launchdJobStore.stop()
         controlServer.stop()
     }
 
@@ -486,6 +489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                       fixedPlanStore: fixedPlanStore,
                                       aiNewsStore: aiNewsStore,
                                       mailBriefStore: mailBriefStore,
+                                      launchdJobStore: launchdJobStore,
                                       navigation: popoverNavigation,
                                       controls: controls,
                                       maxContentHeight: maxContentHeight ?? maxPopoverHeight(on: statusItem.button?.window?.screen),

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -797,11 +797,18 @@ extension AppDelegate: NSWindowDelegate {
     }
 }
 extension AppDelegate: NSPopoverDelegate {
+    func popoverWillShow(_ notification: Notification) {
+        guard let openingPopover = notification.object as? NSPopover,
+              openingPopover === popover else { return }
+        launchdJobStore.setPopoverVisible(true)
+    }
+
     func popoverWillClose(_ notification: Notification) {
         guard let closingPopover = notification.object as? NSPopover else { return }
         if closingPopover === detailPopover {
             detailPopover = nil
         } else if closingPopover === popover {
+            launchdJobStore.setPopoverVisible(false)
             closeDetailPopover()
         }
     }

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -130,6 +130,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in DispatchQueue.main.async { self?.updateStatusItem() } }
             .store(in: &cancellables)
+        launchdJobStore.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in DispatchQueue.main.async { self?.updateStatusItem() } }
+            .store(in: &cancellables)
         dailyGoals.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
@@ -215,7 +219,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mailBriefStore.setEnabled(modules.contains(.mailBrief), hour: prefs.mailBriefHour, minute: prefs.mailBriefMinute,
                                   batchSize: prefs.mailBriefBatchSize, concurrency: prefs.mailBriefConcurrency,
                                   model: prefs.mailBriefModel)
-        launchdJobStore.setEnabled(modules.contains(.launchd))
+        let launchdEnabled = modules.contains(.launchd)
+        launchdJobStore.setEnabled(launchdEnabled)
+        if launchdEnabled { launchdJobStore.refreshStatus() }
     }
 
     /// Providers the user has chosen to show, in display order — drives both the
@@ -260,11 +266,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                   showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
                                   mailBriefSlotLabel: MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount),
                                   showsMailBriefSlot: prefs.isModuleEnabled(.mailBrief),
+                                  launchdStatus: launchdStatus,
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
                                   onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
                                   onAINewsClick: { [weak self] in self?.showPopover(.aiNews) },
-                                  onMailBriefClick: { [weak self] in self?.showPopover(.mailBrief) })
+                                  onMailBriefClick: { [weak self] in self?.showPopover(.mailBrief) },
+                                  onLaunchdClick: { [weak self] in self?.showPopover(.launchd) })
         hostingView = KajiHostingView(rootView: view)
         hostingView.configureKajiHost()
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -286,11 +294,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
                                                mailBriefSlotLabel: MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount),
                                                showsMailBriefSlot: prefs.isModuleEnabled(.mailBrief),
+                                               launchdStatus: launchdStatus,
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
                                                onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
                                                onAINewsClick: { [weak self] in self?.showPopover(.aiNews) },
-                                               onMailBriefClick: { [weak self] in self?.showPopover(.mailBrief) })
+                                               onMailBriefClick: { [weak self] in self?.showPopover(.mailBrief) },
+                                               onLaunchdClick: { [weak self] in self?.showPopover(.launchd) })
         statusItem.length = statusItemLength
     }
 
@@ -320,6 +330,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
+    private var launchdStatus: LaunchdMenuBarStatus? {
+        MenuBarSlotLogic.launchdStatus(
+            enabled: prefs.isModuleEnabled(.launchd),
+            runningCount: launchdJobStore.snapshot.runningCount,
+            failedCount: launchdJobStore.snapshot.failedCount
+        )
+    }
+
     private var statusItemLength: CGFloat {
         let count = max(1, min(4, visibleProviders.count))
         var length = CGFloat(count) * 26 + 6
@@ -333,6 +351,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if prefs.isModuleEnabled(.aiNews) { length += 20 }
         if prefs.isModuleEnabled(.mailBrief) {
             length += 22 + CGFloat(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: mailBriefStore.actCount)?.count ?? 0) * 7
+        }
+        if let launchdStatus {
+            length += 22 + CGFloat(String(launchdStatus.count).count) * 7
         }
         return length
     }
@@ -428,7 +449,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if prefs.isModuleEnabled(.work) { return .work }
             if prefs.isModuleEnabled(.goals) { return .goalsToday }
             return .quota
-        case .work, .goalsToday, .aiNews, .mailBrief:
+        case .work, .goalsToday, .aiNews, .mailBrief, .launchd:
             return .quota
         }
     }
@@ -445,6 +466,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return popoverNavigation.panel == .aiNews
         case .mailBrief:
             return popoverNavigation.panel == .mailBrief
+        case .launchd:
+            return popoverNavigation.panel == .launchd
         }
     }
 
@@ -469,6 +492,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             popoverNavigation.panel = prefs.isModuleEnabled(.aiNews) ? .aiNews : .quota
         case .mailBrief:
             popoverNavigation.panel = prefs.isModuleEnabled(.mailBrief) ? .mailBrief : .quota
+        case .launchd:
+            popoverNavigation.panel = prefs.isModuleEnabled(.launchd) ? .launchd : .quota
         }
     }
 

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -29,10 +29,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var workSession = WorkSessionController(prefs: prefs)
     private let systemMonitor = SystemMonitor()
     let dailyGoals: DailyGoalStore
-    private lazy var controlServer = KajiControlServer(
-        goals: dailyGoals,
-        snapshotProvider: { [weak self] in self?.controlSnapshot() ?? [:] }
-    )
+    private lazy var controlServer: KajiControlServer = {
+        let environment = ProcessInfo.processInfo.environment
+        let testNonce = environment["KAJI_UI_SMOKE_NONCE"]
+        let testPort = environment["KAJI_UI_SMOKE_PORT"].flatMap(UInt16.init)
+        let automation = testNonce.map { nonce in
+            KajiControlServer.TestAutomation(
+                nonce: nonce,
+                render: { [weak self] surface, selection, outputPath in
+                    guard let self else { throw TestUIAutomationError.appUnavailable }
+                    return try self.renderTestSurface(
+                        surface: surface,
+                        selection: selection,
+                        outputPath: outputPath
+                    )
+                }
+            )
+        }
+        return KajiControlServer(
+            goals: dailyGoals,
+            port: testPort ?? KajiControlServer.port,
+            snapshotProvider: { [weak self] in self?.controlSnapshot() ?? [:] },
+            testAutomation: automation
+        )
+    }()
     let fixedPlanStore: FixedPlanStore
     let popoverNavigation = PopoverNavigation()
     private let aiNewsStore: AIHotNewsStore
@@ -385,6 +405,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             applyPopoverDestination(destination)
             return
         }
+        popoverNavigation.launchdCategory = .userAgent
+
 
         // AppKit's first fitting pass can leave the initial SwiftUI page offset.
         // Fit from another enabled page, then switch after placement so every
@@ -677,7 +699,111 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 "replyDrafts": mailBriefStore.replyDrafts,
                 "runRecords": jsonValue(mailBriefStore.runRecords),
             ],
+            "launchd": [
+                "userAgent": controlCategorySnapshot(.userAgent),
+                "application": controlCategorySnapshot(.application),
+                "appleSystem": controlCategorySnapshot(.appleSystem),
+            ],
         ]
+    }
+
+    private func controlCategorySnapshot(_ category: LaunchdJobCategory) -> [String: Any] {
+        let jobs = launchdJobStore.snapshot.jobs(in: category)
+        return [
+            "total": jobs.count,
+            "running": jobs.count { $0.state == .running },
+            "failed": jobs.count { $0.state == .failed },
+            "idle": jobs.count { $0.state == .idle },
+            "unloaded": jobs.count { $0.state == .unloaded },
+        ]
+    }
+
+    private func renderTestSurface(
+        surface: String,
+        selection: String,
+        outputPath: String
+    ) throws -> [String: Any] {
+        guard let artifactRoot = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_ARTIFACTS"] else {
+            throw TestUIAutomationError.disabled
+        }
+        let rootURL = URL(fileURLWithPath: artifactRoot, isDirectory: true).standardizedFileURL
+        let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        guard outputURL.path.hasPrefix(rootURL.path + "/") else {
+            throw TestUIAutomationError.invalidOutputPath
+        }
+
+        let size: CGSize
+        switch surface {
+        case "status":
+            updateStatusItem()
+            hostingView.layoutSubtreeIfNeeded()
+            size = try writePNG(view: hostingView, to: outputURL)
+        case "popover":
+            let parts = selection.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+            guard let pageID = parts.first,
+                  let page = KajiModuleID(rawValue: pageID),
+                  prefs.enabledModules.contains(page),
+                  parts.count <= 2 else {
+                throw TestUIAutomationError.invalidSelection
+            }
+            if parts.count == 2 {
+                guard page == .launchd,
+                      let category = LaunchdJobCategory(rawValue: parts[1]) else {
+                    throw TestUIAutomationError.invalidSelection
+                }
+                popoverNavigation.launchdCategory = category
+            } else if page == .launchd {
+                popoverNavigation.launchdCategory = .userAgent
+            }
+            popoverNavigation.panel = page
+            if page == .goals { popoverNavigation.goalHorizon = .today }
+            let controller = makePopoverContentController(maxContentHeight: 640)
+            let target = popoverFittingSize(for: controller)
+            controller.view.frame = NSRect(origin: .zero, size: target)
+            controller.view.layoutSubtreeIfNeeded()
+            size = try writePNG(view: controller.view, to: outputURL)
+        case "settings":
+            guard let section = SettingsSection(rawValue: selection) else {
+                throw TestUIAutomationError.invalidSelection
+            }
+            let view = KajiHostingView(rootView: SettingsView(
+                prefs: prefs,
+                sleepController: sleepController,
+                fixedPlanStore: fixedPlanStore,
+                mailBriefStore: mailBriefStore,
+                initialSection: section
+            ))
+            view.configureKajiHost()
+            view.frame = NSRect(x: 0, y: 0, width: 760, height: 560)
+            view.layoutSubtreeIfNeeded()
+            size = try writePNG(view: view, to: outputURL)
+        default:
+            throw TestUIAutomationError.invalidSurface
+        }
+        return [
+            "surface": surface,
+            "selection": selection,
+            "path": outputURL.path,
+            "width": Int(size.width),
+            "height": Int(size.height),
+        ]
+    }
+
+    private func writePNG(view: NSView, to outputURL: URL) throws -> CGSize {
+        guard view.bounds.width > 0, view.bounds.height > 0,
+              let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            throw TestUIAutomationError.renderFailed
+        }
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+        guard let data = bitmap.representation(using: .png, properties: [:]) else {
+            throw TestUIAutomationError.renderFailed
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: outputURL, options: .atomic)
+        return view.bounds.size
     }
 
     private func jsonValue<T: Encodable>(_ value: T) -> Any {
@@ -838,4 +964,13 @@ extension AppDelegate: NSPopoverDelegate {
             closeDetailPopover()
         }
     }
+}
+
+private enum TestUIAutomationError: Error {
+    case appUnavailable
+    case disabled
+    case invalidOutputPath
+    case invalidSelection
+    case invalidSurface
+    case renderFailed
 }

--- a/Sources/Kaji/KajiControlServer.swift
+++ b/Sources/Kaji/KajiControlServer.swift
@@ -7,8 +7,14 @@ final class KajiControlServer {
     nonisolated static let port: UInt16 = 37_841
     nonisolated static let baseURL = "http://127.0.0.1:\(port)/v1"
 
+    struct TestAutomation {
+        let nonce: String
+        let render: (_ surface: String, _ selection: String, _ outputPath: String) throws -> [String: Any]
+    }
+
     private weak var goals: DailyGoalStore?
     private let snapshotProvider: () -> [String: Any]
+    private let testAutomation: TestAutomation?
     private let host: NWEndpoint.Host
     private let port: NWEndpoint.Port
     private var listener: NWListener?
@@ -19,10 +25,12 @@ final class KajiControlServer {
         goals: DailyGoalStore,
         host: String = "127.0.0.1",
         port: UInt16 = KajiControlServer.port,
-        snapshotProvider: @escaping () -> [String: Any] = { [:] }
+        snapshotProvider: @escaping () -> [String: Any] = { [:] },
+        testAutomation: TestAutomation? = nil
     ) {
         self.goals = goals
         self.snapshotProvider = snapshotProvider
+        self.testAutomation = testAutomation
         self.host = NWEndpoint.Host(host)
         self.port = NWEndpoint.Port(rawValue: port)!
     }
@@ -97,7 +105,19 @@ final class KajiControlServer {
         do {
             let components = request.path.split(separator: "/").map(String.init)
             let payload: Any
-            if request.method == "GET", components == ["v1", "state"] {
+            if request.method == "POST", components == ["v1", "test", "render"] {
+                guard let testAutomation else {
+                    return .json(status: "404 Not Found", object: ["error": "Unknown local control route"])
+                }
+                let body = try request.jsonBody()
+                guard body["nonce"] as? String == testAutomation.nonce,
+                      let surface = body["surface"] as? String,
+                      let selection = body["selection"] as? String,
+                      let outputPath = body["outputPath"] as? String else {
+                    return .json(status: "404 Not Found", object: ["error": "Unknown local control route"])
+                }
+                payload = try testAutomation.render(surface, selection, outputPath)
+            } else if request.method == "GET", components == ["v1", "state"] {
                 payload = snapshotProvider()
             } else if request.method == "GET", components == ["v1", "goals"] {
                 payload = [

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -81,6 +81,7 @@ struct KajiPopoverView: View {
     @ObservedObject var fixedPlanStore: FixedPlanStore
     @ObservedObject var aiNewsStore: AIHotNewsStore
     @ObservedObject var mailBriefStore: MailBriefStore
+    @ObservedObject var launchdJobStore: LaunchdJobStore
     @ObservedObject var navigation: PopoverNavigation
 
     let controls: KajiPopoverControls
@@ -256,6 +257,112 @@ struct KajiPopoverView: View {
             aiNewsPanel
         case .mailBrief:
             mailBriefPanel
+        case .launchd:
+            launchdPanel
+        }
+    }
+
+    private var launchdPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                launchdSummary("\(launchdJobStore.snapshot.runningCount)", label: "running")
+                launchdSummary("\(launchdJobStore.snapshot.failedCount)", label: "failed")
+                launchdSummary("\(launchdJobStore.snapshot.unloadedCount)", label: "unloaded")
+                Spacer(minLength: 6)
+                Button { launchdJobStore.refresh() } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .disabled(launchdJobStore.isRefreshing)
+                .help("Refresh")
+            }
+
+            if launchdJobStore.snapshot.jobs.isEmpty {
+                HStack {
+                    Spacer()
+                    if launchdJobStore.isRefreshing {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(launchdJobStore.lastError == nil ? "Looking for GUI jobs…" : "Could not read launchd jobs")
+                        .font(.system(size: 10.5, weight: .medium))
+                        .foregroundColor(t.mute)
+                    Spacer()
+                }
+                .padding(.vertical, 24)
+            } else {
+                let installed = launchdJobStore.snapshot.jobs.filter(\.isInstalledUserAgent)
+                let other = launchdJobStore.snapshot.jobs.filter { !$0.isInstalledUserAgent }
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    launchdSection("User agents", jobs: installed)
+                    launchdSection("Other GUI jobs", jobs: other)
+                }
+            }
+        }
+    }
+
+    private func launchdSummary(_ value: String, label: String) -> some View {
+        HStack(spacing: 3) {
+            Text(value)
+                .font(.system(size: 10.5, weight: .bold, design: .rounded))
+                .foregroundColor(t.cream)
+            Text(label)
+                .font(.system(size: 9.5, weight: .medium))
+                .foregroundColor(t.mute)
+        }
+    }
+
+    @ViewBuilder
+    private func launchdSection(_ title: String, jobs: [LaunchdJob]) -> some View {
+        if !jobs.isEmpty {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("\(title) · \(jobs.count)")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(t.mute)
+                    .textCase(.uppercase)
+                ForEach(jobs) { job in
+                    launchdJobRow(job)
+                }
+            }
+        }
+    }
+
+    private func launchdJobRow(_ job: LaunchdJob) -> some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(job.state == .running ? t.cream : t.track)
+                .frame(width: 5, height: 5)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(job.label)
+                    .font(.system(size: 10.5, weight: job.state == .failed ? .semibold : .medium))
+                    .foregroundColor(job.state == .failed ? t.cream : t.ash)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(launchdJobDetail(job))
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(t.mute)
+            }
+            Spacer(minLength: 4)
+            Text(launchdStateLabel(job.state))
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(job.state == .failed ? t.cream : t.mute)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func launchdJobDetail(_ job: LaunchdJob) -> String {
+        if let pid = job.pid { return "PID \(pid)" }
+        if let code = job.lastExitCode { return "Last exit \(code)" }
+        return job.isInstalledUserAgent ? "~/Library/LaunchAgents" : "GUI domain"
+    }
+
+    private func launchdStateLabel(_ state: LaunchdJobState) -> String {
+        switch state {
+        case .failed: "FAILED"
+        case .running: "RUNNING"
+        case .idle: "IDLE"
+        case .unloaded: "UNLOADED"
         }
     }
 
@@ -1860,6 +1967,7 @@ struct KajiPopoverView: View {
         case .goals: return "Goals"
         case .aiNews: return L10n.t(.aiNews, prefs.language)
         case .mailBrief: return "Mail Brief"
+        case .launchd: return "Background Tasks"
         }
     }
 

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -265,7 +265,7 @@ struct KajiPopoverView: View {
     private var launchdPanel: some View {
         let installedJobs = launchdJobStore.snapshot.installedJobs
         let installedSummary = launchdJobStore.snapshot.installedSummary
-        VStack(alignment: .leading, spacing: 10) {
+        return VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
                 launchdSummary("\(installedSummary.runningCount)", label: "running")
                 launchdSummary("\(installedSummary.failedCount)", label: "failed")

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -6,6 +6,7 @@ import KajiCore
 final class PopoverNavigation: ObservableObject {
     @Published var panel: KajiModuleID = .quota
     @Published var goalHorizon: GoalHorizon = .today
+    @Published var launchdCategory: LaunchdJobCategory = .userAgent
 }
 
 struct KajiPopoverControls {
@@ -96,7 +97,6 @@ struct KajiPopoverView: View {
     @State private var previousFocusedGoalHorizon: GoalHorizon = .today
     @FocusState private var focusedGoalID: UUID?
     @State private var showCleanConfirmation = false
-    @State private var selectedLaunchdCategory: LaunchdJobCategory = .userAgent
     @State private var showsGoalCreator = false
     @State private var goalCreationTitle = ""
     @State private var goalCreationTagName = GoalTag.personal.rawValue
@@ -132,6 +132,10 @@ struct KajiPopoverView: View {
     private var panel: KajiModuleID {
         get { navigation.panel }
         nonmutating set { navigation.panel = newValue }
+    }
+    private var selectedLaunchdCategory: LaunchdJobCategory {
+        get { navigation.launchdCategory }
+        nonmutating set { navigation.launchdCategory = newValue }
     }
     private var pageIndex: Int {
         pages.firstIndex(of: panel) ?? 0

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -263,11 +263,13 @@ struct KajiPopoverView: View {
     }
 
     private var launchdPanel: some View {
+        let installedJobs = launchdJobStore.snapshot.installedJobs
+        let installedSummary = launchdJobStore.snapshot.installedSummary
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
-                launchdSummary("\(launchdJobStore.snapshot.runningCount)", label: "running")
-                launchdSummary("\(launchdJobStore.snapshot.failedCount)", label: "failed")
-                launchdSummary("\(launchdJobStore.snapshot.unloadedCount)", label: "unloaded")
+                launchdSummary("\(installedSummary.runningCount)", label: "running")
+                launchdSummary("\(installedSummary.failedCount)", label: "failed")
+                launchdSummary("\(installedSummary.unloadedCount)", label: "unloaded")
                 Spacer(minLength: 6)
                 Button { launchdJobStore.refresh() } label: {
                     Image(systemName: "arrow.clockwise")
@@ -278,25 +280,22 @@ struct KajiPopoverView: View {
                 .help("Refresh")
             }
 
-            if launchdJobStore.snapshot.jobs.isEmpty {
+            if installedJobs.isEmpty {
                 HStack {
                     Spacer()
                     if launchdJobStore.isRefreshing {
                         ProgressView()
                             .controlSize(.small)
                     }
-                    Text(launchdJobStore.lastError == nil ? "Looking for GUI jobs…" : "Could not read launchd jobs")
+                    Text(launchdJobStore.lastError == nil ? "Looking for user agents…" : "Could not read user agents")
                         .font(.system(size: 10.5, weight: .medium))
                         .foregroundColor(t.mute)
                     Spacer()
                 }
                 .padding(.vertical, 24)
             } else {
-                let installed = launchdJobStore.snapshot.jobs.filter(\.isInstalledUserAgent)
-                let other = launchdJobStore.snapshot.jobs.filter { !$0.isInstalledUserAgent }
                 LazyVStack(alignment: .leading, spacing: 10) {
-                    launchdSection("User agents", jobs: installed)
-                    launchdSection("Other GUI jobs", jobs: other)
+                    launchdSection("User agents", jobs: installedJobs)
                 }
             }
         }
@@ -354,7 +353,7 @@ struct KajiPopoverView: View {
     private func launchdJobDetail(_ job: LaunchdJob) -> String {
         if let pid = job.pid { return "PID \(pid)" }
         if let code = job.lastExitCode { return "Last exit \(code)" }
-        return job.isInstalledUserAgent ? "~/Library/LaunchAgents" : "GUI domain"
+        return "~/Library/LaunchAgents"
     }
 
     private func launchdStateLabel(_ state: LaunchdJobState) -> String {

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -96,6 +96,7 @@ struct KajiPopoverView: View {
     @State private var previousFocusedGoalHorizon: GoalHorizon = .today
     @FocusState private var focusedGoalID: UUID?
     @State private var showCleanConfirmation = false
+    @State private var selectedLaunchdCategory: LaunchdJobCategory = .userAgent
     @State private var showsGoalCreator = false
     @State private var goalCreationTitle = ""
     @State private var goalCreationTagName = GoalTag.personal.rawValue
@@ -263,14 +264,17 @@ struct KajiPopoverView: View {
     }
 
     private var launchdPanel: some View {
-        let installedJobs = launchdJobStore.snapshot.installedJobs
-        let installedSummary = launchdJobStore.snapshot.installedSummary
+        let snapshot = launchdJobStore.snapshot
+        let selectedJobs = snapshot.jobs(in: selectedLaunchdCategory)
+        let installedSummary = snapshot.installedSummary
+        let runningCount = selectedJobs.count { $0.state == .running }
+        let idleCount = selectedJobs.count { $0.state == .idle }
         return VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
-                launchdSummary("\(installedSummary.runningCount)", label: "running")
-                launchdSummary("\(installedSummary.failedCount)", label: "failed")
-                launchdSummary("\(installedSummary.unloadedCount)", label: "unloaded")
-                Spacer(minLength: 6)
+            HStack(spacing: 4) {
+                launchdCategoryButton(.userAgent, title: "My Tasks", count: snapshot.count(in: .userAgent))
+                launchdCategoryButton(.application, title: "Apps", count: snapshot.count(in: .application))
+                launchdCategoryButton(.appleSystem, title: "Apple", count: snapshot.count(in: .appleSystem))
+                Spacer(minLength: 4)
                 Button { launchdJobStore.refresh() } label: {
                     Image(systemName: "arrow.clockwise")
                         .font(.system(size: 10, weight: .semibold))
@@ -280,14 +284,24 @@ struct KajiPopoverView: View {
                 .help("Refresh")
             }
 
-            if installedJobs.isEmpty {
+            HStack(spacing: 6) {
+                launchdSummary("\(runningCount)", label: "running")
+                if selectedLaunchdCategory == .userAgent {
+                    launchdSummary("\(installedSummary.failedCount)", label: "failed")
+                    launchdSummary("\(installedSummary.unloadedCount)", label: "unloaded")
+                } else {
+                    launchdSummary("\(idleCount)", label: "idle")
+                }
+            }
+
+            if selectedJobs.isEmpty {
                 HStack {
                     Spacer()
                     if launchdJobStore.isRefreshing {
                         ProgressView()
                             .controlSize(.small)
                     }
-                    Text(launchdJobStore.lastError == nil ? "Looking for user agents…" : "Could not read user agents")
+                    Text(launchdJobStore.lastError == nil ? "No tasks in this category" : "Could not read background tasks")
                         .font(.system(size: 10.5, weight: .medium))
                         .foregroundColor(t.mute)
                     Spacer()
@@ -295,9 +309,39 @@ struct KajiPopoverView: View {
                 .padding(.vertical, 24)
             } else {
                 LazyVStack(alignment: .leading, spacing: 10) {
-                    launchdSection("User agents", jobs: installedJobs)
+                    launchdSection(launchdCategoryTitle(selectedLaunchdCategory), jobs: selectedJobs)
                 }
             }
+        }
+    }
+
+    private func launchdCategoryButton(
+        _ category: LaunchdJobCategory,
+        title: String,
+        count: Int
+    ) -> some View {
+        let isSelected = selectedLaunchdCategory == category
+        return Button {
+            selectedLaunchdCategory = category
+        } label: {
+            Text("\(title) \(count)")
+                .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                .foregroundColor(isSelected ? t.cream : t.mute)
+                .padding(.horizontal, 7)
+                .frame(height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(isSelected ? t.track : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func launchdCategoryTitle(_ category: LaunchdJobCategory) -> String {
+        switch category {
+        case .userAgent: "My Tasks"
+        case .application: "Apps & Services"
+        case .appleSystem: "Apple"
         }
     }
 

--- a/Sources/Kaji/LaunchdJobStore.swift
+++ b/Sources/Kaji/LaunchdJobStore.swift
@@ -46,8 +46,17 @@ final class LaunchdJobStore: ObservableObject {
         }
     }
 
+    func refreshStatus() {
+        guard enabled else { return }
+        refresh(requiresVisibility: false)
+    }
+
     func refresh() {
-        guard isActive, !isRefreshing else { return }
+        refresh(requiresVisibility: true)
+    }
+
+    private func refresh(requiresVisibility: Bool) {
+        guard enabled, (!requiresVisibility || popoverVisible), !isRefreshing else { return }
         isRefreshing = true
         refreshInvocationCount += 1
         if ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_AUDIT_LAUNCHD_REFRESH"] == "1" {
@@ -59,7 +68,8 @@ final class LaunchdJobStore: ObservableObject {
             let result = Result { try loader() }
             DispatchQueue.main.async {
                 guard let self,
-                      self.isActive,
+                      self.enabled,
+                      (!requiresVisibility || self.popoverVisible),
                       generation == self.refreshGeneration else { return }
                 self.isRefreshing = false
                 switch result {

--- a/Sources/Kaji/LaunchdJobStore.swift
+++ b/Sources/Kaji/LaunchdJobStore.swift
@@ -24,6 +24,7 @@ final class LaunchdJobStore: ObservableObject {
     var isActive: Bool { enabled && popoverVisible }
 
     func setEnabled(_ enabled: Bool) {
+        guard self.enabled != enabled else { return }
         self.enabled = enabled
         if enabled {
             if popoverVisible { refresh() }
@@ -49,6 +50,9 @@ final class LaunchdJobStore: ObservableObject {
         guard isActive, !isRefreshing else { return }
         isRefreshing = true
         refreshInvocationCount += 1
+        if ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_AUDIT_LAUNCHD_REFRESH"] == "1" {
+            FileHandle.standardOutput.write(Data("KAJI_UI_SMOKE launchd-refresh\n".utf8))
+        }
         let generation = refreshGeneration
         let loader = loadSnapshot
         DispatchQueue.global(qos: .utility).async { [weak self] in

--- a/Sources/Kaji/LaunchdJobStore.swift
+++ b/Sources/Kaji/LaunchdJobStore.swift
@@ -107,9 +107,10 @@ final class LaunchdJobStore: ObservableObject {
         )
     }
 
-    nonisolated private static func installedUserAgentLabels() -> Set<String> {
-        let directory = FileManager.default.homeDirectoryForCurrentUser
+    nonisolated static func installedUserAgentLabels(
+        in directory: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+    ) -> Set<String> {
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: nil,
@@ -117,18 +118,14 @@ final class LaunchdJobStore: ObservableObject {
         ) else { return [] }
 
         return Set(files.compactMap { url in
-            guard url.pathExtension == "plist" else { return nil }
-            if let data = try? Data(contentsOf: url),
-               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
-               let dictionary = plist as? [String: Any],
-               let label = dictionary["Label"] as? String,
-               !label.isEmpty {
-                return label
-            }
-            // A plist file is still an installed agent even when an updater
-            // omits Label or the file is temporarily malformed. Keep it
-            // visible under its conventional filename-derived label.
-            return url.deletingPathExtension().lastPathComponent
+            guard url.pathExtension == "plist",
+                  let data = try? Data(contentsOf: url),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                  let dictionary = plist as? [String: Any],
+                  let label = dictionary["Label"] as? String,
+                  !label.isEmpty
+            else { return nil }
+            return label
         })
     }
 }

--- a/Sources/Kaji/LaunchdJobStore.swift
+++ b/Sources/Kaji/LaunchdJobStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+import KajiCore
+
+@MainActor
+final class LaunchdJobStore: ObservableObject {
+    @Published private(set) var snapshot = LaunchdJobSnapshot(jobs: [])
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var lastError: String?
+
+    private var timer: Timer?
+    private let loadSnapshot: @Sendable () throws -> LaunchdJobSnapshot
+    private(set) var refreshInvocationCount = 0
+
+    init(
+        initialSnapshot: LaunchdJobSnapshot = LaunchdJobSnapshot(jobs: []),
+        loadSnapshot: (@Sendable () throws -> LaunchdJobSnapshot)? = nil
+    ) {
+        snapshot = initialSnapshot
+        self.loadSnapshot = loadSnapshot ?? { try LaunchdJobStore.loadLocalSnapshot() }
+    }
+
+    var isPolling: Bool { timer != nil }
+
+    func setEnabled(_ enabled: Bool) {
+        if enabled {
+            guard timer == nil else { return }
+            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                Task { @MainActor in self?.refresh() }
+            }
+            refresh()
+        } else {
+            timer?.invalidate()
+            timer = nil
+            isRefreshing = false
+            lastError = nil
+            snapshot = LaunchdJobSnapshot(jobs: [])
+        }
+    }
+
+    func refresh() {
+        guard timer != nil, !isRefreshing else { return }
+        isRefreshing = true
+        refreshInvocationCount += 1
+        let loader = loadSnapshot
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let result = Result { try loader() }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isRefreshing = false
+                switch result {
+                case .success(let snapshot):
+                    self.snapshot = snapshot
+                    self.lastError = nil
+                case .failure:
+                    self.lastError = "launchctl_list_failed"
+                }
+            }
+        }
+    }
+
+    func stop() {
+        setEnabled(false)
+    }
+
+    nonisolated private static func loadLocalSnapshot() throws -> LaunchdJobSnapshot {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["list"]
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw LaunchdJobStoreError.launchctlFailed
+        }
+        let listOutput = String(decoding: data, as: UTF8.self)
+        return LaunchdJobLogic.snapshot(
+            listOutput: listOutput,
+            installedLabels: installedUserAgentLabels()
+        )
+    }
+
+    nonisolated private static func installedUserAgentLabels() -> Set<String> {
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        return Set(files.compactMap { url in
+            guard url.pathExtension == "plist" else { return nil }
+            if let data = try? Data(contentsOf: url),
+               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+               let dictionary = plist as? [String: Any],
+               let label = dictionary["Label"] as? String,
+               !label.isEmpty {
+                return label
+            }
+            // A plist file is still an installed agent even when an updater
+            // omits Label or the file is temporarily malformed. Keep it
+            // visible under its conventional filename-derived label.
+            return url.deletingPathExtension().lastPathComponent
+        })
+    }
+}
+
+private enum LaunchdJobStoreError: Error {
+    case launchctlFailed
+}

--- a/Sources/Kaji/LaunchdJobStore.swift
+++ b/Sources/Kaji/LaunchdJobStore.swift
@@ -7,8 +7,10 @@ final class LaunchdJobStore: ObservableObject {
     @Published private(set) var isRefreshing = false
     @Published private(set) var lastError: String?
 
-    private var timer: Timer?
     private let loadSnapshot: @Sendable () throws -> LaunchdJobSnapshot
+    private var enabled = false
+    private var popoverVisible = false
+    private var refreshGeneration = 0
     private(set) var refreshInvocationCount = 0
 
     init(
@@ -19,33 +21,42 @@ final class LaunchdJobStore: ObservableObject {
         self.loadSnapshot = loadSnapshot ?? { try LaunchdJobStore.loadLocalSnapshot() }
     }
 
-    var isPolling: Bool { timer != nil }
+    var isActive: Bool { enabled && popoverVisible }
 
     func setEnabled(_ enabled: Bool) {
+        self.enabled = enabled
         if enabled {
-            guard timer == nil else { return }
-            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-                Task { @MainActor in self?.refresh() }
-            }
-            refresh()
+            if popoverVisible { refresh() }
         } else {
-            timer?.invalidate()
-            timer = nil
+            refreshGeneration += 1
             isRefreshing = false
             lastError = nil
             snapshot = LaunchdJobSnapshot(jobs: [])
         }
     }
 
+    func setPopoverVisible(_ visible: Bool) {
+        popoverVisible = visible
+        if visible {
+            refresh()
+        } else {
+            refreshGeneration += 1
+            isRefreshing = false
+        }
+    }
+
     func refresh() {
-        guard timer != nil, !isRefreshing else { return }
+        guard isActive, !isRefreshing else { return }
         isRefreshing = true
         refreshInvocationCount += 1
+        let generation = refreshGeneration
         let loader = loadSnapshot
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let result = Result { try loader() }
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self,
+                      self.isActive,
+                      generation == self.refreshGeneration else { return }
                 self.isRefreshing = false
                 switch result {
                 case .success(let snapshot):

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 import KajiCore
 
-private enum SettingsSection: String, CaseIterable, Identifiable {
+enum SettingsSection: String, CaseIterable, Identifiable {
     case general = "General"
     case modules = "Modules"
     case work = "Work"
@@ -51,6 +51,22 @@ struct SettingsView: View {
     @State private var loginPermission: PermissionState = .notAuthorized
     @State private var sleepPermission: PermissionState = .notAuthorized
 
+
+    init(
+        prefs: Prefs,
+        sleepController: SleepController,
+        fixedPlanStore: FixedPlanStore,
+        mailBriefStore: MailBriefStore,
+        initialSection: SettingsSection = .general,
+        onFixedPlanEditorChange: ((Bool) -> Void)? = nil
+    ) {
+        self.prefs = prefs
+        self.sleepController = sleepController
+        self.fixedPlanStore = fixedPlanStore
+        self.mailBriefStore = mailBriefStore
+        self.onFixedPlanEditorChange = onFixedPlanEditorChange
+        _selection = State(initialValue: initialSection)
+    }
     @Environment(\.colorScheme) private var scheme
     private var t: KajiTheme { .resolve(scheme) }
 

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -90,6 +90,7 @@ struct SettingsView: View {
                     moduleRow(.goals, title: L10n.t(.moduleGoals, prefs.language), lockedOn: false)
                     moduleRow(.aiNews, title: L10n.t(.moduleAINews, prefs.language), lockedOn: false)
                     moduleRow(.mailBrief, title: "Mail Brief", lockedOn: false)
+                    moduleRow(.launchd, title: "Background Tasks", lockedOn: false)
                 }
             }
             }

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import KajiCore
 
 // MARK: - StatusItemView
 //
@@ -27,11 +28,13 @@ struct StatusItemView: View {
     var showsAINewsSlot: Bool = false
     var mailBriefSlotLabel: String? = nil
     var showsMailBriefSlot: Bool = false
+    var launchdStatus: LaunchdMenuBarStatus? = nil
     var onQuotaClick: () -> Void = {}
     var onWorkClick: () -> Void = {}
     var onGoalsClick: () -> Void = {}
     var onAINewsClick: () -> Void = {}
     var onMailBriefClick: () -> Void = {}
+    var onLaunchdClick: () -> Void = {}
 
     @Environment(\.colorScheme) private var scheme
 
@@ -87,6 +90,29 @@ struct StatusItemView: View {
                     .foregroundStyle(scheme == .dark ? .white : .black)
                     .fixedSize()
                     .contentShape(Rectangle())
+                }.buttonStyle(.plain)
+            }
+            if let launchdStatus {
+                Button(action: onLaunchdClick) {
+                    HStack(spacing: 2) {
+                        Image(systemName: "gearshape.2")
+                            .font(.system(size: 10.5, weight: .medium))
+                        Text(String(launchdStatus.count))
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .monospacedDigit()
+                    }
+                    .foregroundStyle(
+                        launchdStatus.hasFailures
+                            ? KajiTheme.resolve(scheme).amber
+                            : (scheme == .dark ? .white : .black)
+                    )
+                    .fixedSize()
+                    .contentShape(Rectangle())
+                    .accessibilityLabel(
+                        launchdStatus.hasFailures
+                            ? "\(launchdStatus.count) failed background tasks"
+                            : "\(launchdStatus.count) running background tasks"
+                    )
                 }.buttonStyle(.plain)
             }
         }

--- a/Sources/Kaji/main.swift
+++ b/Sources/Kaji/main.swift
@@ -8,7 +8,17 @@ import AppKit
 let app = NSApplication.shared
 // main.swift top-level runs on the main thread but is nonisolated to the type
 // system; AppDelegate is @MainActor, so assume isolation to build it here.
-let delegate = MainActor.assumeIsolated { AppDelegate() }
+let delegate = MainActor.assumeIsolated {
+    let environment = ProcessInfo.processInfo.environment
+    if let nonce = environment["KAJI_UI_SMOKE_NONCE"],
+       let defaults = UserDefaults(suiteName: "dev.kaji.ui-smoke.\(nonce)") {
+        let cacheDirectory = environment["KAJI_UI_SMOKE_ARTIFACTS"].map {
+            URL(fileURLWithPath: $0, isDirectory: true)
+        }
+        return AppDelegate(defaults: defaults, cacheDirectory: cacheDirectory)
+    }
+    return AppDelegate()
+}
 app.delegate = delegate
 app.setActivationPolicy(.accessory)
 app.run()

--- a/Sources/KajiCore/GoalHorizonModel.swift
+++ b/Sources/KajiCore/GoalHorizonModel.swift
@@ -231,6 +231,7 @@ public enum MenuBarDestination: Equatable, Sendable {
     case goalsToday
     case aiNews
     case mailBrief
+    case launchd
 }
 
 public enum MenuBarSlotLogic {
@@ -255,12 +256,35 @@ public enum MenuBarSlotLogic {
         case .goals: .goalsToday
         case .aiNews: .aiNews
         case .mailBrief: .mailBrief
+        case .launchd: .launchd
         }
     }
 
     public static func mailBriefLabel(enabled: Bool, actCount: Int) -> String? {
         guard enabled, actCount > 0 else { return nil }
         return String(actCount)
+    }
+
+    public static func launchdStatus(
+        enabled: Bool,
+        runningCount: Int,
+        failedCount: Int
+    ) -> LaunchdMenuBarStatus? {
+        guard enabled else { return nil }
+        if failedCount > 0 {
+            return LaunchdMenuBarStatus(count: failedCount, hasFailures: true)
+        }
+        return LaunchdMenuBarStatus(count: runningCount, hasFailures: false)
+    }
+}
+
+public struct LaunchdMenuBarStatus: Equatable, Sendable {
+    public let count: Int
+    public let hasFailures: Bool
+
+    public init(count: Int, hasFailures: Bool) {
+        self.count = count
+        self.hasFailures = hasFailures
     }
 }
 
@@ -270,5 +294,6 @@ public enum MenuBarSlot: Equatable, Sendable {
     case goals
     case aiNews
     case mailBrief
+    case launchd
     case background
 }

--- a/Sources/KajiCore/LaunchdJobLogic.swift
+++ b/Sources/KajiCore/LaunchdJobLogic.swift
@@ -33,6 +33,20 @@ public struct LaunchdJob: Identifiable, Equatable, Sendable {
     }
 }
 
+public struct LaunchdInstalledJobSummary: Equatable, Sendable {
+    public let runningCount: Int
+    public let failedCount: Int
+    public let unloadedCount: Int
+    public let idleCount: Int
+
+    public init(runningCount: Int, failedCount: Int, unloadedCount: Int, idleCount: Int) {
+        self.runningCount = runningCount
+        self.failedCount = failedCount
+        self.unloadedCount = unloadedCount
+        self.idleCount = idleCount
+    }
+}
+
 public struct LaunchdJobSnapshot: Equatable, Sendable {
     public let jobs: [LaunchdJob]
 
@@ -40,9 +54,30 @@ public struct LaunchdJobSnapshot: Equatable, Sendable {
         self.jobs = jobs
     }
 
-    public var runningCount: Int { jobs.count { $0.state == .running } }
-    public var failedCount: Int { jobs.count { $0.state == .failed } }
-    public var unloadedCount: Int { jobs.count { $0.state == .unloaded } }
+    public var installedJobs: [LaunchdJob] {
+        jobs.filter(\.isInstalledUserAgent)
+    }
+
+    public var installedSummary: LaunchdInstalledJobSummary {
+        var runningCount = 0
+        var failedCount = 0
+        var unloadedCount = 0
+        var idleCount = 0
+        for job in jobs where job.isInstalledUserAgent {
+            switch job.state {
+            case .running: runningCount += 1
+            case .failed: failedCount += 1
+            case .unloaded: unloadedCount += 1
+            case .idle: idleCount += 1
+            }
+        }
+        return LaunchdInstalledJobSummary(
+            runningCount: runningCount,
+            failedCount: failedCount,
+            unloadedCount: unloadedCount,
+            idleCount: idleCount
+        )
+    }
 }
 
 public enum LaunchdJobLogic {

--- a/Sources/KajiCore/LaunchdJobLogic.swift
+++ b/Sources/KajiCore/LaunchdJobLogic.swift
@@ -9,7 +9,7 @@ public enum LaunchdJobState: Int, Codable, Sendable, CaseIterable {
     public var sortRank: Int { rawValue }
 }
 
-public enum LaunchdJobCategory: Sendable, CaseIterable {
+public enum LaunchdJobCategory: String, Sendable, CaseIterable {
     case userAgent
     case application
     case appleSystem

--- a/Sources/KajiCore/LaunchdJobLogic.swift
+++ b/Sources/KajiCore/LaunchdJobLogic.swift
@@ -9,6 +9,12 @@ public enum LaunchdJobState: Int, Codable, Sendable, CaseIterable {
     public var sortRank: Int { rawValue }
 }
 
+public enum LaunchdJobCategory: Sendable, CaseIterable {
+    case userAgent
+    case application
+    case appleSystem
+}
+
 public struct LaunchdJob: Identifiable, Equatable, Sendable {
     public let label: String
     public let pid: Int?
@@ -17,6 +23,14 @@ public struct LaunchdJob: Identifiable, Equatable, Sendable {
     public let state: LaunchdJobState
 
     public var id: String { label }
+
+    public var category: LaunchdJobCategory {
+        if isInstalledUserAgent { return .userAgent }
+        if label.hasPrefix("com.apple.") || label.hasPrefix("application.com.apple.") {
+            return .appleSystem
+        }
+        return .application
+    }
 
     public init(
         label: String,
@@ -55,7 +69,15 @@ public struct LaunchdJobSnapshot: Equatable, Sendable {
     }
 
     public var installedJobs: [LaunchdJob] {
-        jobs.filter(\.isInstalledUserAgent)
+        jobs(in: .userAgent)
+    }
+
+    public func jobs(in category: LaunchdJobCategory) -> [LaunchdJob] {
+        jobs.filter { $0.category == category }
+    }
+
+    public func count(in category: LaunchdJobCategory) -> Int {
+        jobs.count { $0.category == category }
     }
 
     public var installedSummary: LaunchdInstalledJobSummary {
@@ -95,10 +117,11 @@ public enum LaunchdJobLogic {
 
             let pid = Int(pidText)
             let lastExitCode = Int(exitText)
+            let isInstalledUserAgent = installedLabels.contains(label)
             let state: LaunchdJobState
             if pid != nil {
                 state = .running
-            } else if let lastExitCode, lastExitCode != 0 {
+            } else if isInstalledUserAgent, let lastExitCode, lastExitCode != 0 {
                 state = .failed
             } else {
                 state = .idle
@@ -107,7 +130,7 @@ public enum LaunchdJobLogic {
                 label: label,
                 pid: pid,
                 lastExitCode: lastExitCode,
-                isInstalledUserAgent: installedLabels.contains(label),
+                isInstalledUserAgent: isInstalledUserAgent,
                 state: state
             )
         }

--- a/Sources/KajiCore/LaunchdJobLogic.swift
+++ b/Sources/KajiCore/LaunchdJobLogic.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public enum LaunchdJobState: Int, Codable, Sendable, CaseIterable {
+    case failed
+    case running
+    case idle
+    case unloaded
+
+    public var sortRank: Int { rawValue }
+}
+
+public struct LaunchdJob: Identifiable, Equatable, Sendable {
+    public let label: String
+    public let pid: Int?
+    public let lastExitCode: Int?
+    public let isInstalledUserAgent: Bool
+    public let state: LaunchdJobState
+
+    public var id: String { label }
+
+    public init(
+        label: String,
+        pid: Int?,
+        lastExitCode: Int?,
+        isInstalledUserAgent: Bool,
+        state: LaunchdJobState
+    ) {
+        self.label = label
+        self.pid = pid
+        self.lastExitCode = lastExitCode
+        self.isInstalledUserAgent = isInstalledUserAgent
+        self.state = state
+    }
+}
+
+public struct LaunchdJobSnapshot: Equatable, Sendable {
+    public let jobs: [LaunchdJob]
+
+    public init(jobs: [LaunchdJob]) {
+        self.jobs = jobs
+    }
+
+    public var runningCount: Int { jobs.count { $0.state == .running } }
+    public var failedCount: Int { jobs.count { $0.state == .failed } }
+    public var unloadedCount: Int { jobs.count { $0.state == .unloaded } }
+}
+
+public enum LaunchdJobLogic {
+    /// Parses the tab-separated output of `launchctl list` in one pass, then
+    public static func snapshot(listOutput: String, installedLabels: Set<String>) -> LaunchdJobSnapshot {
+        var jobsByLabel: [String: LaunchdJob] = [:]
+
+        for line in listOutput.split(whereSeparator: \.isNewline) {
+            let columns = line.split(separator: "\t", omittingEmptySubsequences: false)
+            guard columns.count >= 3 else { continue }
+            let pidText = String(columns[0])
+            let exitText = String(columns[1])
+            let label = columns.dropFirst(2).joined(separator: "\t")
+            guard label != "Label", !label.isEmpty else { continue }
+
+            let pid = Int(pidText)
+            let lastExitCode = Int(exitText)
+            let state: LaunchdJobState
+            if pid != nil {
+                state = .running
+            } else if let lastExitCode, lastExitCode != 0 {
+                state = .failed
+            } else {
+                state = .idle
+            }
+            jobsByLabel[label] = LaunchdJob(
+                label: label,
+                pid: pid,
+                lastExitCode: lastExitCode,
+                isInstalledUserAgent: installedLabels.contains(label),
+                state: state
+            )
+        }
+
+        for label in installedLabels where jobsByLabel[label] == nil {
+            jobsByLabel[label] = LaunchdJob(
+                label: label,
+                pid: nil,
+                lastExitCode: nil,
+                isInstalledUserAgent: true,
+                state: .unloaded
+            )
+        }
+
+        let jobs = jobsByLabel.values.sorted {
+            if $0.isInstalledUserAgent != $1.isInstalledUserAgent {
+                return $0.isInstalledUserAgent && !$1.isInstalledUserAgent
+            }
+            if $0.state.sortRank != $1.state.sortRank {
+                return $0.state.sortRank < $1.state.sortRank
+            }
+            return $0.label.localizedStandardCompare($1.label) == .orderedAscending
+        }
+        return LaunchdJobSnapshot(jobs: jobs)
+    }
+}

--- a/Sources/KajiCore/ModulePrefsLogic.swift
+++ b/Sources/KajiCore/ModulePrefsLogic.swift
@@ -8,9 +8,10 @@ public enum KajiModuleID: String, CaseIterable, Codable, Sendable, Comparable {
     case goals
     case aiNews
     case mailBrief
+    case launchd
 
     /// Stable popover order. Unknown / disabled ids never appear here.
-    public static let stableOrder: [KajiModuleID] = [.quota, .work, .system, .goals, .aiNews, .mailBrief]
+    public static let stableOrder: [KajiModuleID] = [.quota, .work, .system, .goals, .aiNews, .mailBrief, .launchd]
 
     public static func < (lhs: KajiModuleID, rhs: KajiModuleID) -> Bool {
         let li = stableOrder.firstIndex(of: lhs) ?? Int.max

--- a/Tests/KajiTests/KajiControlServerTests.swift
+++ b/Tests/KajiTests/KajiControlServerTests.swift
@@ -31,6 +31,66 @@ final class KajiControlServerTests: XCTestCase {
         XCTAssertEqual(state["sample"] as? Bool, true)
     }
 
+    func testUIAutomationRouteIsHiddenWithoutExactNonce() async throws {
+        let suite = "KajiControlServerTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = DailyGoalStore(defaults: defaults)
+
+        let unavailablePort = UInt16.random(in: 40_000...49_999)
+        let unavailableServer = KajiControlServer(goals: store, port: unavailablePort)
+        unavailableServer.start()
+        let unavailableBase = try XCTUnwrap(URL(string: "http://127.0.0.1:\(unavailablePort)/v1"))
+        try await waitUntilReachable(unavailableBase.appending(path: "goals"))
+        let unavailable = try await rawRequest(
+            unavailableBase,
+            method: "POST",
+            path: "test/render",
+            body: ["nonce": "anything", "surface": "status", "selection": "status", "outputPath": "/tmp/x"]
+        )
+        XCTAssertEqual(unavailable.status, 404)
+        unavailableServer.stop()
+
+        let automationPort = UInt16.random(in: 50_000...60_000)
+        let automationBase = try XCTUnwrap(URL(string: "http://127.0.0.1:\(automationPort)/v1"))
+        let automationServer = KajiControlServer(
+            goals: store,
+            port: automationPort,
+            testAutomation: .init(
+                nonce: "exact-test-nonce",
+                render: { surface, selection, outputPath in
+                    ["surface": surface, "selection": selection, "path": outputPath]
+                }
+            )
+        )
+        automationServer.start()
+        defer { automationServer.stop() }
+        try await waitUntilReachable(automationBase.appending(path: "goals"))
+
+        let rejected = try await rawRequest(
+            automationBase,
+            method: "POST",
+            path: "test/render",
+            body: ["nonce": "wrong", "surface": "popover", "selection": "quota", "outputPath": "/tmp/x"]
+        )
+        XCTAssertEqual(rejected.status, 404)
+
+        let accepted = try await rawRequest(
+            automationBase,
+            method: "POST",
+            path: "test/render",
+            body: [
+                "nonce": "exact-test-nonce",
+                "surface": "popover",
+                "selection": "launchd",
+                "outputPath": "/tmp/render.png",
+            ]
+        )
+        XCTAssertEqual(accepted.status, 200)
+        XCTAssertEqual(accepted.object["selection"] as? String, "launchd")
+        XCTAssertEqual(accepted.object["path"] as? String, "/tmp/render.png")
+    }
+
     private func waitUntilReachable(_ url: URL) async throws {
         for _ in 0..<50 {
             var request = URLRequest(url: url)
@@ -52,5 +112,24 @@ final class KajiControlServerTests: XCTestCase {
         let (data, response) = try await URLSession.shared.data(for: request)
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200, String(decoding: data, as: UTF8.self))
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func rawRequest(
+        _ base: URL,
+        method: String,
+        path: String,
+        body: [String: Any]? = nil
+    ) async throws -> (status: Int, object: [String: Any]) {
+        var request = URLRequest(url: base.appending(path: path))
+        request.httpMethod = method
+        if let body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, response) = try await URLSession.shared.data(for: request)
+        return (
+            try XCTUnwrap((response as? HTTPURLResponse)?.statusCode),
+            try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        )
     }
 }

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -80,7 +80,6 @@ final class LaunchdJobLogicTests: XCTestCase {
         XCTAssertEqual(snapshot.installedJobs.first(where: { $0.label == "dev.brook.failed" })?.lastExitCode, 78)
     }
 
-
     func testSkipsHeaderAndMalformedRows() {
         let snapshot = LaunchdJobLogic.snapshot(
             listOutput: "PID\tStatus\tLabel\nnot a launchctl row\n-\t-\tvalid.label\n",
@@ -90,6 +89,28 @@ final class LaunchdJobLogicTests: XCTestCase {
         XCTAssertEqual(snapshot.jobs.map(\.label), ["valid.label"])
         XCTAssertEqual(snapshot.jobs[0].state, .idle)
         XCTAssertNil(snapshot.jobs[0].lastExitCode)
+    }
+}
+
+@MainActor
+final class LaunchdJobDiscoveryTests: XCTestCase {
+    func testDiscoversOnlyPlistsWithValidLabels() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let valid = ["Label": "dev.brook.valid"]
+        let labelLess = ["Program": "/usr/bin/true"]
+        let empty: [String: String] = [:]
+        for (name, plist) in [("valid", valid), ("label-less", labelLess), ("empty", empty)] {
+            let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+            try data.write(to: directory.appendingPathComponent("\(name).plist"))
+        }
+        try Data("not a plist".utf8).write(to: directory.appendingPathComponent("malformed.plist"))
+        try Data("ignored".utf8).write(to: directory.appendingPathComponent("not-a-plist.txt"))
+
+        XCTAssertEqual(LaunchdJobStore.installedUserAgentLabels(in: directory), ["dev.brook.valid"])
     }
 }
 

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -61,23 +61,32 @@ final class LaunchdJobLogicTests: XCTestCase {
 
 @MainActor
 final class LaunchdJobStoreLifecycleTests: XCTestCase {
-    func testDisabledStoreDoesNotRefreshAndClearsModuleState() {
+    func testRefreshRunsOnlyWhileEnabledAndPopoverVisible() {
         let loaded = LaunchdJobSnapshot(jobs: [
             LaunchdJob(label: "dev.kaji.test", pid: 42, lastExitCode: 0, isInstalledUserAgent: true, state: .running),
         ])
-        let store = LaunchdJobStore(loadSnapshot: { loaded })
+        let store = LaunchdJobStore(initialSnapshot: loaded, loadSnapshot: { loaded })
 
         store.refresh()
         XCTAssertEqual(store.refreshInvocationCount, 0)
-        XCTAssertFalse(store.isPolling)
+        XCTAssertFalse(store.isActive)
 
         store.setEnabled(true)
+        XCTAssertEqual(store.refreshInvocationCount, 0)
+        XCTAssertFalse(store.isActive)
+
+        store.setPopoverVisible(true)
         XCTAssertEqual(store.refreshInvocationCount, 1)
-        XCTAssertTrue(store.isPolling)
+        XCTAssertTrue(store.isActive)
+
+        store.setPopoverVisible(false)
+        XCTAssertFalse(store.isActive)
+        store.refresh()
+        XCTAssertEqual(store.refreshInvocationCount, 1, "closing the popover must stop further refreshes")
 
         store.setEnabled(false)
-        XCTAssertFalse(store.isPolling)
         XCTAssertTrue(store.snapshot.jobs.isEmpty)
+        store.setPopoverVisible(true)
         store.refresh()
         XCTAssertEqual(store.refreshInvocationCount, 1)
     }

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Kaji
+@testable import KajiCore
+
+final class LaunchdJobLogicTests: XCTestCase {
+    func testParsesStatesAndAddsUnloadedInstalledAgent() {
+        let output = """
+        PID\tStatus\tLabel
+        321\t0\tdev.kaji.running
+        -\t1\tdev.kaji.failed
+        -\t0\tdev.kaji.idle
+        """
+
+        let snapshot = LaunchdJobLogic.snapshot(
+            listOutput: output,
+            installedLabels: ["dev.kaji.running", "dev.kaji.failed", "dev.kaji.unloaded"]
+        )
+
+        XCTAssertEqual(snapshot.runningCount, 1)
+        XCTAssertEqual(snapshot.failedCount, 1)
+        XCTAssertEqual(snapshot.unloadedCount, 1)
+        XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.running" })?.pid, 321)
+        XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.failed" })?.state, .failed)
+        XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.idle" })?.state, .idle)
+        XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.unloaded" })?.state, .unloaded)
+    }
+
+    func testSortsInstalledAgentsBeforeOtherGUIJobsAndAttentionFirst() {
+        let output = """
+        PID\tStatus\tLabel
+        11\t0\tcom.apple.running
+        22\t0\tdev.kaji.running
+        -\t7\tdev.kaji.failed
+        -\t0\tdev.kaji.idle
+        """
+
+        let snapshot = LaunchdJobLogic.snapshot(
+            listOutput: output,
+            installedLabels: ["dev.kaji.running", "dev.kaji.failed", "dev.kaji.idle"]
+        )
+
+        XCTAssertEqual(snapshot.jobs.map(\.label), [
+            "dev.kaji.failed",
+            "dev.kaji.running",
+            "dev.kaji.idle",
+            "com.apple.running",
+        ])
+    }
+
+    func testSkipsHeaderAndMalformedRows() {
+        let snapshot = LaunchdJobLogic.snapshot(
+            listOutput: "PID\tStatus\tLabel\nnot a launchctl row\n-\t-\tvalid.label\n",
+            installedLabels: []
+        )
+
+        XCTAssertEqual(snapshot.jobs.map(\.label), ["valid.label"])
+        XCTAssertEqual(snapshot.jobs[0].state, .idle)
+        XCTAssertNil(snapshot.jobs[0].lastExitCode)
+    }
+}
+
+@MainActor
+final class LaunchdJobStoreLifecycleTests: XCTestCase {
+    func testDisabledStoreDoesNotRefreshAndClearsModuleState() {
+        let loaded = LaunchdJobSnapshot(jobs: [
+            LaunchdJob(label: "dev.kaji.test", pid: 42, lastExitCode: 0, isInstalledUserAgent: true, state: .running),
+        ])
+        let store = LaunchdJobStore(loadSnapshot: { loaded })
+
+        store.refresh()
+        XCTAssertEqual(store.refreshInvocationCount, 0)
+        XCTAssertFalse(store.isPolling)
+
+        store.setEnabled(true)
+        XCTAssertEqual(store.refreshInvocationCount, 1)
+        XCTAssertTrue(store.isPolling)
+
+        store.setEnabled(false)
+        XCTAssertFalse(store.isPolling)
+        XCTAssertTrue(store.snapshot.jobs.isEmpty)
+        store.refresh()
+        XCTAssertEqual(store.refreshInvocationCount, 1)
+    }
+}

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -47,6 +47,7 @@ final class LaunchdJobLogicTests: XCTestCase {
             "com.apple.running",
         ])
     }
+
     func testInstalledSummaryIgnoresLargeSessionDomainAndKeepsNonzeroExitFailed() {
         let otherJobs = (0..<128).map { index in
             index.isMultiple(of: 2)
@@ -78,6 +79,40 @@ final class LaunchdJobLogicTests: XCTestCase {
         )
         XCTAssertEqual(snapshot.installedJobs.first(where: { $0.label == "dev.brook.failed" })?.state, .failed)
         XCTAssertEqual(snapshot.installedJobs.first(where: { $0.label == "dev.brook.failed" })?.lastExitCode, 78)
+    }
+
+    func testCategorizesJobsAndLimitsFailureToInstalledAgents() {
+        let output = """
+        PID\tStatus\tLabel
+        -\t78\tdev.brook.task
+        -\t-9\tcom.adobe.helper
+        -\t78\tcom.openai.service
+        -\t-9\tcom.apple.cache
+        -\t78\tapplication.com.apple.Safari.123
+        """
+        let snapshot = LaunchdJobLogic.snapshot(
+            listOutput: output,
+            installedLabels: ["dev.brook.task"]
+        )
+
+        XCTAssertEqual(snapshot.jobs(in: .userAgent).map(\.label), ["dev.brook.task"])
+        XCTAssertEqual(Set(snapshot.jobs(in: .application).map(\.label)), [
+            "com.adobe.helper",
+            "com.openai.service",
+        ])
+        XCTAssertEqual(Set(snapshot.jobs(in: .appleSystem).map(\.label)), [
+            "application.com.apple.Safari.123",
+            "com.apple.cache",
+        ])
+        XCTAssertEqual(snapshot.jobs(in: .userAgent).first?.state, .failed)
+        XCTAssertEqual(snapshot.jobs(in: .userAgent).first?.lastExitCode, 78)
+        XCTAssertTrue(snapshot.jobs(in: .application).allSatisfy { $0.state == .idle })
+        XCTAssertTrue(snapshot.jobs(in: .appleSystem).allSatisfy { $0.state == .idle })
+        XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "com.adobe.helper" })?.lastExitCode, -9)
+        XCTAssertEqual(
+            snapshot.jobs.first(where: { $0.label == "application.com.apple.Safari.123" })?.lastExitCode,
+            78
+        )
     }
 
     func testSkipsHeaderAndMalformedRows() {

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -90,4 +90,16 @@ final class LaunchdJobStoreLifecycleTests: XCTestCase {
         store.refresh()
         XCTAssertEqual(store.refreshInvocationCount, 1)
     }
+
+    func testStatusRefreshCanRunOnceWhilePopoverIsHidden() {
+        let loaded = LaunchdJobSnapshot(jobs: [])
+        let store = LaunchdJobStore(initialSnapshot: loaded, loadSnapshot: { loaded })
+
+        store.refreshStatus()
+        XCTAssertEqual(store.refreshInvocationCount, 0)
+        store.setEnabled(true)
+        store.refreshStatus()
+        XCTAssertEqual(store.refreshInvocationCount, 1)
+        XCTAssertFalse(store.isActive)
+    }
 }

--- a/Tests/KajiTests/LaunchdJobLogicTests.swift
+++ b/Tests/KajiTests/LaunchdJobLogicTests.swift
@@ -16,9 +16,10 @@ final class LaunchdJobLogicTests: XCTestCase {
             installedLabels: ["dev.kaji.running", "dev.kaji.failed", "dev.kaji.unloaded"]
         )
 
-        XCTAssertEqual(snapshot.runningCount, 1)
-        XCTAssertEqual(snapshot.failedCount, 1)
-        XCTAssertEqual(snapshot.unloadedCount, 1)
+        XCTAssertEqual(snapshot.installedSummary.runningCount, 1)
+        XCTAssertEqual(snapshot.installedSummary.failedCount, 1)
+        XCTAssertEqual(snapshot.installedSummary.unloadedCount, 1)
+        XCTAssertEqual(snapshot.installedSummary.idleCount, 0)
         XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.running" })?.pid, 321)
         XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.failed" })?.state, .failed)
         XCTAssertEqual(snapshot.jobs.first(where: { $0.label == "dev.kaji.idle" })?.state, .idle)
@@ -46,6 +47,39 @@ final class LaunchdJobLogicTests: XCTestCase {
             "com.apple.running",
         ])
     }
+    func testInstalledSummaryIgnoresLargeSessionDomainAndKeepsNonzeroExitFailed() {
+        let otherJobs = (0..<128).map { index in
+            index.isMultiple(of: 2)
+                ? "\(index + 1000)\t0\tcom.apple.session.\(index)"
+                : "-\t\(index + 1)\tcom.apple.session.\(index)"
+        }
+        let output = ([
+            "PID\tStatus\tLabel",
+            "42\t0\tdev.brook.running",
+            "-\t78\tdev.brook.failed",
+            "-\t0\tdev.brook.idle",
+        ] + otherJobs).joined(separator: "\n")
+
+        let snapshot = LaunchdJobLogic.snapshot(
+            listOutput: output,
+            installedLabels: ["dev.brook.running", "dev.brook.failed", "dev.brook.idle", "dev.brook.unloaded"]
+        )
+
+        XCTAssertEqual(snapshot.jobs.count, 132)
+        XCTAssertEqual(snapshot.installedJobs.map(\.label), [
+            "dev.brook.failed",
+            "dev.brook.running",
+            "dev.brook.idle",
+            "dev.brook.unloaded",
+        ])
+        XCTAssertEqual(
+            snapshot.installedSummary,
+            LaunchdInstalledJobSummary(runningCount: 1, failedCount: 1, unloadedCount: 1, idleCount: 1)
+        )
+        XCTAssertEqual(snapshot.installedJobs.first(where: { $0.label == "dev.brook.failed" })?.state, .failed)
+        XCTAssertEqual(snapshot.installedJobs.first(where: { $0.label == "dev.brook.failed" })?.lastExitCode, 78)
+    }
+
 
     func testSkipsHeaderAndMalformedRows() {
         let snapshot = LaunchdJobLogic.snapshot(

--- a/Tests/KajiTests/MenuBarSlotLogicTests.swift
+++ b/Tests/KajiTests/MenuBarSlotLogicTests.swift
@@ -50,6 +50,7 @@ final class MenuBarSlotLogicTests: XCTestCase {
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .background), .quota)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .aiNews), .aiNews)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .mailBrief), .mailBrief)
+        XCTAssertEqual(MenuBarSlotLogic.destination(for: .launchd), .launchd)
     }
 
     func testMailBriefLabelShowsTrueActCountWithoutCap() {
@@ -57,5 +58,17 @@ final class MenuBarSlotLogicTests: XCTestCase {
         XCTAssertNil(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: 0))
         XCTAssertEqual(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: 4), "4")
         XCTAssertEqual(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: 128), "128")
+    }
+
+    func testLaunchdStatusPrioritizesFailedCountAndDisappearsWhenDisabled() {
+        XCTAssertNil(MenuBarSlotLogic.launchdStatus(enabled: false, runningCount: 12, failedCount: 3))
+        XCTAssertEqual(
+            MenuBarSlotLogic.launchdStatus(enabled: true, runningCount: 12, failedCount: 0),
+            LaunchdMenuBarStatus(count: 12, hasFailures: false)
+        )
+        XCTAssertEqual(
+            MenuBarSlotLogic.launchdStatus(enabled: true, runningCount: 12, failedCount: 3),
+            LaunchdMenuBarStatus(count: 3, hasFailures: true)
+        )
     }
 }

--- a/Tests/KajiTests/ModulePrefsLogicTests.swift
+++ b/Tests/KajiTests/ModulePrefsLogicTests.swift
@@ -62,7 +62,7 @@ final class ModulePrefsLogicTests: XCTestCase {
 
     func testPopoverPages_allEnabled_fullOrder() {
         let pages = ModulePrefsLogic.popoverPages(
-            enabled: [.quota, .work, .system, .goals, .aiNews, .mailBrief]
+            enabled: Set(KajiModuleID.allCases)
         )
         XCTAssertEqual(pages, KajiModuleID.stableOrder)
     }
@@ -77,6 +77,14 @@ final class ModulePrefsLogicTests: XCTestCase {
         XCTAssertEqual(
             ModulePrefsLogic.popoverPages(enabled: [.quota, .goals, .aiNews, .mailBrief]),
             [.quota, .goals, .aiNews, .mailBrief]
+        )
+    }
+
+    func testLaunchdDefaultsOffAndAppearsLastWhenEnabled() {
+        XCTAssertFalse(ModulePrefsLogic.normalizeEnabledModules(nil).contains(.launchd))
+        XCTAssertEqual(
+            ModulePrefsLogic.popoverPages(enabled: [.quota, .launchd]),
+            [.quota, .launchd]
         )
     }
 

--- a/Tests/KajiTests/PopoverHeightBudgetTests.swift
+++ b/Tests/KajiTests/PopoverHeightBudgetTests.swift
@@ -99,6 +99,7 @@ final class PopoverHeightBudgetTests: XCTestCase {
             fixedPlanStore: fixture.fixedPlanStore,
             aiNewsStore: fixture.aiNewsStore,
             mailBriefStore: fixture.mailBriefStore,
+            launchdJobStore: fixture.launchdJobStore,
             navigation: fixture.navigation,
             controls: KajiPopoverControls(
                 onOpenSettings: {}, onQuit: {},

--- a/Tests/KajiTests/UITestHarness.swift
+++ b/Tests/KajiTests/UITestHarness.swift
@@ -282,6 +282,7 @@ final class PopoverRenderFixture {
     let fixedPlanStore: FixedPlanStore
     let aiNewsStore: AIHotNewsStore
     let mailBriefStore: MailBriefStore
+    let launchdJobStore: LaunchdJobStore
     let navigation = PopoverNavigation()
 
     private let suiteName: String
@@ -348,6 +349,11 @@ final class PopoverRenderFixture {
             ),
             cacheDirectory: cacheDirectory
         )
+        launchdJobStore = LaunchdJobStore(initialSnapshot: LaunchdJobSnapshot(jobs: [
+            LaunchdJob(label: "dev.kaji.fixture", pid: 4242, lastExitCode: 0, isInstalledUserAgent: true, state: .running),
+            LaunchdJob(label: "com.example.failed", pid: nil, lastExitCode: 1, isInstalledUserAgent: true, state: .failed),
+            LaunchdJob(label: "com.apple.fixture", pid: nil, lastExitCode: 0, isInstalledUserAgent: false, state: .idle),
+        ]))
         workSession = WorkSessionController(prefs: prefs)
         prefs.enabledModules = Set(KajiModuleID.allCases)
         _ = try? dailyGoals.addGoal(
@@ -385,6 +391,7 @@ final class PopoverRenderFixture {
             fixedPlanStore: fixedPlanStore,
             aiNewsStore: aiNewsStore,
             mailBriefStore: mailBriefStore,
+            launchdJobStore: launchdJobStore,
             navigation: navigation,
             controls: KajiPopoverControls(
                 onOpenSettings: {},

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -20,6 +20,7 @@ Feature specs、bug-fix notes、implementation plans、单次 UI 调整和逐版
 | [product/vision.md](product/vision.md) | Kaji 在 AI 时代的长期位置 |
 | [product/2026-08-05-popover-visualization-decision.md](product/2026-08-05-popover-visualization-decision.md) | Popover 与圆环的可视化架构选择 |
 | [product/2026-08-08-mail-brief-executor-adr.md](product/2026-08-08-mail-brief-executor-adr.md) | Gmail、Codex 与本地数据的执行边界 |
+| [product/2026-08-26-launchd-visibility-boundary.md](product/2026-08-26-launchd-visibility-boundary.md) | launchd 后台任务模块的只读范围与刷新边界 |
 
 ### Design
 

--- a/dev_docs/product/2026-08-26-launchd-visibility-boundary.md
+++ b/dev_docs/product/2026-08-26-launchd-visibility-boundary.md
@@ -4,7 +4,7 @@
 
 Kaji 的 Background Tasks 模块 v1 只读，并且默认关闭。它只观察当前用户的 GUI launchd 域，不提供启动、停止、卸载、重新加载或提权操作。
 
-模块启用后，每次只执行一次 `launchctl list`，并读取 `~/Library/LaunchAgents` 中 plist 的 `Label`，把已安装但未出现在 GUI 域中的任务标为 `unloaded`。不为每个 label 调用 `launchctl print`。刷新间隔为一分钟；禁用模块时立即停止刷新并清空模块状态。
+模块启用后，只在状态栏 popover 可见时执行一次 `launchctl list`，并读取 `~/Library/LaunchAgents` 中 plist 的 `Label`，把已安装但未出现在 GUI 域中的任务标为 `unloaded`。不为每个 label 调用 `launchctl print`，也不在 popover 关闭时保留定时心跳；禁用模块时立即停止刷新并清空模块状态。
 
 ## 信息层级
 

--- a/dev_docs/product/2026-08-26-launchd-visibility-boundary.md
+++ b/dev_docs/product/2026-08-26-launchd-visibility-boundary.md
@@ -1,0 +1,17 @@
+# launchd 可见性模块边界
+
+## 决策
+
+Kaji 的 Background Tasks 模块 v1 只读，并且默认关闭。它只观察当前用户的 GUI launchd 域，不提供启动、停止、卸载、重新加载或提权操作。
+
+模块启用后，每次只执行一次 `launchctl list`，并读取 `~/Library/LaunchAgents` 中 plist 的 `Label`，把已安装但未出现在 GUI 域中的任务标为 `unloaded`。不为每个 label 调用 `launchctl print`。刷新间隔为一分钟；禁用模块时立即停止刷新并清空模块状态。
+
+## 信息层级
+
+首先显示 running、failed、unloaded 三个汇总，让异常与不可见的未加载任务一眼可见。任务列表先显示用户安装的 LaunchAgents，再显示 GUI 域中的其他任务；每组内按 failed、running、idle、unloaded 排序，然后按 label 排序。
+
+这不是 launchctl 的图形控制台。Kaji 只负责让后台活动变得可见，避免在混有系统更新器、第三方守护和 Kaji 自身任务的域里增加误操作风险。
+
+## 后续门槛
+
+只有在真实使用证明只读观察不足，并且能设计出明确的来源、风险提示与防误触机制后，才重新评估控制操作。system 域与 LaunchDaemons 不在本模块范围内。

--- a/scripts/screenshots.sh
+++ b/scripts/screenshots.sh
@@ -42,6 +42,10 @@ if [[ "$LANG_ARG" == "mail" || "$LANG_ARG" == "settings" ]]; then
   echo "==> rendering $LANG_ARG light + dark verification"
   /tmp/kaji-snap both "$LANG_ARG" zh
   echo "==> wrote /tmp/$LANG_ARG-{light,dark}.png"
+elif [[ "$LANG_ARG" == "launchd" ]]; then
+  echo "==> rendering launchd light + dark verification"
+  /tmp/kaji-snap launchd
+  echo "==> wrote /tmp/launchd-{light,dark}.png"
 elif [[ "$LANG_ARG" == "goals" || "$LANG_ARG" == "work" || "$LANG_ARG" == "break" ]]; then
   echo "==> rendering $LANG_ARG dark verification"
   /tmp/kaji-snap dark "$LANG_ARG" zh

--- a/scripts/snapshot.swift
+++ b/scripts/snapshot.swift
@@ -166,6 +166,7 @@ struct Snap {
             let workMode = args.contains("work")
             let breakMode = args.contains("break")
             let mailMode = args.contains("mail")
+            let launchdMode = args.contains("launchd")
             let settingsMode = args.contains("settings")
             let lang: Lang = args.contains("zh") ? .zh : .en
             let showRemaining = args.contains("remaining")
@@ -174,6 +175,7 @@ struct Snap {
             if goalsMode { prefs.enabledModules = [.quota, .goals] }
             if workMode || breakMode { prefs.enabledModules = [.quota, .work] }
             if mailMode { prefs.enabledModules = [.quota, .mailBrief] }
+            if launchdMode { prefs.enabledModules = [.quota, .launchd] }
 
             let store = QuotaStore(previewProviders: mocks, updated: Date())
             let workSession = WorkSessionController(prefs: prefs)
@@ -185,10 +187,18 @@ struct Snap {
             let mailBriefStore = mailMode
                 ? MailBriefStore(previewGeneration: makeMailGeneration())
                 : MailBriefStore(cacheURL: URL(fileURLWithPath: "/tmp/kaji-snapshot-mail.json"))
+            let launchdJobStore = LaunchdJobStore(initialSnapshot: LaunchdJobSnapshot(jobs: [
+                LaunchdJob(label: "com.bubu.lisa-daemon", pid: 65368, lastExitCode: 0, isInstalledUserAgent: true, state: .running),
+                LaunchdJob(label: "dev.bubu.hub-sync", pid: 842, lastExitCode: 0, isInstalledUserAgent: true, state: .running),
+                LaunchdJob(label: "com.openai.atlas.update-helper", pid: nil, lastExitCode: 78, isInstalledUserAgent: true, state: .failed),
+                LaunchdJob(label: "com.google.keystone.agent", pid: nil, lastExitCode: nil, isInstalledUserAgent: true, state: .unloaded),
+                LaunchdJob(label: "com.apple.coreservices.uiagent", pid: 321, lastExitCode: 0, isInstalledUserAgent: false, state: .running),
+            ]))
             let navigation = PopoverNavigation()
             if goalsMode { navigation.panel = .goals }
             if workMode || breakMode { navigation.panel = .work }
             if mailMode { navigation.panel = .mailBrief }
+            if launchdMode { navigation.panel = .launchd }
             let controls = KajiPopoverControls(
                 onOpenSettings: {},
                 onQuit: {}
@@ -203,6 +213,7 @@ struct Snap {
                 fixedPlanStore: fixedPlanStore,
                 aiNewsStore: aiNewsStore,
                 mailBriefStore: mailBriefStore,
+                launchdJobStore: launchdJobStore,
                 navigation: navigation,
                 controls: controls,
                 maxContentHeight: 720,
@@ -260,6 +271,11 @@ struct Snap {
             if mailMode {
                 render(popover, appearance: .darkAqua, scheme: .dark, to: "/tmp/mail-dark.png")
                 render(popover, appearance: .aqua, scheme: .light, to: "/tmp/mail-light.png")
+                return
+            }
+            if launchdMode {
+                render(popover, appearance: .darkAqua, scheme: .dark, to: "/tmp/launchd-dark.png")
+                render(popover, appearance: .aqua, scheme: .light, to: "/tmp/launchd-light.png")
                 return
             }
             if goalsMode {

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -86,6 +86,7 @@ if pgrep -x Kaji >/dev/null 2>&1; then
     exit 1
 fi
 
+export KAJI_UI_SMOKE_AUDIT_LAUNCHD_REFRESH=1
 APP_ARGS=(
     -enabledModules "$(seed_modules_plist_array)"
     -language "$SEED_LANGUAGE"

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -30,9 +30,9 @@ PREFS_DOMAIN="dev.kaji"
 # popover's Mail Brief page and the Settings > Mail Brief page, is the
 # regression test for that fix — if it ever starts failing, that is a real
 # regression, not a reason to re-exclude mailBrief from this list.
-SEED_MODULES=(quota work goals aiNews mailBrief)
+SEED_MODULES=(quota work goals aiNews mailBrief launchd)
 SEED_LANGUAGE=en
-EXPECTED_PAGE_TITLES="Quota|Work / Break|Goals|AI News|Mail Brief"
+EXPECTED_PAGE_TITLES="Quota|Work / Break|Goals|AI News|Mail Brief|Background Tasks"
 
 # Old-style property-list array literal, e.g. "(quota, work, goals, aiNews)" —
 # the format NSArgumentDomain parsing accepts for array-typed arguments.
@@ -86,10 +86,14 @@ if pgrep -x Kaji >/dev/null 2>&1; then
     exit 1
 fi
 
-printf '%s\n' 'UI-SMOKE launch: dist/Kaji.app'
-"$APP_EXECUTABLE" \
-    -enabledModules "$(seed_modules_plist_array)" \
-    -language "$SEED_LANGUAGE" \
+APP_ARGS=(
+    -enabledModules "$(seed_modules_plist_array)"
+    -language "$SEED_LANGUAGE"
+)
+if [[ -n "${KAJI_UI_SMOKE_APPEARANCE:-}" ]]; then
+    APP_ARGS+=(-AppleInterfaceStyle "$KAJI_UI_SMOKE_APPEARANCE")
+fi
+"$APP_EXECUTABLE" "${APP_ARGS[@]}" \
     >"$ARTIFACTS/kaji.stdout.log" 2>"$ARTIFACTS/kaji.stderr.log" &
 KAJI_PID=$!
 
@@ -98,6 +102,9 @@ if ! kill -0 "$KAJI_PID" 2>/dev/null; then
     exit 1
 fi
 
+shopt -s nullglob
+USER_AGENT_PLISTS=("$HOME"/Library/LaunchAgents/*.plist)
+export KAJI_UI_SMOKE_EXPECT_USER_AGENT_COUNT="${#USER_AGENT_PLISTS[@]}"
 "$HELPER" "$KAJI_PID" "$ARTIFACTS" "$EXPECTED_PAGE_TITLES"
 
 PREFS_MD5_AFTER=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -7,35 +7,14 @@ HELPER="$ARTIFACTS/ui-smoke-helper"
 APP_EXECUTABLE="$ROOT/dist/Kaji.app/Contents/MacOS/Kaji"
 KAJI_PID=""
 PREFS_DOMAIN="dev.kaji"
-
-# The smoke run also exercises page navigation, which only renders header
-# chevrons when more than one module is enabled (KajiPopoverView.header).
-# We never write to the app's real `defaults` domain to get there — a crash
-# or `kill -9` mid-run would leave the user's real dev.kaji preferences
-# stuck in test state, which is exactly the pollution we're trying to avoid.
-# Instead we pass `-key value` command-line arguments, which macOS populates
-# into `NSArgumentDomain` — the highest-priority, read-only, never-persisted
-# UserDefaults search layer (see `man defaults`/`NSUserDefaults` "argument
-# domain"). Confirmed empirically with a standalone Foundation binary: an
-# arg of `-enabledModules '(quota, work, goals)'` is readable via
-# `UserDefaults.standard.array(forKey:)` with zero effect on the on-disk
-# domain. `language` is pinned to `en` the same way so panelTitle assertions
-# are deterministic regardless of what this machine's Kaji has persisted.
-#
-# mailBrief is included below: MailBriefCredentialStore's keychain probe was
-# fixed to use kSecUseAuthenticationUIFail / LAContext noninteractive reads
-# and to fall back to "not connected" instead of surfacing a system prompt
-# on an ACL mismatch (with a one-shot v3 ACL migration). The
-# `no-system-auth-prompt` assertion in ui-smoke.swift, exercised across the
-# popover's Mail Brief page and the Settings > Mail Brief page, is the
-# regression test for that fix — if it ever starts failing, that is a real
-# regression, not a reason to re-exclude mailBrief from this list.
-SEED_MODULES=(quota work goals aiNews mailBrief launchd)
+NONCE="$(uuidgen)-$(uuidgen)"
+PORT="$(jot -r 1 40000 59999)"
+SMOKE_DOMAIN="dev.kaji.ui-smoke.$NONCE"
+SEED_MODULES=(quota work system goals aiNews mailBrief launchd)
 SEED_LANGUAGE=en
-EXPECTED_PAGE_TITLES="Quota|Work / Break|Goals|AI News|Mail Brief|Background Tasks"
+PAGE_IDS="quota|work|system|goals|aiNews|mailBrief|launchd|launchd:application|launchd:appleSystem"
+SETTINGS_SECTIONS="General|Modules|Work|Goals|Quota|AI News|Mail Brief|CLI|Permissions"
 
-# Old-style property-list array literal, e.g. "(quota, work, goals, aiNews)" —
-# the format NSArgumentDomain parsing accepts for array-typed arguments.
 seed_modules_plist_array() {
     local joined
     joined=$(printf '%s, ' "${SEED_MODULES[@]}")
@@ -47,45 +26,26 @@ cleanup() {
         kill "$KAJI_PID" 2>/dev/null || true
         wait "$KAJI_PID" 2>/dev/null || true
     fi
+    defaults delete "$SMOKE_DOMAIN" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
 mkdir -p "$ARTIFACTS"
 rm -f "$ARTIFACTS"/*.png "$HELPER"
 
-# Proof that this run never persists into the user's real preferences
-# domain. The whole-domain md5 is diagnostic only: DailyGoalStore /
-# FixedPlanStore re-encode their own JSON-blob keys (scheduledGoalsV1,
-# scheduledGoalCompletionV1, ...) via JSONEncoder on every single launch —
-# same content, non-deterministic Codable field order — independent of
-# anything this script does (a plain `open dist/Kaji.app` triggers the same
-# diff). What this script must never move is the two keys it could have
-# seeded via `defaults write`: enabledModules and language. Those are
-# checked for byte-for-byte equality below and fail the run if touched.
 PREFS_MD5_BEFORE=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
 PREFS_ENABLED_BEFORE=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
 PREFS_LANGUAGE_BEFORE=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
 
-
 printf '%s\n' 'UI-SMOKE build: ./scripts/build-app.sh'
 "$ROOT/scripts/build-app.sh"
-
-printf '%s\n' 'UI-SMOKE helper: compiling ad-hoc local verifier'
+printf '%s\n' 'UI-SMOKE helper: compiling nonintrusive local verifier'
 swiftc "$ROOT/scripts/ui-smoke.swift" -o "$HELPER"
 codesign --force --sign - "$HELPER" >/dev/null
 
-# The smoke run owns the only Kaji instance so AX lookup and window ownership
-# cannot accidentally target an installed or previously launched copy.
-pkill -x Kaji 2>/dev/null || true
-for _ in {1..50}; do
-    pgrep -x Kaji >/dev/null 2>&1 || break
-    sleep 0.1
-done
-if pgrep -x Kaji >/dev/null 2>&1; then
-    printf '%s\n' 'UI-SMOKE FAIL: stale Kaji process did not terminate' >&2
-    exit 1
-fi
-
+export KAJI_UI_SMOKE_NONCE="$NONCE"
+export KAJI_UI_SMOKE_PORT="$PORT"
+export KAJI_UI_SMOKE_ARTIFACTS="$ARTIFACTS"
 export KAJI_UI_SMOKE_AUDIT_LAUNCHD_REFRESH=1
 APP_ARGS=(
     -enabledModules "$(seed_modules_plist_array)"
@@ -94,41 +54,34 @@ APP_ARGS=(
 if [[ -n "${KAJI_UI_SMOKE_APPEARANCE:-}" ]]; then
     APP_ARGS+=(-AppleInterfaceStyle "$KAJI_UI_SMOKE_APPEARANCE")
 fi
+
+printf 'UI-SMOKE launch: owned Kaji process on control port %s\n' "$PORT"
 "$APP_EXECUTABLE" "${APP_ARGS[@]}" \
     >"$ARTIFACTS/kaji.stdout.log" 2>"$ARTIFACTS/kaji.stderr.log" &
 KAJI_PID=$!
-
 if ! kill -0 "$KAJI_PID" 2>/dev/null; then
-    printf 'UI-SMOKE FAIL: Kaji exited during launch; inspect %s\n' "$ARTIFACTS/kaji.stderr.log" >&2
+    printf 'UI-SMOKE FAIL: owned Kaji process exited during launch; inspect %s\n' "$ARTIFACTS/kaji.stderr.log" >&2
     exit 1
 fi
 
-shopt -s nullglob
-USER_AGENT_PLISTS=("$HOME"/Library/LaunchAgents/*.plist)
-export KAJI_UI_SMOKE_EXPECT_USER_AGENT_COUNT="${#USER_AGENT_PLISTS[@]}"
-"$HELPER" "$KAJI_PID" "$ARTIFACTS" "$EXPECTED_PAGE_TITLES"
+"$HELPER" "$KAJI_PID" "$ARTIFACTS" "$NONCE" "$PORT" "$PAGE_IDS" "$SETTINGS_SECTIONS" \
+    "$ROOT/scripts/ui-smoke.swift" "$ROOT/scripts/ui-smoke.sh"
+
+if ! /usr/bin/grep -q 'KAJI_UI_SMOKE launchd-refresh' "$ARTIFACTS/kaji.stdout.log"; then
+    printf '%s\n' 'UI-SMOKE FAIL: Background Tasks module never refreshed live launchd state' >&2
+    exit 1
+fi
+printf '%s\n' 'ASSERT launchd-refresh: PASS live refresh ran in the owned app process'
 
 PREFS_MD5_AFTER=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
 PREFS_ENABLED_AFTER=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
 PREFS_LANGUAGE_AFTER=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
 
-if [[ "$PREFS_ENABLED_BEFORE" != "$PREFS_ENABLED_AFTER" || "$PREFS_LANGUAGE_BEFORE" != "$PREFS_LANGUAGE_AFTER" ]]; then
-    printf 'UI-SMOKE FAIL: dev.kaji enabledModules/language were persisted by this run — the NSArgumentDomain seed must never touch disk\n' >&2
-    printf '  enabledModules before: %s\n' "$PREFS_ENABLED_BEFORE" >&2
-    printf '  enabledModules after:  %s\n' "$PREFS_ENABLED_AFTER" >&2
-    printf '  language before: %s\n' "$PREFS_LANGUAGE_BEFORE" >&2
-    printf '  language after:  %s\n' "$PREFS_LANGUAGE_AFTER" >&2
+if [[ "$PREFS_MD5_BEFORE" != "$PREFS_MD5_AFTER" || \
+      "$PREFS_ENABLED_BEFORE" != "$PREFS_ENABLED_AFTER" || \
+      "$PREFS_LANGUAGE_BEFORE" != "$PREFS_LANGUAGE_AFTER" ]]; then
+    printf '%s\n' 'UI-SMOKE FAIL: the real dev.kaji preferences domain changed' >&2
     exit 1
 fi
-printf 'UI-SMOKE: dev.kaji enabledModules and language are byte-for-byte unchanged (enabledModules=%s language=%s)\n' \
-    "$PREFS_ENABLED_AFTER" "$PREFS_LANGUAGE_AFTER"
-
-if [[ "$PREFS_MD5_BEFORE" != "$PREFS_MD5_AFTER" ]]; then
-    printf 'UI-SMOKE: dev.kaji whole-domain md5 changed (before=%s after=%s) — expected: DailyGoalStore/FixedPlanStore re-encode their own JSON-blob keys with non-deterministic Codable field order on every Kaji launch, independent of this script (a plain `open dist/Kaji.app` reproduces the same diff). Not a regression in this harness; enabledModules/language above are the keys this script could pollute, and they are unchanged.\n' \
-        "$PREFS_MD5_BEFORE" "$PREFS_MD5_AFTER"
-else
-    printf 'UI-SMOKE: dev.kaji preferences domain byte-for-byte unchanged (md5 %s)\n' "$PREFS_MD5_AFTER"
-fi
-
-
-printf 'UI-SMOKE PASS: menu-bar popover opened/closed, AX content verified, page navigation verified; artifacts: %s\n' "$ARTIFACTS"
+printf 'ASSERT preferences-isolated: PASS dev.kaji unchanged (md5 %s)\n' "$PREFS_MD5_AFTER"
+printf 'UI-SMOKE PASS: input devices/frontmost app untouched; real popover and settings views rendered offscreen; artifacts: %s\n' "$ARTIFACTS"

--- a/scripts/ui-smoke.swift
+++ b/scripts/ui-smoke.swift
@@ -1,499 +1,239 @@
-import ApplicationServices
+import AppKit
 import CoreGraphics
 import Foundation
 
-struct WindowSnapshot {
-    let id: CGWindowID
-    let bounds: CGRect
+struct SmokeError: Error, CustomStringConvertible {
+    let description: String
 }
 
-enum SmokeError: Error, CustomStringConvertible {
-    case message(String)
+struct DesktopState: Equatable {
+    let mouse: CGPoint
+    let frontmostBundleID: String?
+    let frontmostPID: pid_t?
 
-    var description: String {
-        switch self {
-        case .message(let text): return text
+    static func capture() throws -> DesktopState {
+        guard let event = CGEvent(source: CGEventSource(stateID: .hidSystemState)) else {
+            throw SmokeError(description: "could not read mouse position")
+        }
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        return DesktopState(
+            mouse: event.location,
+            frontmostBundleID: frontmost?.bundleIdentifier,
+            frontmostPID: frontmost?.processIdentifier
+        )
+    }
+}
+
+struct HTTPResult {
+    let status: Int
+    let object: [String: Any]
+}
+
+func request(
+    port: UInt16,
+    method: String,
+    path: String,
+    body: [String: Any]? = nil
+) throws -> HTTPResult {
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/\(path)")!)
+    request.httpMethod = method
+    request.timeoutInterval = 10
+    if let body {
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Result<HTTPResult, Error>?
+    URLSession.shared.dataTask(with: request) { data, response, error in
+        defer { semaphore.signal() }
+        if let error {
+            result = .failure(error)
+            return
+        }
+        guard let http = response as? HTTPURLResponse, let data else {
+            result = .failure(SmokeError(description: "control request returned no HTTP response"))
+            return
+        }
+        let object = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        result = .success(HTTPResult(status: http.statusCode, object: object))
+    }.resume()
+    guard semaphore.wait(timeout: .now() + 12) == .success, let result else {
+        throw SmokeError(description: "control request timed out for \(method) \(path)")
+    }
+    return try result.get()
+}
+
+func render(
+    port: UInt16,
+    nonce: String,
+    surface: String,
+    selection: String,
+    outputPath: String
+) throws -> [String: Any] {
+    let result = try request(
+        port: port,
+        method: "POST",
+        path: "test/render",
+        body: [
+            "nonce": nonce,
+            "surface": surface,
+            "selection": selection,
+            "outputPath": outputPath,
+        ]
+    )
+    guard result.status == 200 else {
+        throw SmokeError(description: "render \(surface):\(selection) failed with HTTP \(result.status): \(result.object)")
+    }
+    return result.object
+}
+
+func waitForServer(port: UInt16) throws -> [String: Any] {
+    let deadline = Date().addingTimeInterval(10)
+    var lastError: Error?
+    while Date() < deadline {
+        do {
+            let result = try request(port: port, method: "GET", path: "state")
+            if result.status == 200 { return result.object }
+        } catch {
+            lastError = error
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+    throw lastError ?? SmokeError(description: "test control server did not become ready")
+}
+
+func waitForLaunchdSnapshot(port: UInt16, initial: [String: Any]) throws -> [String: Any] {
+    var state = initial
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+        if let launchd = state["launchd"] as? [String: Any],
+           let user = launchd["userAgent"] as? [String: Any],
+           (user["total"] as? Int ?? 0) > 0 {
+            return state
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+        let result = try request(port: port, method: "GET", path: "state")
+        if result.status == 200 { state = result.object }
+    }
+    return state
+}
+
+func assertPNG(_ path: String, label: String) throws {
+    guard let image = NSImage(contentsOfFile: path),
+          image.size.width > 0,
+          image.size.height > 0,
+          let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+          let bytes = attributes[.size] as? NSNumber,
+          bytes.intValue > 256 else {
+        throw SmokeError(description: "ASSERT render-\(label): FAIL missing or blank PNG at \(path)")
+    }
+    print("ASSERT render-\(label): PASS \(Int(image.size.width))x\(Int(image.size.height)) \(bytes.intValue) bytes")
+}
+
+func assertNoInputAutomation(in paths: [String]) throws {
+    let forbidden = [
+        "CGWarpMouse" + "CursorPosition",
+        "leftMouse" + "Down",
+        "leftMouse" + "Up",
+        "mouse" + "Moved",
+        ".post(" + "tap:",
+        "CGEvent" + "Post",
+        "key" + "Down",
+        "key" + "Up",
+        "perform" + "Click",
+        "osa" + "script",
+        "AXUIElement" + "PerformAction",
+        "pk" + "ill",
+    ]
+    for path in paths {
+        let source = try String(contentsOfFile: path, encoding: .utf8)
+        if let match = forbidden.first(where: source.contains) {
+            throw SmokeError(description: "ASSERT no-input-implementation: FAIL \(path) contains \(match)")
         }
     }
+    print("ASSERT no-input-implementation: PASS no posting, warp, keyboard, AppleScript, AX action, or global process-kill APIs")
 }
 
-struct AXElementInfo {
-    let role: String
-    let text: String
-    let identifier: String?
-    let bounds: CGRect?
-}
-
-func stringAttribute(_ element: AXUIElement, _ name: CFString) -> String? {
-    guard let raw = attribute(element, name) else { return nil }
-    if CFGetTypeID(raw) == CFStringGetTypeID() {
-        return unsafeBitCast(raw, to: CFString.self) as String
-    }
-    return nil
-}
-
-/// NSPopover's backing panel is a nonactivating borderless window; for an
-/// `.accessory`-policy (LSUIElement) app like Kaji it is never listed under
-/// the application element's `kAXWindowsAttribute` (confirmed empirically —
-/// that attribute reports 0 windows while the popover is open). The
-/// reliable way in is a system-wide hit-test at a point inside the
-/// CGWindow's bounds, then reading `kAXWindowAttribute` off whatever was
-/// hit to climb to the enclosing window element (role `AXPopover`).
-func findAXWindow(pid: pid_t, matching target: CGRect) -> AXUIElement? {
-    let systemWide = AXUIElementCreateSystemWide()
-    let point = CGPoint(x: target.midX, y: target.midY)
-    var hit: AXUIElement?
-    guard AXUIElementCopyElementAtPosition(systemWide, Float(point.x), Float(point.y), &hit) == .success,
-          let hit else { return nil }
-    var ownerPID: pid_t = 0
-    AXUIElementGetPid(hit, &ownerPID)
-    guard ownerPID == pid else { return nil }
-    if let raw = attribute(hit, kAXWindowAttribute as CFString), CFGetTypeID(raw) == AXUIElementGetTypeID() {
-        return unsafeBitCast(raw, to: AXUIElement.self)
-    }
-    // The hit element itself may already be the window/popover root.
-    if let role = attribute(hit, kAXRoleAttribute as CFString) as? String,
-       role == kAXWindowRole as String || role == "AXPopover" {
-        return hit
-    }
-    return nil
-}
-
-/// Depth-first walk collecting every element's role/text/identifier/bounds.
-/// Depth and node counts are capped so a runaway SwiftUI tree cannot hang
-/// the smoke run.
-func collectAXElements(_ element: AXUIElement, depth: Int = 0, budget: inout Int) -> [AXElementInfo] {
-    guard depth < 40, budget > 0 else { return [] }
-    budget -= 1
-    let role = (attribute(element, kAXRoleAttribute as CFString) as? String)
-        ?? stringAttribute(element, kAXRoleAttribute as CFString)
-        ?? "?"
-    let title = stringAttribute(element, kAXTitleAttribute as CFString) ?? ""
-    let value = stringAttribute(element, kAXValueAttribute as CFString) ?? ""
-    let description = stringAttribute(element, kAXDescriptionAttribute as CFString) ?? ""
-    let text = [title, value, description].first(where: { !$0.isEmpty }) ?? ""
-    let identifier = stringAttribute(element, kAXIdentifierAttribute as CFString)
-    var own = [AXElementInfo(role: role, text: text, identifier: identifier, bounds: bounds(of: element))]
-    for child in children(of: element) {
-        own.append(contentsOf: collectAXElements(child, depth: depth + 1, budget: &budget))
-    }
-    return own
-}
-
-func dumpAXElements(_ elements: [AXElementInfo]) {
-    for info in elements where !info.text.isEmpty || info.role == "AXButton" {
-        let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
-        let idText = info.identifier ?? "-"
-        print("AX-DUMP role=\(info.role) text=\"\(info.text)\" id=\(idText) bounds=\(boundsText)")
+func systemAuthPromptWindows() -> [String] {
+    let owners: Set<String> = ["SecurityAgent", "loginwindow", "coreauthd", "UserNotificationCenter"]
+    guard let windows = CGWindowListCopyWindowInfo(
+        [.optionOnScreenOnly, .excludeDesktopElements],
+        kCGNullWindowID
+    ) as? [[String: Any]] else { return [] }
+    return windows.compactMap { window in
+        guard let owner = window[kCGWindowOwnerName as String] as? String,
+              owners.contains(owner) else { return nil }
+        let title = window[kCGWindowName as String] as? String ?? ""
+        return "\(owner):\(title)"
     }
 }
 
-/// macOS surfaces real Keychain/credential prompts as separate on-screen
-/// windows owned by system agent processes, never by the app itself — this
-/// is the acceptance signal for "permission asks once, never again":
-/// scan every on-screen window (not just Kaji's) for one owned by any of
-/// these processes. Overridable via KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS
-/// (comma-separated) purely so this script can prove the assertion truly
-/// fires (see the failure-injection run in the task write-up); the real
-/// default set is fixed.
-func systemAuthPromptOwnerNames() -> Set<String> {
-    if let override = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS"] {
-        return Set(override.split(separator: ",").map(String.init))
+func assertNoSystemAuthPrompt(_ context: String) throws {
+    let prompts = systemAuthPromptWindows()
+    guard prompts.isEmpty else {
+        throw SmokeError(description: "ASSERT no-system-auth-prompt: FAIL during \(context): \(prompts)")
     }
-    return ["SecurityAgent", "loginwindow", "coreauthd", "UserNotificationCenter"]
-}
-
-struct SystemAuthPromptWindow: CustomStringConvertible {
-    let ownerName: String
-    let ownerPID: pid_t
-    let title: String
-    var description: String { "owner=\(ownerName) pid=\(ownerPID) title=\"\(title)\"" }
-}
-
-func systemAuthPromptWindows() -> [SystemAuthPromptWindow] {
-    let owners = systemAuthPromptOwnerNames()
-    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
-            as? [[String: Any]] else { return [] }
-    return raw.compactMap { info in
-        guard let ownerName = info[kCGWindowOwnerName as String] as? String, owners.contains(ownerName),
-              let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value else { return nil }
-        let title = info[kCGWindowName as String] as? String ?? ""
-        return SystemAuthPromptWindow(ownerName: ownerName, ownerPID: ownerPID, title: title)
-    }
-}
-
-/// Call after every action that could plausibly trigger a Keychain/credential
-/// prompt. Throws (and screenshots) the instant one is seen — checked at
-/// every popover-page transition, every Settings-page transition, and
-/// before/after opening Settings, so the whole click-through is covered.
-var authPromptCheckCount = 0
-func checkNoSystemAuthPrompt(_ context: String, artifacts: String) throws {
-    authPromptCheckCount += 1
-    let found = systemAuthPromptWindows()
-    guard found.isEmpty else {
-        capture("\(artifacts)/system-auth-prompt-failure.png")
-        throw SmokeError.message("ASSERT no-system-auth-prompt: FAIL a system authorization window appeared during \"\(context)\": \(found.map(\.description).joined(separator: "; "))")
-    }
-}
-
-/// Header chevrons are 30x30 icon-only buttons (see KajiPopoverView.arrow);
-/// distinguish them from the (30x28) footer icon buttons by requiring the
-/// button sit within the popover's top ~44pt, where the header row lives.
-func pageArrowButtons(in elements: [AXElementInfo], windowTop: CGFloat) -> [AXElementInfo] {
-    elements.filter { info in
-        guard info.role == "AXButton", let rect = info.bounds else { return false }
-        return rect.width >= 28 && rect.width <= 32 && rect.height >= 28 && rect.height <= 32
-            && rect.minY - windowTop < 44
-    }.sorted { ($0.bounds?.minX ?? 0) < ($1.bounds?.minX ?? 0) }
-}
-
-func attribute(_ element: AXUIElement, _ name: CFString) -> CFTypeRef? {
-    var value: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, name, &value) == .success else { return nil }
-    return value
-}
-
-func children(of element: AXUIElement) -> [AXUIElement] {
-    guard let raw = attribute(element, kAXChildrenAttribute as CFString),
-          CFGetTypeID(raw) == CFArrayGetTypeID() else { return [] }
-    let array = unsafeBitCast(raw, to: CFArray.self)
-    return (0..<CFArrayGetCount(array)).map {
-        unsafeBitCast(CFArrayGetValueAtIndex(array, $0), to: AXUIElement.self)
-    }
-}
-
-func bounds(of element: AXUIElement) -> CGRect? {
-    guard let rawPosition = attribute(element, kAXPositionAttribute as CFString),
-          CFGetTypeID(rawPosition) == AXValueGetTypeID(),
-          let rawSize = attribute(element, kAXSizeAttribute as CFString),
-          CFGetTypeID(rawSize) == AXValueGetTypeID() else { return nil }
-    let positionValue = unsafeBitCast(rawPosition, to: AXValue.self)
-    let sizeValue = unsafeBitCast(rawSize, to: AXValue.self)
-    var position = CGPoint.zero
-    var size = CGSize.zero
-    guard AXValueGetValue(positionValue, .cgPoint, &position),
-          AXValueGetValue(sizeValue, .cgSize, &size),
-          size.width > 0, size.height > 0 else { return nil }
-    return CGRect(origin: position, size: size)
-}
-
-func isMainMenuBarBounds(_ rect: CGRect) -> Bool {
-    let mainFrame = CGDisplayBounds(CGMainDisplayID())
-    return rect.width > 0 && rect.height > 0 &&
-        rect.minX >= mainFrame.minX && rect.maxX <= mainFrame.maxX &&
-        rect.minY >= mainFrame.minY && rect.minY <= mainFrame.minY + 40
-}
-
-func statusItemBounds(pid: pid_t) -> CGRect? {
-    let application = AXUIElementCreateApplication(pid)
-    guard let rawMenuBar = attribute(application, kAXExtrasMenuBarAttribute as CFString)
-            ?? attribute(application, kAXMenuBarAttribute as CFString),
-          CFGetTypeID(rawMenuBar) == AXUIElementGetTypeID() else {
-        return nil
-    }
-    let menuBar = unsafeBitCast(rawMenuBar, to: AXUIElement.self)
-    for child in children(of: menuBar) {
-        guard let role = attribute(child, kAXRoleAttribute as CFString) as? String,
-              role == kAXMenuBarItemRole as String else { continue }
-        return bounds(of: child)
-    }
-    return nil
-}
-
-func windows(pid: pid_t) -> [WindowSnapshot] {
-    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
-            as? [[String: Any]] else { return [] }
-    return raw.compactMap { info in
-        guard let ownerPID = info[kCGWindowOwnerPID as String] as? NSNumber,
-              ownerPID.int32Value == pid,
-              let number = info[kCGWindowNumber as String] as? NSNumber,
-              let boundsObject = info[kCGWindowBounds as String] as? NSDictionary else { return nil }
-        let boundsDictionary = unsafeBitCast(boundsObject, to: CFDictionary.self)
-        guard let bounds = CGRect(dictionaryRepresentation: boundsDictionary) else { return nil }
-        return WindowSnapshot(id: CGWindowID(number.uint32Value), bounds: bounds)
-    }
-}
-
-func popoverWindow(in snapshots: [WindowSnapshot], excluding ids: Set<CGWindowID> = []) -> WindowSnapshot? {
-    snapshots.first {
-        !ids.contains($0.id) &&
-        $0.bounds.width >= 180 && $0.bounds.width <= 700 &&
-        $0.bounds.height >= 100 && $0.bounds.height <= 1_200
-    }
-}
-
-func wait<T>(timeout: TimeInterval, interval: TimeInterval = 0.1, for value: () -> T?) -> T? {
-    let deadline = Date().addingTimeInterval(timeout)
-    repeat {
-        if let result = value() { return result }
-        Thread.sleep(forTimeInterval: interval)
-    } while Date() < deadline
-    return nil
-}
-
-func click(_ point: CGPoint) throws {
-    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
-                             mouseCursorPosition: point, mouseButton: .left),
-          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
-                           mouseCursorPosition: point, mouseButton: .left) else {
-        throw SmokeError.message("could not create CGEvent mouse events")
-    }
-    down.post(tap: .cghidEventTap)
-    Thread.sleep(forTimeInterval: 0.08)
-    up.post(tap: .cghidEventTap)
-}
-
-func capture(_ path: String) {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-    process.arguments = ["-x", path]
-    try? process.run()
-    process.waitUntilExit()
 }
 
 func run() throws {
-    guard CommandLine.arguments.count == 4, let pid = pid_t(CommandLine.arguments[1]) else {
-        throw SmokeError.message("usage: ui-smoke.swift <pid> <artifact-directory> <expected-page-titles-pipe-separated>")
+    guard CommandLine.arguments.count == 9,
+          let pid = pid_t(CommandLine.arguments[1]),
+          let port = UInt16(CommandLine.arguments[4]) else {
+        throw SmokeError(description: "usage: ui-smoke-helper PID ARTIFACTS NONCE PORT PAGE_IDS SETTINGS_SECTIONS SWIFT_SOURCE SHELL_SOURCE")
     }
     let artifacts = CommandLine.arguments[2]
-    let expectedPageTitles = CommandLine.arguments[3].split(separator: "|").map(String.init)
+    let nonce = CommandLine.arguments[3]
+    let pageIDs = CommandLine.arguments[5].split(separator: "|").map(String.init)
+    let settingsSections = CommandLine.arguments[6].split(separator: "|").map(String.init)
+    let implementationPaths = [CommandLine.arguments[7], CommandLine.arguments[8]]
 
-    guard AXIsProcessTrusted() else {
-        throw SmokeError.message("Accessibility permission is missing. Enable System Settings > Privacy & Security > Accessibility for your terminal (or the agent host running this script), then rerun ./scripts/ui-smoke.sh")
+    guard kill(pid, 0) == 0 else {
+        throw SmokeError(description: "owned Kaji test process is not running")
     }
+    try assertNoInputAutomation(in: implementationPaths)
+    let before = try DesktopState.capture()
+    try assertNoSystemAuthPrompt("before render")
 
-    let mainFrame = CGDisplayBounds(CGMainDisplayID())
-    let mainCenter = CGPoint(x: mainFrame.midX, y: mainFrame.midY)
-    CGWarpMouseCursorPosition(mainCenter)
-    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
-            mouseCursorPosition: mainCenter, mouseButton: .left)?.post(tap: .cghidEventTap)
-    Thread.sleep(forTimeInterval: 0.5)
-
-    guard let initialBounds = wait(timeout: 10, for: { () -> CGRect? in
-        guard let candidate = statusItemBounds(pid: pid), isMainMenuBarBounds(candidate) else { return nil }
-        return candidate
-    }) else {
-        throw SmokeError.message("Kaji status item did not expose stable AX bounds on the main menu bar within 10 seconds")
-    }
-    print("ASSERT status-item: PASS bounds=\(Int(initialBounds.minX)),\(Int(initialBounds.minY)) \(Int(initialBounds.width))x\(Int(initialBounds.height))")
-    Thread.sleep(forTimeInterval: 0.3)
-
-    let baselineIDs = Set(windows(pid: pid).map(\.id))
-    let openPoint = CGPoint(x: initialBounds.minX + min(12, initialBounds.width / 2), y: initialBounds.midY)
-    if ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_SKIP_CLICK"] == nil {
-        try click(openPoint)
-    }
-
-    guard let opened = wait(timeout: 3, for: {
-        popoverWindow(in: windows(pid: pid), excluding: baselineIDs)
-    }) else {
-        capture("\(artifacts)/open-failure.png")
-        throw SmokeError.message("ASSERT click-opens-popover: FAIL no popover-sized Kaji window appeared within 3 seconds")
-    }
-    capture("\(artifacts)/open.png")
-    print("ASSERT click-opens-popover: PASS window=\(opened.id) size=\(Int(opened.bounds.width))x\(Int(opened.bounds.height))")
-    try checkNoSystemAuthPrompt("popover opened", artifacts: artifacts)
-
-    // Re-hit-test on every read instead of holding one AXUIElement handle:
-    // resizing the popover for a different page can tear down and rebuild
-    // its AX backing objects, which would make a cached handle go stale.
-    func popoverElements() throws -> [AXElementInfo] {
-        guard let currentWindow = windows(pid: pid).first(where: { $0.id == opened.id })
-                ?? popoverWindow(in: windows(pid: pid)),
-              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
-            throw SmokeError.message("ASSERT ax-popover-tree: FAIL could not locate the popover's AXUIElement window via system-wide hit-test")
-        }
-        var budget = 4000
-        return collectAXElements(element, budget: &budget)
-    }
-
-    var elements = try popoverElements()
-    print("ASSERT ax-popover-tree: PASS discovered \(elements.count) AX nodes")
-    dumpAXElements(elements)
-
-    let expectedQuotaTitle = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_EXPECT_QUOTA_TITLE"] ?? "Quota"
-    guard elements.contains(where: { $0.role == "AXStaticText" && $0.text == expectedQuotaTitle }) else {
-        capture("\(artifacts)/ax-quota-page-failure.png")
-        let observedTexts = elements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text)
-        throw SmokeError.message("ASSERT ax-quota-page: FAIL expected an AXStaticText titled \"\(expectedQuotaTitle)\"; observed static text: \(observedTexts)")
-    }
-    print("ASSERT ax-quota-page: PASS found AXStaticText \"\(expectedQuotaTitle)\"")
-    let launchdAuditURL = URL(fileURLWithPath: artifacts).appendingPathComponent("kaji.stdout.log")
-    func launchdRefreshCount() -> Int {
-        let log = (try? String(contentsOf: launchdAuditURL, encoding: .utf8)) ?? ""
-        return log.split(whereSeparator: \.isNewline)
-            .count { $0 == "KAJI_UI_SMOKE launchd-refresh" }
-    }
-
-
-    if expectedPageTitles.count > 1 {
-        let windowTop = opened.bounds.minY
-        var sequence = [expectedPageTitles[0]]
-        for step in 0..<expectedPageTitles.count {
-            elements = try popoverElements()
-            let arrows = pageArrowButtons(in: elements, windowTop: windowTop)
-            guard arrows.count == 2, let nextArrow = arrows.last, let nextBounds = nextArrow.bounds else {
-                capture("\(artifacts)/ax-page-nav-failure.png")
-                let candidateButtons = elements.filter { $0.role == "AXButton" }
-                throw SmokeError.message("""
-                    ASSERT ax-page-nav: FAIL expected exactly 2 header chevron buttons \
-                    (30x30 icon-only AXButton within the popover's top 44pt); found \(arrows.count). \
-                    All AXButton nodes seen: \(candidateButtons). \
-                    The chevrons carry no AXTitle/AXDescription/AXIdentifier, so if this heuristic \
-                    ever stops matching, the fix is accessibility identifiers in Sources/Kaji/KajiPopoverView.swift: \
-                    add .accessibilityIdentifier("kaji.popover.page.prev") / ("kaji.popover.page.next") to the \
-                    two Button closures built by `arrow(_:action:)` (used for chevron.left / chevron.right in `header`), \
-                    plus .accessibilityIdentifier("kaji.popover.title") on the `Text(panelTitle)` header line, and \
-                    root-level identifiers ("kaji.popover.panel.quota" / ".work" / ".system" / ".goals" / ".aiNews" / \
-                    ".mailBrief") on each case of `panelBody` for reliable per-page content assertions.
-                    """)
-            }
-            let center = CGPoint(x: nextBounds.midX, y: nextBounds.midY)
-            try click(center)
-            let expected = expectedPageTitles[(step + 1) % expectedPageTitles.count]
-            guard wait(timeout: 2, for: { () -> Bool? in
-                (try? popoverElements())?.contains(where: { $0.role == "AXStaticText" && $0.text == expected }) == true ? true : nil
-            }) != nil else {
-                capture("\(artifacts)/ax-page-nav-failure.png")
-                let observedTexts = (try? popoverElements())?.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text) ?? []
-                throw SmokeError.message("ASSERT ax-page-nav: FAIL clicking the next-page chevron did not surface header title \"\(expected)\"; observed static text: \(observedTexts)")
-            }
-            sequence.append(expected)
-            try checkNoSystemAuthPrompt("popover page \(expected)", artifacts: artifacts)
-            if expected == "Background Tasks" {
-                guard wait(timeout: 3, for: { () -> Bool? in
-                    let texts = (try? popoverElements())?
-                        .filter { $0.role == "AXStaticText" }
-                        .map(\.text) ?? []
-                    return texts.contains(where: { $0.uppercased().hasPrefix("USER AGENTS · ") }) ? true : nil
-                }) != nil else {
-                    capture("\(artifacts)/background-tasks-failure.png")
-                    throw SmokeError.message("ASSERT background-tasks-real-data: FAIL no installed user-agent section appeared")
-                }
-                let launchdTexts = try popoverElements()
-                    .filter { $0.role == "AXStaticText" }
-                    .map(\.text)
-                let expectedCount = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_EXPECT_USER_AGENT_COUNT"]
-                let expectedSection = expectedCount.map { "USER AGENTS · \($0)" }
-                guard expectedSection.map(launchdTexts.contains) ?? true,
-                      launchdTexts.contains(where: { ["RUNNING", "FAILED", "IDLE", "UNLOADED"].contains($0) }) else {
-                    capture("\(artifacts)/background-tasks-failure.png")
-                    throw SmokeError.message("ASSERT background-tasks-real-data: FAIL expected installed agents and visible job states; observed \(launchdTexts)")
-                }
-                capture("\(artifacts)/background-tasks.png")
-                print("ASSERT background-tasks-real-data: PASS rendered \(expectedCount ?? "installed") user agents with live launchd states")
-            }
-        }
-        print("ASSERT ax-page-nav: PASS clicked through pages in order \(sequence.joined(separator: " -> "))")
+    var state = try waitForServer(port: port)
+    state = try waitForLaunchdSnapshot(port: port, initial: state)
+    if let launchd = state["launchd"] as? [String: Any],
+       let user = launchd["userAgent"] as? [String: Any] {
+        print("ASSERT launchd-state: PASS My Tasks total=\(user["total"] ?? "?") running=\(user["running"] ?? "?") failed=\(user["failed"] ?? "?") idle=\(user["idle"] ?? "?") unloaded=\(user["unloaded"] ?? "?")")
     } else {
-        print("ASSERT ax-page-nav: SKIP only \(expectedPageTitles.count) page(s) enabled; header chevrons are hidden (pages.count > 1 gate in KajiPopoverView.header)")
-    }
-    let refreshCountBeforeVisibilityClose = launchdRefreshCount()
-    guard refreshCountBeforeVisibilityClose > 0 else {
-        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL no refresh occurred while the popover was visible")
-    }
-    try click(openPoint)
-    guard wait(timeout: 3, for: {
-        windows(pid: pid).contains(where: { $0.id == opened.id }) ? nil : true
-    }) != nil else {
-        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL popover did not close for lifecycle check")
-    }
-    Thread.sleep(forTimeInterval: 1.0)
-    let refreshCountAfterVisibilityClose = launchdRefreshCount()
-    guard refreshCountAfterVisibilityClose == refreshCountBeforeVisibilityClose else {
-        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL refresh count changed after close (\(refreshCountBeforeVisibilityClose) -> \(refreshCountAfterVisibilityClose))")
-    }
-    print("ASSERT background-tasks-visible-lifecycle: PASS refresh occurred while visible and count stayed \(refreshCountAfterVisibilityClose) after close")
-    try click(openPoint)
-    guard wait(timeout: 3, for: { popoverWindow(in: windows(pid: pid)) }) != nil else {
-        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL popover did not reopen after lifecycle check")
+        throw SmokeError(description: "ASSERT launchd-state: FAIL control snapshot omitted launchd.userAgent")
     }
 
+    let statusPath = URL(fileURLWithPath: artifacts).appendingPathComponent("status.png").path
+    _ = try render(port: port, nonce: nonce, surface: "status", selection: "status", outputPath: statusPath)
+    try assertPNG(statusPath, label: "status")
 
-    // Settings walk: click gearshape in the popover footer, then click every
-    // sidebar section and assert the visible content actually changes.
-    // Mail Brief is the highest-risk page for this run — it's the module
-    // whose credential lookup used to pop a live Keychain prompt.
-    //
-    // Re-fetch elements: the page-nav loop's last read is one click stale
-    // (captured before the click back to the wrap-around page), and footer
-    // buttons shift vertically with popover height, so a stale bounds would
-    // miss the real button.
-    elements = try popoverElements()
-    let settingsButton = elements.first { $0.role == "AXButton" && $0.identifier == "gearshape" }
-    guard let settingsButton, let settingsButtonBounds = settingsButton.bounds else {
-        capture("\(artifacts)/settings-open-failure.png")
-        throw SmokeError.message("ASSERT settings-opens: FAIL no AXButton with identifier \"gearshape\" found in the popover footer; AXButtons seen: \(elements.filter { $0.role == "AXButton" })")
+    for page in pageIDs {
+        let safeName = page.replacingOccurrences(of: ":", with: "-")
+        let path = URL(fileURLWithPath: artifacts).appendingPathComponent("popover-\(safeName).png").path
+        _ = try render(port: port, nonce: nonce, surface: "popover", selection: page, outputPath: path)
+        try assertPNG(path, label: "popover-\(safeName)")
+        try assertNoSystemAuthPrompt("popover \(page)")
     }
-    let settingsBaselineIDs = Set(windows(pid: pid).map(\.id))
-    try click(CGPoint(x: settingsButtonBounds.midX, y: settingsButtonBounds.midY))
-
-    guard let settingsWindow = wait(timeout: 3, for: { () -> WindowSnapshot? in
-        windows(pid: pid).first { !settingsBaselineIDs.contains($0.id) && $0.bounds.width >= 500 && $0.bounds.height >= 300 }
-    }) else {
-        capture("\(artifacts)/settings-open-failure.png")
-        throw SmokeError.message("ASSERT settings-opens: FAIL no Settings-sized (>=500x300) Kaji window appeared within 3 seconds of clicking gearshape")
-    }
-    print("ASSERT settings-opens: PASS window=\(settingsWindow.id) size=\(Int(settingsWindow.bounds.width))x\(Int(settingsWindow.bounds.height))")
-    try checkNoSystemAuthPrompt("settings opened", artifacts: artifacts)
-
-    func settingsElements() throws -> [AXElementInfo] {
-        guard let currentWindow = windows(pid: pid).first(where: { $0.id == settingsWindow.id }),
-              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
-            throw SmokeError.message("ASSERT settings-nav: FAIL could not locate the Settings AXUIElement window via system-wide hit-test")
-        }
-        var budget = 4000
-        return collectAXElements(element, budget: &budget)
+    for section in settingsSections {
+        let safeName = section.replacingOccurrences(of: " ", with: "-").lowercased()
+        let path = URL(fileURLWithPath: artifacts).appendingPathComponent("settings-\(safeName).png").path
+        _ = try render(port: port, nonce: nonce, surface: "settings", selection: section, outputPath: path)
+        try assertPNG(path, label: "settings-\(safeName)")
+        try assertNoSystemAuthPrompt("settings \(section)")
     }
 
-    let settingsSections = ["General", "Modules", "Work", "Goals", "Quota", "AI News", "Mail Brief", "CLI"]
-    var previousSignature: Set<String>? = nil
-    for (index, section) in settingsSections.enumerated() {
-        if index > 0 {
-            let currentElements = try settingsElements()
-            guard let row = currentElements.first(where: { $0.role == "AXStaticText" && $0.text == section }),
-                  let rowBounds = row.bounds else {
-                capture("\(artifacts)/settings-nav-failure.png")
-                throw SmokeError.message("ASSERT settings-nav: FAIL no sidebar row titled \"\(section)\" found in the Settings AX tree; static text seen: \(currentElements.filter { $0.role == "AXStaticText" }.map(\.text))")
-            }
-            try click(CGPoint(x: rowBounds.midX, y: rowBounds.midY))
-        }
-        Thread.sleep(forTimeInterval: 1.0)
-        let pageElements = try settingsElements()
-        let signature = Set(pageElements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text))
-        print("AX-DUMP [Settings:\(section)] discovered \(pageElements.count) nodes")
-        for info in pageElements where !info.text.isEmpty {
-            let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
-            print("AX-DUMP [Settings:\(section)] role=\(info.role) text=\"\(info.text)\" bounds=\(boundsText)")
-        }
-        try checkNoSystemAuthPrompt("settings section \(section)", artifacts: artifacts)
-        if let previousSignature, index > 0 {
-            guard signature != previousSignature else {
-                capture("\(artifacts)/settings-nav-failure.png")
-                throw SmokeError.message("ASSERT settings-nav: FAIL clicking sidebar row \"\(section)\" did not change the visible content; static text stayed: \(signature.sorted())")
-            }
-        }
-        previousSignature = signature
+    let after = try DesktopState.capture()
+    guard before.mouse == after.mouse else {
+        throw SmokeError(description: "ASSERT mouse-position: FAIL \(before.mouse) -> \(after.mouse)")
     }
-    print("ASSERT settings-nav: PASS walked \(settingsSections.count) sidebar sections, content changed on every click")
-    print("ASSERT no-system-auth-prompt: PASS checked \(authPromptCheckCount) times, no system authorization window ever appeared")
-
-
-
-    guard let refreshedBounds = statusItemBounds(pid: pid) else {
-        throw SmokeError.message("ASSERT click-closes-popover: FAIL could not refresh status-item AX bounds")
+    print("ASSERT mouse-position: PASS unchanged at \(before.mouse)")
+    guard before.frontmostBundleID == after.frontmostBundleID,
+          before.frontmostPID == after.frontmostPID else {
+        throw SmokeError(description: "ASSERT frontmost-application: FAIL \(String(describing: before.frontmostBundleID))/\(String(describing: before.frontmostPID)) -> \(String(describing: after.frontmostBundleID))/\(String(describing: after.frontmostPID))")
     }
-    let closePoint = CGPoint(x: refreshedBounds.minX + min(12, refreshedBounds.width / 2), y: refreshedBounds.midY)
-    try click(closePoint)
-
-    guard wait(timeout: 3, for: {
-        windows(pid: pid).contains(where: { $0.id == opened.id }) ? nil : true
-    }) != nil else {
-        capture("\(artifacts)/close-failure.png")
-        throw SmokeError.message("ASSERT click-closes-popover: FAIL popover window \(opened.id) remained on screen after second click")
-    }
-    capture("\(artifacts)/closed.png")
-    print("ASSERT click-closes-popover: PASS window=\(opened.id) disappeared")
+    print("ASSERT frontmost-application: PASS unchanged \(before.frontmostBundleID ?? "<none>") pid=\(before.frontmostPID.map(String.init) ?? "<none>")")
+    print("ASSERT no-system-auth-prompt: PASS across all offscreen renders")
 }
 
 do {

--- a/scripts/ui-smoke.swift
+++ b/scripts/ui-smoke.swift
@@ -318,6 +318,13 @@ func run() throws {
         throw SmokeError.message("ASSERT ax-quota-page: FAIL expected an AXStaticText titled \"\(expectedQuotaTitle)\"; observed static text: \(observedTexts)")
     }
     print("ASSERT ax-quota-page: PASS found AXStaticText \"\(expectedQuotaTitle)\"")
+    let launchdAuditURL = URL(fileURLWithPath: artifacts).appendingPathComponent("kaji.stdout.log")
+    func launchdRefreshCount() -> Int {
+        let log = (try? String(contentsOf: launchdAuditURL, encoding: .utf8)) ?? ""
+        return log.split(whereSeparator: \.isNewline)
+            .count { $0 == "KAJI_UI_SMOKE launchd-refresh" }
+    }
+
 
     if expectedPageTitles.count > 1 {
         let windowTop = opened.bounds.minY
@@ -381,6 +388,27 @@ func run() throws {
     } else {
         print("ASSERT ax-page-nav: SKIP only \(expectedPageTitles.count) page(s) enabled; header chevrons are hidden (pages.count > 1 gate in KajiPopoverView.header)")
     }
+    let refreshCountBeforeVisibilityClose = launchdRefreshCount()
+    guard refreshCountBeforeVisibilityClose > 0 else {
+        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL no refresh occurred while the popover was visible")
+    }
+    try click(openPoint)
+    guard wait(timeout: 3, for: {
+        windows(pid: pid).contains(where: { $0.id == opened.id }) ? nil : true
+    }) != nil else {
+        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL popover did not close for lifecycle check")
+    }
+    Thread.sleep(forTimeInterval: 1.0)
+    let refreshCountAfterVisibilityClose = launchdRefreshCount()
+    guard refreshCountAfterVisibilityClose == refreshCountBeforeVisibilityClose else {
+        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL refresh count changed after close (\(refreshCountBeforeVisibilityClose) -> \(refreshCountAfterVisibilityClose))")
+    }
+    print("ASSERT background-tasks-visible-lifecycle: PASS refresh occurred while visible and count stayed \(refreshCountAfterVisibilityClose) after close")
+    try click(openPoint)
+    guard wait(timeout: 3, for: { popoverWindow(in: windows(pid: pid)) }) != nil else {
+        throw SmokeError.message("ASSERT background-tasks-visible-lifecycle: FAIL popover did not reopen after lifecycle check")
+    }
+
 
     // Settings walk: click gearshape in the popover footer, then click every
     // sidebar section and assert the visible content actually changes.
@@ -449,6 +477,7 @@ func run() throws {
     }
     print("ASSERT settings-nav: PASS walked \(settingsSections.count) sidebar sections, content changed on every click")
     print("ASSERT no-system-auth-prompt: PASS checked \(authPromptCheckCount) times, no system authorization window ever appeared")
+
 
 
     guard let refreshedBounds = statusItemBounds(pid: pid) else {

--- a/scripts/ui-smoke.swift
+++ b/scripts/ui-smoke.swift
@@ -353,6 +353,29 @@ func run() throws {
             }
             sequence.append(expected)
             try checkNoSystemAuthPrompt("popover page \(expected)", artifacts: artifacts)
+            if expected == "Background Tasks" {
+                guard wait(timeout: 3, for: { () -> Bool? in
+                    let texts = (try? popoverElements())?
+                        .filter { $0.role == "AXStaticText" }
+                        .map(\.text) ?? []
+                    return texts.contains(where: { $0.uppercased().hasPrefix("USER AGENTS · ") }) ? true : nil
+                }) != nil else {
+                    capture("\(artifacts)/background-tasks-failure.png")
+                    throw SmokeError.message("ASSERT background-tasks-real-data: FAIL no installed user-agent section appeared")
+                }
+                let launchdTexts = try popoverElements()
+                    .filter { $0.role == "AXStaticText" }
+                    .map(\.text)
+                let expectedCount = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_EXPECT_USER_AGENT_COUNT"]
+                let expectedSection = expectedCount.map { "USER AGENTS · \($0)" }
+                guard expectedSection.map(launchdTexts.contains) ?? true,
+                      launchdTexts.contains(where: { ["RUNNING", "FAILED", "IDLE", "UNLOADED"].contains($0) }) else {
+                    capture("\(artifacts)/background-tasks-failure.png")
+                    throw SmokeError.message("ASSERT background-tasks-real-data: FAIL expected installed agents and visible job states; observed \(launchdTexts)")
+                }
+                capture("\(artifacts)/background-tasks.png")
+                print("ASSERT background-tasks-real-data: PASS rendered \(expectedCount ?? "installed") user agents with live launchd states")
+            }
         }
         print("ASSERT ax-page-nav: PASS clicked through pages in order \(sequence.joined(separator: " -> "))")
     } else {


### PR DESCRIPTION
## Summary
- add an opt-in, read-only Background Tasks module for the user GUI launchd domain
- classify jobs into `My Tasks` (valid installed `~/Library/LaunchAgents` labels), `Apps & Services`, and `Apple`, with a compact in-popover category switcher
- keep the header summary and menubar signal scoped to My Tasks; only installed nonzero exits trigger failure priority
- present non-installed Apple/app nonzero exits as idle while retaining `Last exit N` metadata, because `launchctl list` cannot establish that on-demand/system jobs should be continuously running
- discover installed agents only from parseable plist dictionaries with a non-empty `Label`; malformed, empty, and label-less placeholders are ignored
- preserve module opt-in, visibility-driven refresh, and module-owned state cleanup when disabled

## Why this PR is stacked on #42
This module uses #42's measured-height `PopoverHeightBudget` API and keeps its `PopoverHeightBudgetTests` coverage green. Those APIs and tests are not on `main` yet, so retargeting now would mean adapting the module to the old height mechanism and changing it again after #42 lands. Recommended merge order: **#42 → #43**.

## Refresh strategy
There is no heartbeat or repeating timer. When enabled, Kaji performs one launch-time snapshot so the menubar segment has a real My Tasks count. Opening the status popover refreshes the snapshot once; closing it blocks further popover-driven refreshes and discards late visible-page results. Disabling clears the snapshot and stops all module work. Category selection lasts only for the current popover view lifecycle.

## Verification
- `swift build`
- `swift test` — 189 tests, 0 failures
- behavior coverage verifies 128 unrelated GUI-session jobs cannot change the installed summary; installed exit 78 is failed, while non-installed app/Apple exits -9 and 78 remain idle with exit metadata
- category coverage verifies `com.apple.*` and `application.com.apple.*` map to Apple, installed labels map to My Tasks, and other GUI jobs map to Apps & Services
- discovery coverage verifies a valid `Label` is included while empty dictionaries, malformed plists, label-less plists, and non-plist files are ignored

The previous `scripts/ui-smoke.sh` drives the real pointer with CGEvent and can steal foreground focus. It was not run. The currently running Kaji inspection App was not restarted, activated, or otherwise interacted with.

## Appearance evidence limitation
The real App inspection uses the machine's current dark system appearance. Earlier light-mode evidence was an offscreen `.aqua` render of the same SwiftUI view, not the App run under a real light system appearance. This avoids changing the user's system appearance setting.