### PR TITLE
Make delayed goal-removal tests deterministic

### DIFF
--- a/Sources/Kaji/DailyGoalStore.swift
+++ b/Sources/Kaji/DailyGoalStore.swift
@@ -30,7 +30,8 @@ final class DailyGoalStore: ObservableObject {
     private var now: () -> Date
     private var calendar: Calendar
     private let completionRemovalDelay: Duration
-    private var completionRemovalTasks: [UUID: Task<Void, Never>] = [:]
+    private let completionRemovalSleep: @Sendable (Duration) async -> Void
+    var completionRemovalTasks: [UUID: Task<Void, Never>] = [:]
     private(set) var loadIssue: GoalStateLoadIssue?
     private static let tagDefinitionsKey = "goalTagDefinitionsV1"
 
@@ -38,12 +39,14 @@ final class DailyGoalStore: ObservableObject {
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
         calendar: Calendar = .current,
-        completionRemovalDelay: Duration = .seconds(5)
+        completionRemovalDelay: Duration = .seconds(5),
+        completionRemovalSleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
     ) {
         self.defaults = defaults
         self.now = now
         self.calendar = calendar
         self.completionRemovalDelay = completionRemovalDelay
+        self.completionRemovalSleep = completionRemovalSleep
         if let data = defaults.data(forKey: Self.tagDefinitionsKey),
            let saved = try? JSONDecoder().decode([GoalTagDefinition].self, from: data),
            !saved.isEmpty {
@@ -319,7 +322,7 @@ final class DailyGoalStore: ObservableObject {
         guard isDone else { return }
         completionRemovalTasks[id] = Task { [weak self] in
             guard let self else { return }
-            try? await Task.sleep(for: self.completionRemovalDelay)
+            await self.completionRemovalSleep(self.completionRemovalDelay)
             guard !Task.isCancelled else { return }
             self.completionRemovalTasks[id] = nil
             self.mutate(horizon) { goals in

--- a/Tests/KajiTests/GoalStatePersistenceTests.swift
+++ b/Tests/KajiTests/GoalStatePersistenceTests.swift
@@ -160,35 +160,52 @@ final class GoalStatePersistenceTests: XCTestCase {
 
     @MainActor
     func testCompletedGoalCanBeUndoneBeforeDelayedRemoval() async throws {
+        let gate = SleepGate()
         let store = DailyGoalStore(
             defaults: defaults,
-            completionRemovalDelay: .milliseconds(30)
+            completionRemovalDelay: .milliseconds(30),
+            completionRemovalSleep: { await gate.sleep($0) }
         )
         let goal = try store.addGoal(title: "Undo me", tag: "Work", note: "", in: .today)
 
         store.toggle(goal)
         XCTAssertTrue(store.goals.first?.isDone == true)
-        try await Task.sleep(for: .milliseconds(10))
+        let removalTask = try XCTUnwrap(store.completionRemovalTasks[goal.id])
+        // Wait until the removal task has actually reached its delay, proving
+        // there is a pending removal in flight to cancel below.
+        await gate.waitUntilReached()
+
         let completed = try XCTUnwrap(store.goals.first)
         store.toggle(completed)
-        try await Task.sleep(for: .milliseconds(40))
 
+        // The cancellation above happens synchronously inside `toggle`, so
+        // this assertion does not race any clock.
         XCTAssertEqual(store.goals.map(\.id), [goal.id])
         XCTAssertFalse(store.goals[0].isDone)
+
+        // Release the (already cancelled) task so it observes cancellation
+        // and exits cleanly instead of leaking a suspended continuation.
+        await gate.release()
+        _ = await removalTask.value
     }
 
     @MainActor
     func testCompletedGoalIsRemovedAfterDelay() async throws {
+        let gate = SleepGate()
         let store = DailyGoalStore(
             defaults: defaults,
-            completionRemovalDelay: .milliseconds(20)
+            completionRemovalDelay: .milliseconds(20),
+            completionRemovalSleep: { await gate.sleep($0) }
         )
         let goal = try store.addGoal(title: "Finish me", tag: "Work", note: "", in: .today)
 
         store.toggle(goal)
-        for _ in 0..<50 where !store.goals.isEmpty {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        let removalTask = try XCTUnwrap(store.completionRemovalTasks[goal.id])
+        await gate.waitUntilReached()
+        XCTAssertEqual(store.goals.map(\.id), [goal.id])
+
+        await gate.release()
+        await removalTask.value
 
         XCTAssertTrue(store.goals.isEmpty)
     }
@@ -203,5 +220,43 @@ final class GoalStatePersistenceTests: XCTestCase {
             history: ["2026-8-2": GoalHistoryDay(day: "2026-8-2", completed: 1, total: 2)],
             yesterdayPending: [GoalItem(id: UUID(), title: "Pending", isDone: false, tag: "Home")]
         )
+    }
+}
+
+/// Deterministic stand-in for `Task.sleep` used by `DailyGoalStore`'s
+/// delayed-removal task. Lets a test observe exactly when the production
+/// code has entered its delay (`waitUntilReached`) and control exactly when
+/// it resumes (`release`), replacing wall-clock races with explicit
+/// state-machine signaling.
+private actor SleepGate {
+    private var hasReached = false
+    private var reachedContinuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    /// Called by the code under test in place of `Task.sleep`.
+    func sleep(_ duration: Duration) async {
+        hasReached = true
+        reachedContinuation?.resume()
+        reachedContinuation = nil
+        if isReleased { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    /// Suspends the caller until `sleep(_:)` has been entered.
+    func waitUntilReached() async {
+        if hasReached { return }
+        await withCheckedContinuation { continuation in
+            reachedContinuation = continuation
+        }
+    }
+
+    /// Lets a suspended (or future) `sleep(_:)` call resume.
+    func release() {
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
     }
 }


### PR DESCRIPTION
Both delayed-removal tests in `GoalStatePersistenceTests` raced two independent real-time `Task.sleep` calls (the test's own sleep and `DailyGoalStore`'s completion-removal timer), which could flip under CI scheduling jitter.

- Inject a `completionRemovalSleep` closure into `DailyGoalStore` (default unchanged: real `Task.sleep(for:)`); no production call site or behavior changes.
- Tests drive it with a local `SleepGate` actor that signals when the removal task has actually entered its delay and lets the test control exactly when it resumes, so assertions target state-machine transitions instead of wall-clock timing.
- Replaced the polling loop in `testCompletedGoalIsRemovedAfterDelay` (its `for ... where` clause filtered each iteration's body instead of breaking early, so it never exited before its 500ms cap) with directly awaiting the removal task's completion.
- `completionRemovalDelay` values are kept in both tests to document the delay semantics; they no longer gate timing.

Both target tests pass 20/20 with `--filter`; full suite green.