### PR TITLE
fix(mail): preserve Gmail credentials across transient failures

### DIFF
--- a/Sources/Kaji/GmailMailBriefClient.swift
+++ b/Sources/Kaji/GmailMailBriefClient.swift
@@ -16,6 +16,20 @@ enum GmailThreadMutation: Sendable {
     }
 }
 
+@MainActor
+enum MailBriefAuthorizedRequest {
+    static func run<T>(
+        token: (Bool) async throws -> String,
+        operation: (String) async throws -> T
+    ) async throws -> T {
+        do {
+            return try await operation(try await token(false))
+        } catch MailBriefError.gmailUnauthorized {
+            return try await operation(try await token(true))
+        }
+    }
+}
+
 struct GmailMailBriefClient {
     private let session: URLSession
     init(session: URLSession = .shared) { self.session = session }
@@ -99,8 +113,20 @@ struct GmailMailBriefClient {
             request.httpBody = body
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw MailBriefError.transient("Gmail is temporarily unavailable")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw MailBriefError.invalidResponse
+        }
+        if http.statusCode == 401 { throw MailBriefError.gmailUnauthorized }
+        if http.statusCode == 429 || (500..<600).contains(http.statusCode) {
+            throw MailBriefError.transient("Gmail is temporarily unavailable")
+        }
+        guard (200..<300).contains(http.statusCode) else {
             throw MailBriefError.invalidResponse
         }
         return data

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -221,6 +221,19 @@ struct KajiPopoverView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }.frame(maxWidth: .infinity).padding(22)
+            case .credentialUnavailable:
+                VStack(spacing: 8) {
+                    Text("Kaji needs permission to use the saved Gmail credential.")
+                        .font(.system(size: 10.5, weight: .medium)).foregroundColor(t.mute)
+                    Button("Authorize Access") { mailBriefStore.authorizeCredentialAccess() }
+                        .buttonStyle(.bordered)
+                }.frame(maxWidth: .infinity).padding(22)
+            case .needsReauthorization:
+                VStack(spacing: 8) {
+                    Text("Gmail authorization needs to be renewed.")
+                        .font(.system(size: 10.5, weight: .medium)).foregroundColor(t.mute)
+                    Button("Reconnect Gmail") { mailBriefStore.connect() }.buttonStyle(.bordered)
+                }.frame(maxWidth: .infinity).padding(22)
             case .scheduled where mailBriefStore.generation == nil:
                 Text("Next brief \(mailBriefStore.nextDue?.formatted(date: .omitted, time: .shortened) ?? "09:00")")
                     .font(.system(size: 10.5, weight: .medium)).foregroundColor(t.mute)
@@ -271,6 +284,15 @@ struct KajiPopoverView: View {
                     Text("Inbox \(count)").font(.system(size: 9, weight: .medium, design: .monospaced)).foregroundColor(t.mute)
                 }
                 if mailBriefStore.state == .stale { Text("上次生成失败，显示旧简报").font(.system(size: 9)).foregroundColor(t.mute) }
+                switch mailBriefStore.credentialState {
+                case .unavailable where mailBriefStore.generation != nil:
+                    Button("Authorize Access") { mailBriefStore.authorizeCredentialAccess() }
+                        .buttonStyle(.plain)
+                case .needsGoogleReauthorization where mailBriefStore.generation != nil:
+                    Button("Reconnect Gmail") { mailBriefStore.connect() }.buttonStyle(.plain)
+                default:
+                    EmptyView()
+                }
                 if let error = mailBriefStore.lastError, mailBriefStore.state != .stale {
                     Text(error).font(.system(size: 9)).foregroundColor(t.mute).lineLimit(2)
                 }

--- a/Sources/Kaji/MailBriefCredentialStore.swift
+++ b/Sources/Kaji/MailBriefCredentialStore.swift
@@ -11,7 +11,11 @@ struct MailBriefOAuthCredential: Codable, Sendable, Equatable {
 }
 
 final class MailBriefCredentialCache: @unchecked Sendable {
-    private enum State { case empty, loaded(MailBriefOAuthCredential?) }
+    private enum State {
+        case empty
+        case absent
+        case loaded(MailBriefOAuthCredential)
+    }
     private let lock = NSLock()
     private var state: State = .empty
 
@@ -20,27 +24,38 @@ final class MailBriefCredentialCache: @unchecked Sendable {
         defer { lock.unlock() }
         switch state {
         case .loaded(let value):
-            guard let value else { throw MailBriefError.notConnected }
             return value
+        case .absent:
+            throw MailBriefError.notConnected
         case .empty:
             do {
                 let value = try load()
                 state = .loaded(value)
                 return value
+            } catch MailBriefError.notConnected {
+                state = .absent
+                throw MailBriefError.notConnected
             } catch {
-                state = .loaded(nil)
+                // Access and transient Keychain failures must remain retryable.
                 throw error
             }
         }
     }
 
     func store(_ value: MailBriefOAuthCredential?) {
-        lock.withLock { state = .loaded(value) }
+        lock.withLock { state = value.map(State.loaded) ?? .absent }
     }
 
     func invalidate() {
         lock.withLock { state = .empty }
     }
+}
+
+enum MailBriefCredentialStatus: Equatable {
+    case absent
+    case unavailable
+    case present(account: String?, canModify: Bool)
+    case needsGoogleReauthorization
 }
 
 enum KeychainInteractionScope {
@@ -56,6 +71,14 @@ enum KeychainInteractionScope {
         return try operation()
     }
 }
+private final class MailBriefReauthorizationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var required = false
+
+    func read() -> Bool { lock.withLock { required } }
+    func set(_ value: Bool) { lock.withLock { required = value } }
+}
+
 
 enum MailBriefCredentialStore {
     private static let service = "dev.kaji.mail-brief.gmail"
@@ -63,6 +86,7 @@ enum MailBriefCredentialStore {
     private static let previousCredentialAccount = "oauth-credential-v2"
     private static let legacyCredentialAccount = "oauth-credential-v1"
     private static let cache = MailBriefCredentialCache()
+    private static let reauthorizationState = MailBriefReauthorizationState()
 
     enum AuthorizationStatus: Equatable {
         case authorized
@@ -70,17 +94,29 @@ enum MailBriefCredentialStore {
         case needsReauthorization
     }
 
-    static var hasCredential: Bool { (try? credential()) != nil }
-    static var account: String? { try? credential().account }
-    static var canModify: Bool { (try? credential().scopes?.contains(MailBriefOAuthFlow.modifyScope)) ?? false }
+    static func status() -> MailBriefCredentialStatus {
+        if reauthorizationState.read() {
+            return .needsGoogleReauthorization
+        }
+        do {
+            let value = try credential()
+            return .present(
+                account: value.account,
+                canModify: value.scopes?.contains(MailBriefOAuthFlow.modifyScope) ?? false
+            )
+        } catch MailBriefError.notConnected {
+            return .absent
+        } catch {
+            return .unavailable
+        }
+    }
+
     static func authorizationStatus() -> AuthorizationStatus {
         cache.invalidate()
-        do {
-            return try read(account: credentialAccount) == nil ? .notAuthorized : .authorized
-        } catch MailBriefError.notConnected {
-            return .needsReauthorization
-        } catch {
-            return .notAuthorized
+        switch status() {
+        case .present: return .authorized
+        case .absent: return .notAuthorized
+        case .unavailable, .needsGoogleReauthorization: return .needsReauthorization
         }
     }
 
@@ -124,21 +160,43 @@ enum MailBriefCredentialStore {
     static func save(_ credential: MailBriefOAuthCredential) throws {
         try write(credential, account: credentialAccount)
         cache.store(credential)
+        reauthorizationState.set(false)
     }
 
-    static func validAccessToken(clientID: String, clientSecret: String) async throws -> String {
+    static func validAccessToken(
+        clientID: String,
+        clientSecret: String,
+        forceRefresh: Bool = false,
+        session: URLSession = .shared
+    ) async throws -> String {
         var value = try credential()
-        if value.expiresAt.timeIntervalSinceNow > 120 { return value.accessToken }
-        guard let refreshToken = value.refreshToken else { throw MailBriefError.notConnected }
+        if !forceRefresh, value.expiresAt.timeIntervalSinceNow > 120 { return value.accessToken }
+        guard let refreshToken = value.refreshToken else {
+            markNeedsGoogleReauthorization()
+            throw MailBriefError.reauthorizationRequired
+        }
         var request = URLRequest(url: URL(string: "https://oauth2.googleapis.com/token")!)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = form(["client_id": clientID, "client_secret": clientSecret,
                                  "refresh_token": refreshToken, "grant_type": "refresh_token"])
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse, http.statusCode == 200,
-              let refreshed = try? JSONDecoder().decode(TokenRefresh.self, from: data) else {
-            throw MailBriefError.oauth("Gmail authorization expired; connect again")
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw MailBriefError.transient("Gmail token refresh is temporarily unavailable")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw MailBriefError.transient("Gmail token refresh returned an invalid response")
+        }
+        if let refreshError = tokenRefreshError(statusCode: http.statusCode, data: data) {
+            if case .reauthorizationRequired = refreshError {
+                markNeedsGoogleReauthorization()
+            }
+            throw refreshError
+        }
+        guard let refreshed = try? JSONDecoder().decode(TokenRefresh.self, from: data) else {
+            throw MailBriefError.transient("Gmail token refresh is temporarily unavailable")
         }
         value.accessToken = refreshed.accessToken
         value.expiresAt = Date().addingTimeInterval(TimeInterval(refreshed.expiresIn))
@@ -146,11 +204,25 @@ enum MailBriefCredentialStore {
         return value.accessToken
     }
 
-    static func delete() {
+    static func markNeedsGoogleReauthorization() {
+        reauthorizationState.set(true)
+    }
+    static func tokenRefreshError(statusCode: Int, data: Data) -> MailBriefError? {
+        if statusCode == 200 { return nil }
+        if statusCode == 400,
+           (try? JSONDecoder().decode(TokenRefreshError.self, from: data).error) == "invalid_grant" {
+            return .reauthorizationRequired
+        }
+        return .transient("Gmail token refresh is temporarily unavailable")
+    }
+
+
+    static func disconnectByUser() {
         delete(account: credentialAccount)
         delete(account: previousCredentialAccount)
         delete(account: legacyCredentialAccount)
         cache.store(nil)
+        reauthorizationState.set(false)
     }
 
     private static func read(account: String, allowsInteraction: Bool = false) throws -> MailBriefOAuthCredential? {
@@ -174,10 +246,10 @@ enum MailBriefCredentialStore {
     static func decodedCredential(status: OSStatus, result: CFTypeRef?) throws -> MailBriefOAuthCredential {
         if status == errSecInteractionNotAllowed || status == errSecUserCanceled ||
             status == errSecAuthFailed {
-            throw MailBriefError.notConnected
+            throw MailBriefError.credentialUnavailable
         }
         guard status == errSecSuccess, let data = result as? Data else {
-            throw MailBriefError.oauth("Could not read Gmail credential (\(status))")
+            throw MailBriefError.credentialUnavailable
         }
         return try JSONDecoder().decode(MailBriefOAuthCredential.self, from: data)
     }
@@ -300,6 +372,9 @@ enum MailBriefCredentialStore {
     private struct TokenRefresh: Decodable {
         let accessToken: String; let expiresIn: Int
         enum CodingKeys: String, CodingKey { case accessToken = "access_token"; case expiresIn = "expires_in" }
+    }
+    private struct TokenRefreshError: Decodable {
+        let error: String
     }
     static func form(_ values: [String: String]) -> Data {
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))

--- a/Sources/Kaji/MailBriefStore.swift
+++ b/Sources/Kaji/MailBriefStore.swift
@@ -3,7 +3,8 @@ import Foundation
 import KajiCore
 
 enum MailBriefState: Equatable {
-    case disabled, disconnected, scheduled, running, ready, stale, failed
+    case disabled, disconnected, credentialUnavailable, needsReauthorization
+    case scheduled, running, ready, stale, failed
 }
 
 @MainActor
@@ -19,7 +20,7 @@ final class MailBriefStore: ObservableObject {
     @Published private(set) var draftingThreadIDs: Set<String> = []
 
     private let cacheURL: URL
-    private let credentialStatus: () -> (hasCredential: Bool, account: String?, canModify: Bool)
+    private let credentialStatus: () -> MailBriefCredentialStatus
     private let runHistoryURL: URL
     private var enabled = false
     private var timer: Timer?
@@ -32,9 +33,8 @@ final class MailBriefStore: ObservableObject {
 
     init(
         cacheURL: URL? = nil,
-        credentialStatus: @escaping () -> (hasCredential: Bool, account: String?, canModify: Bool) = {
-            (MailBriefCredentialStore.hasCredential, MailBriefCredentialStore.account,
-             MailBriefCredentialStore.canModify)
+        credentialStatus: @escaping () -> MailBriefCredentialStatus = {
+            MailBriefCredentialStore.status()
         }
     ) {
         self.cacheURL = cacheURL ?? Self.defaultCacheURL()
@@ -48,14 +48,14 @@ final class MailBriefStore: ObservableObject {
     init(
         previewGeneration: MailBriefGeneration,
         cacheDirectory: URL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("kaji-mail-preview-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("kaji-mail-preview-\(UUID().uuidString)", isDirectory: true),
+        credentialStatus: @escaping () -> MailBriefCredentialStatus = {
+            MailBriefCredentialStore.status()
+        }
     ) {
         cacheURL = cacheDirectory.appendingPathComponent("mail-brief-cache-v1.json")
         runHistoryURL = cacheDirectory.appendingPathComponent("mail-brief-runs-v1.json")
-        credentialStatus = {
-            (MailBriefCredentialStore.hasCredential, MailBriefCredentialStore.account,
-             MailBriefCredentialStore.canModify)
-        }
+        self.credentialStatus = credentialStatus
         generation = previewGeneration
         state = .ready
     }
@@ -85,12 +85,24 @@ final class MailBriefStore: ObservableObject {
                                               archivedIDs: generation.archivedThreadIDs,
                                               trashedIDs: generation.trashedThreadIDs)
     }
-    private var cachedCredentialStatus: (hasCredential: Bool, account: String?, canModify: Bool)? {
+    private var currentCredentialStatus: MailBriefCredentialStatus? {
         enabled ? credentialStatus() : nil
     }
-    var isConnected: Bool { cachedCredentialStatus?.hasCredential ?? false }
-    var accountLabel: String? { cachedCredentialStatus?.account }
-    var canModify: Bool { cachedCredentialStatus?.canModify ?? false }
+    var credentialState: MailBriefCredentialStatus {
+        currentCredentialStatus ?? .absent
+    }
+    var isConnected: Bool {
+        if case .present = currentCredentialStatus { return true }
+        return false
+    }
+    var accountLabel: String? {
+        guard case .present(let account, _) = currentCredentialStatus else { return nil }
+        return account
+    }
+    var canModify: Bool {
+        guard case .present(_, let canModify) = currentCredentialStatus else { return false }
+        return canModify
+    }
 
     func setEnabled(_ enabled: Bool, hour: Int, minute: Int, batchSize: Int, concurrency: Int,
                     model: MailBriefModel) {
@@ -104,10 +116,25 @@ final class MailBriefStore: ObservableObject {
 
     func evaluateSchedule(now: Date = Date()) {
         guard enabled else { return }
-        guard isConnected else { timer?.invalidate(); state = .disconnected; return }
-        let decision = MailBriefSchedulePolicy.decision(now: now, hour: hour, minute: minute,
-                                                        calendar: .current,
-                                                        lastAutomaticSuccess: generation?.isComplete == false ? nil : generation?.createdAt)
+        switch currentCredentialStatus {
+        case .present:
+            break
+        case .absent:
+            timer?.invalidate(); state = .disconnected; return
+        case .unavailable:
+            timer?.invalidate(); state = generation == nil ? .credentialUnavailable : .stale; return
+        case .needsGoogleReauthorization:
+            timer?.invalidate(); state = generation == nil ? .needsReauthorization : .stale; return
+        case nil:
+            return
+        }
+        let decision = MailBriefSchedulePolicy.decision(
+            now: now,
+            hour: hour,
+            minute: minute,
+            calendar: .current,
+            lastAutomaticSuccess: generation?.isComplete == false ? nil : generation?.createdAt
+        )
         nextDue = decision.nextDue
         if decision.isDue { generateNow(automatic: true); return }
         state = generation == nil ? .scheduled : .ready
@@ -116,7 +143,7 @@ final class MailBriefStore: ObservableObject {
 
     func generateNow(automatic: Bool = false) {
         guard enabled, isConnected, runTask == nil else {
-            if !isConnected { state = .disconnected }
+            if !isConnected { evaluateSchedule() }
             return
         }
         state = .running; lastError = nil
@@ -131,9 +158,10 @@ final class MailBriefStore: ObservableObject {
                 guard let clientID = Bundle.main.object(forInfoDictionaryKey: "KajiGoogleOAuthClientID") as? String,
                       let clientSecret = Bundle.main.object(forInfoDictionaryKey: "KajiGoogleOAuthClientSecret") as? String,
                       !clientID.isEmpty, !clientSecret.isEmpty else { throw MailBriefError.oauth("Google OAuth client is not configured") }
-                let token = try await MailBriefCredentialStore.validAccessToken(clientID: clientID, clientSecret: clientSecret)
                 updateRun(id: runID) { $0.stage = .fetching }
-                let candidates = try await GmailMailBriefClient().fetchCandidates(accessToken: token)
+                let candidates = try await withGmailAccess(clientID: clientID, clientSecret: clientSecret) {
+                    try await GmailMailBriefClient().fetchCandidates(accessToken: $0)
+                }
                 syncProgress = (0, candidates.count)
                 let canReuse = generation?.classifierModelID == generationModel.rawValue
                 let oldByID = Dictionary(uniqueKeysWithValues: (canReuse ? generation?.entries ?? [] : []).map { ($0.threadID, $0) })
@@ -200,12 +228,8 @@ final class MailBriefStore: ObservableObject {
                 lastError = Self.safeError(error)
                 let errorCode = Self.safeErrorCode(error)
                 finishRun(id: runID, status: .failed, errorCode: errorCode)
-                if MailBriefFailurePolicy.disposition(errorCode: errorCode) == .reconnect {
-                    MailBriefCredentialStore.delete()
-                    nextDue = nil
-                    state = .disconnected
-                } else {
-                    state = generation == nil ? .failed : .stale
+                applyFailureState(error)
+                if state == .failed || state == .stale {
                     scheduleNextAutomaticAttempt()
                 }
             }
@@ -246,13 +270,15 @@ final class MailBriefStore: ObservableObject {
                 try await MailBriefOAuthFlow(clientID: clientID, clientSecret: clientSecret, requestsModify: false).connect()
                 self?.evaluateSchedule()
             } catch {
-                self?.lastError = Self.safeError(error)
-                self?.state = .disconnected
+                guard let self else { return }
+                lastError = Self.safeError(error)
+                applyFailureState(error)
             }
         }
     }
 
     func generateReplyDraft(for entry: MailBriefEntry) {
+        guard isConnected else { evaluateSchedule(); return }
         guard !draftingThreadIDs.contains(entry.threadID) else { return }
         draftingThreadIDs.insert(entry.threadID)
         lastError = nil
@@ -266,24 +292,20 @@ final class MailBriefStore: ObservableObject {
                       !clientID.isEmpty, !clientSecret.isEmpty else {
                     throw MailBriefError.oauth("Google OAuth client is not configured")
                 }
-                let token = try await MailBriefCredentialStore.validAccessToken(
+                let candidate = try await withGmailAccess(
                     clientID: clientID,
                     clientSecret: clientSecret
-                )
-                let candidate = try await GmailMailBriefClient().fetchCandidate(
-                    threadID: entry.threadID,
-                    accessToken: token
-                )
+                ) {
+                    try await GmailMailBriefClient().fetchCandidate(
+                        threadID: entry.threadID,
+                        accessToken: $0
+                    )
+                }
                 replyDrafts[entry.threadID] = try await CodexMailBriefExecutor()
                     .draftReply(candidate, model: generationModel)
             } catch {
                 lastError = Self.safeError(error)
-                let errorCode = Self.safeErrorCode(error)
-                if MailBriefFailurePolicy.disposition(errorCode: errorCode) == .reconnect {
-                    MailBriefCredentialStore.delete()
-                    nextDue = nil
-                    state = .disconnected
-                }
+                applyFailureState(error)
             }
         }
     }
@@ -299,6 +321,7 @@ final class MailBriefStore: ObservableObject {
     func untrash(_ entry: MailBriefEntry) { mutate(entry, .untrash) }
 
     private func mutate(_ entry: MailBriefEntry, _ mutation: GmailThreadMutation) {
+        guard isConnected else { evaluateSchedule(); return }
         guard !pendingThreadIDs.contains(entry.threadID), let current = generation else { return }
         pendingThreadIDs.insert(entry.threadID)
         lastError = nil
@@ -313,34 +336,27 @@ final class MailBriefStore: ObservableObject {
                       !clientID.isEmpty, !clientSecret.isEmpty else {
                     throw MailBriefError.oauth("Google OAuth client is not configured")
                 }
-                if !MailBriefCredentialStore.canModify {
+                if !canModify {
                     try await MailBriefOAuthFlow(
                         clientID: clientID,
                         clientSecret: clientSecret,
                         requestsModify: true
                     ).connect()
                 }
-                let token = try await MailBriefCredentialStore.validAccessToken(
-                    clientID: clientID,
-                    clientSecret: clientSecret
-                )
-                try await GmailMailBriefClient().mutate(
-                    threadID: entry.threadID,
-                    mutation: mutation,
-                    accessToken: token
-                )
+                try await withGmailAccess(clientID: clientID, clientSecret: clientSecret) {
+                    try await GmailMailBriefClient().mutate(
+                        threadID: entry.threadID,
+                        mutation: mutation,
+                        accessToken: $0
+                    )
+                }
             } catch {
                 if let current = generation {
                     generation = Self.applying(mutation.inverse, entry: entry, to: current)
                     try? saveCache()
                 }
                 lastError = Self.safeError(error)
-                let errorCode = Self.safeErrorCode(error)
-                if MailBriefFailurePolicy.disposition(errorCode: errorCode) == .reconnect {
-                    MailBriefCredentialStore.delete()
-                    nextDue = nil
-                    state = .disconnected
-                }
+                applyFailureState(error)
             }
         }
     }
@@ -377,13 +393,55 @@ final class MailBriefStore: ObservableObject {
     }
 
     func disconnect(deleteBrief: Bool = false) {
-        MailBriefCredentialStore.delete(); timer?.invalidate(); cancelActiveRun(); runTask?.cancel(); runTask = nil
+        MailBriefCredentialStore.disconnectByUser()
+        timer?.invalidate(); cancelActiveRun(); runTask?.cancel(); runTask = nil
         if deleteBrief {
             generation = nil; runRecords = []
             try? FileManager.default.removeItem(at: cacheURL)
             try? FileManager.default.removeItem(at: runHistoryURL)
         }
         state = enabled ? .disconnected : .disabled
+    }
+
+    func authorizeCredentialAccess() {
+        lastError = nil
+        do {
+            try MailBriefCredentialStore.authorizeAccess()
+            evaluateSchedule()
+        } catch {
+            lastError = Self.safeError(error)
+            state = generation == nil ? .credentialUnavailable : .stale
+        }
+    }
+
+    private func withGmailAccess<T>(
+        clientID: String,
+        clientSecret: String,
+        operation: (String) async throws -> T
+    ) async throws -> T {
+        try await MailBriefAuthorizedRequest.run(
+            token: { forceRefresh in
+                try await MailBriefCredentialStore.validAccessToken(
+                    clientID: clientID,
+                    clientSecret: clientSecret,
+                    forceRefresh: forceRefresh
+                )
+            },
+            operation: operation
+        )
+    }
+
+    private func applyFailureState(_ error: Error) {
+        switch error {
+        case MailBriefError.credentialUnavailable:
+            state = generation == nil ? .credentialUnavailable : .stale
+        case MailBriefError.reauthorizationRequired:
+            state = generation == nil ? .needsReauthorization : .stale
+        case MailBriefError.notConnected:
+            state = .disconnected
+        default:
+            state = generation == nil ? .failed : .stale
+        }
     }
 
     func stop() {
@@ -484,7 +542,12 @@ final class MailBriefStore: ObservableObject {
     private static func safeErrorCode(_ error: Error) -> String {
         guard let value = error as? MailBriefError else { return "unknown" }
         return switch value {
-        case .notConnected, .oauth: "oauth"
+        case .notConnected: "credential_absent"
+        case .credentialUnavailable: "credential_unavailable"
+        case .reauthorizationRequired: "reauthorization_required"
+        case .gmailUnauthorized: "gmail_unauthorized"
+        case .transient: "transient"
+        case .oauth: "oauth"
         case .invalidResponse: "gmail_invalid_response"
         case .executorUnavailable: "codex_unavailable"
         case .invalidOutput: "invalid_result"
@@ -493,14 +556,26 @@ final class MailBriefStore: ObservableObject {
 }
 
 enum MailBriefError: Error {
-    case notConnected, invalidResponse, executorUnavailable, invalidOutput, oauth(String)
+    case notConnected
+    case credentialUnavailable
+    case reauthorizationRequired
+    case gmailUnauthorized
+    case transient(String)
+    case invalidResponse
+    case executorUnavailable
+    case invalidOutput
+    case oauth(String)
+
     var errorDescription: String {
         switch self {
         case .notConnected: "Connect Gmail first"
+        case .credentialUnavailable: "Authorize Kaji to access the saved Gmail credential"
+        case .reauthorizationRequired: "Gmail authorization needs to be renewed"
+        case .gmailUnauthorized: "Gmail rejected the access token"
+        case .transient(let value), .oauth(let value): value
         case .invalidResponse: "Gmail returned an invalid response"
         case .executorUnavailable: "Codex is unavailable or not signed in"
         case .invalidOutput: "Codex returned an invalid brief"
-        case .oauth(let value): value
         }
     }
 }

--- a/Sources/KajiCore/MailBriefSchedulePolicy.swift
+++ b/Sources/KajiCore/MailBriefSchedulePolicy.swift
@@ -37,13 +37,3 @@ public enum MailBriefSchedulePolicy {
     }
 }
 
-public enum MailBriefFailureDisposition: Equatable, Sendable {
-    case reconnect
-    case waitUntilNextSchedule
-}
-
-public enum MailBriefFailurePolicy {
-    public static func disposition(errorCode: String) -> MailBriefFailureDisposition {
-        errorCode == "oauth" ? .reconnect : .waitUntilNextSchedule
-    }
-}

--- a/Tests/KajiTests/GmailMailBriefClientTests.swift
+++ b/Tests/KajiTests/GmailMailBriefClientTests.swift
@@ -49,6 +49,96 @@ final class GmailMailBriefClientTests: XCTestCase {
         XCTAssertTrue(requests[0].body.contains("INBOX"))
         XCTAssertTrue(requests[2].body.contains("STARRED"))
     }
+    func testUnauthorizedIsDistinguishedForSingleRefreshRetry() async {
+        GmailURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            return Self.response(for: url, status: 401, json: "{}")
+        }
+
+        do {
+            _ = try await makeClient().fetchCandidates(accessToken: "expired")
+            XCTFail("Expected unauthorized")
+        } catch MailBriefError.gmailUnauthorized {
+            // Expected: the store may refresh exactly once.
+        } catch {
+            XCTFail("Expected gmailUnauthorized, got \(error)")
+        }
+    }
+
+    func testRateLimitAndServerErrorsAreTransient() async {
+        for status in [429, 500, 503] {
+            GmailURLProtocol.handler = { request in
+                let url = try XCTUnwrap(request.url)
+                return Self.response(for: url, status: status, json: "{}")
+            }
+            do {
+                _ = try await makeClient().fetchCandidates(accessToken: "token")
+                XCTFail("Expected transient error for \(status)")
+            } catch MailBriefError.transient {
+                // Expected: credentials remain intact and the cached brief stays stale.
+            } catch {
+                XCTFail("Expected transient error for \(status), got \(error)")
+            }
+        }
+    }
+
+    func testNetworkErrorIsTransient() async {
+        GmailURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        do {
+            _ = try await makeClient().fetchCandidates(accessToken: "token")
+            XCTFail("Expected transient error")
+        } catch MailBriefError.transient {
+            // Expected.
+        } catch {
+            XCTFail("Expected transient error, got \(error)")
+        }
+    }
+
+    func testUnauthorizedRefreshesAndRetriesExactlyOnce() async throws {
+        var tokenRequests: [Bool] = []
+        var operations = 0
+
+        let value = try await MailBriefAuthorizedRequest.run(
+            token: { forceRefresh in
+                tokenRequests.append(forceRefresh)
+                return forceRefresh ? "fresh" : "expired"
+            },
+            operation: { token in
+                operations += 1
+                if token == "expired" { throw MailBriefError.gmailUnauthorized }
+                return "ok"
+            }
+        )
+
+        XCTAssertEqual(value, "ok")
+        XCTAssertEqual(tokenRequests, [false, true])
+        XCTAssertEqual(operations, 2)
+    }
+
+    func testSecondUnauthorizedIsNotRetriedAgain() async {
+        var tokenRequests: [Bool] = []
+        var operations = 0
+
+        do {
+            _ = try await MailBriefAuthorizedRequest.run(
+                token: { forceRefresh in
+                    tokenRequests.append(forceRefresh)
+                    return "token"
+                },
+                operation: { _ -> String in
+                    operations += 1
+                    throw MailBriefError.gmailUnauthorized
+                }
+            )
+            XCTFail("Expected unauthorized")
+        } catch MailBriefError.gmailUnauthorized {
+            XCTAssertEqual(tokenRequests, [false, true])
+            XCTAssertEqual(operations, 2)
+        } catch {
+            XCTFail("Expected gmailUnauthorized, got \(error)")
+        }
+    }
+
 
     private func makeClient() -> GmailMailBriefClient {
         let config = URLSessionConfiguration.ephemeral
@@ -56,8 +146,12 @@ final class GmailMailBriefClientTests: XCTestCase {
         return GmailMailBriefClient(session: URLSession(configuration: config))
     }
 
-    private static func response(for url: URL, json: String) -> (HTTPURLResponse, Data) {
-        (HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(json.utf8))
+    private static func response(
+        for url: URL,
+        status: Int = 200,
+        json: String
+    ) -> (HTTPURLResponse, Data) {
+        (HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!, Data(json.utf8))
     }
 
     private static func threadJSON(id: String) -> String {

--- a/Tests/KajiTests/MailBriefCredentialStoreTests.swift
+++ b/Tests/KajiTests/MailBriefCredentialStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KajiCore
 import XCTest
 @testable import Kaji
 
@@ -50,6 +51,24 @@ final class MailBriefCredentialStoreTests: XCTestCase {
         XCTAssertThrowsError(try cache.value(load: missing))
         XCTAssertEqual(loads, 2)
     }
+    func testTransientCredentialReadFailureIsRetried() throws {
+        let cache = MailBriefCredentialCache()
+        var loads = 0
+
+        XCTAssertThrowsError(try cache.value {
+            loads += 1
+            throw MailBriefError.credentialUnavailable
+        })
+        XCTAssertEqual(
+            try cache.value {
+                loads += 1
+                return credential
+            },
+            credential
+        )
+        XCTAssertEqual(loads, 2)
+    }
+
 
     func testV2CredentialMigratesToV3BeforeDeletion() throws {
         var reads: [String] = []
@@ -96,7 +115,7 @@ final class MailBriefCredentialStoreTests: XCTestCase {
             .appendingPathComponent("kaji-disabled-mail-brief-\(UUID().uuidString).json")
         let store = MailBriefStore(cacheURL: cacheURL) {
             reads += 1
-            return (true, "user@example.com", true)
+            return .present(account: "user@example.com", canModify: true)
         }
 
         XCTAssertFalse(store.isConnected)
@@ -105,14 +124,72 @@ final class MailBriefCredentialStoreTests: XCTestCase {
         XCTAssertEqual(reads, 0)
     }
 
-    func testAuthenticationUIFailuresBecomeNotConnected() {
+    func testAuthenticationUIFailuresRemainRetryable() {
         for status in [errSecInteractionNotAllowed, errSecUserCanceled, errSecAuthFailed] {
             XCTAssertThrowsError(try MailBriefCredentialStore.decodedCredential(
                 status: status, result: nil
             )) { error in
-                guard case MailBriefError.notConnected = error else {
-                    return XCTFail("Expected notConnected, got \(error)")
+                guard case MailBriefError.credentialUnavailable = error else {
+                    return XCTFail("Expected credentialUnavailable, got \(error)")
                 }
+            }
+        }
+    }
+
+    @MainActor
+    func testConfirmedAbsentAloneShowsConnectState() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-credential-state-\(UUID().uuidString)", isDirectory: true)
+        let absent = MailBriefStore(cacheURL: root.appendingPathComponent("absent.json")) { .absent }
+        absent.setEnabled(true, hour: 9, minute: 0, batchSize: 10, concurrency: 2, model: .defaultValue)
+        XCTAssertEqual(absent.state, .disconnected)
+
+        let unavailable = MailBriefStore(cacheURL: root.appendingPathComponent("unavailable.json")) { .unavailable }
+        unavailable.setEnabled(true, hour: 9, minute: 0, batchSize: 10, concurrency: 2, model: .defaultValue)
+        XCTAssertEqual(unavailable.state, .credentialUnavailable)
+
+        let reauthorization = MailBriefStore(cacheURL: root.appendingPathComponent("reauthorization.json")) {
+            .needsGoogleReauthorization
+        }
+        reauthorization.setEnabled(true, hour: 9, minute: 0, batchSize: 10, concurrency: 2, model: .defaultValue)
+        XCTAssertEqual(reauthorization.state, .needsReauthorization)
+    }
+
+    @MainActor
+    func testTransientCredentialFailureKeepsCachedBriefStale() {
+        let generation = MailBriefGeneration(
+            briefDay: "2026-08-26",
+            entries: [],
+            snapshotInboxThreadCount: 60
+        )
+        let store = MailBriefStore(
+            previewGeneration: generation,
+            credentialStatus: { .unavailable }
+        )
+
+        store.setEnabled(true, hour: 9, minute: 0, batchSize: 10, concurrency: 2, model: .defaultValue)
+
+        XCTAssertEqual(store.state, .stale)
+        XCTAssertEqual(store.generation?.snapshotInboxThreadCount, 60)
+        XCTAssertEqual(store.credentialState, .unavailable)
+    }
+
+    func testInvalidGrantRequiresGoogleReauthorizationWithoutTreatingOtherFailuresAsRevocation() {
+        let invalidGrant = MailBriefCredentialStore.tokenRefreshError(
+            statusCode: 400,
+            data: Data(#"{"error":"invalid_grant"}"#.utf8)
+        )
+        guard case .reauthorizationRequired = invalidGrant else {
+            return XCTFail("Expected reauthorizationRequired")
+        }
+
+        for status in [400, 401, 429, 500, 503] {
+            let error = MailBriefCredentialStore.tokenRefreshError(
+                statusCode: status,
+                data: Data(#"{"error":"temporarily_unavailable"}"#.utf8)
+            )
+            guard case .transient = error else {
+                return XCTFail("Expected transient for \(status)")
             }
         }
     }

--- a/Tests/KajiTests/MailBriefSchedulePolicyTests.swift
+++ b/Tests/KajiTests/MailBriefSchedulePolicyTests.swift
@@ -42,13 +42,6 @@ final class MailBriefSchedulePolicyTests: XCTestCase {
         )
     }
 
-    func testOAuthFailureRequiresReconnect() {
-        XCTAssertEqual(MailBriefFailurePolicy.disposition(errorCode: "oauth"), .reconnect)
-        XCTAssertEqual(
-            MailBriefFailurePolicy.disposition(errorCode: "codex_unavailable"),
-            .waitUntilNextSchedule
-        )
-    }
 
     private func date(_ y: Int, _ m: Int, _ d: Int, _ h: Int, _ minute: Int) -> Date {
         calendar.date(from: DateComponents(year: y, month: m, day: d, hour: h, minute: minute))!


### PR DESCRIPTION
## Summary
- model Gmail credential availability explicitly instead of collapsing Keychain errors into disconnected
- retain saved credentials across transient refresh, network, and Gmail failures
- refresh and retry Gmail 401 responses once; require Google reauthorization only for invalid_grant
- keep cached briefs visible while credential access is temporarily unavailable

## Verification
- swift build
- swift test (169 tests)
- noninteractive Keychain metadata check: v3 item present and readable

No input-device UI smoke was run.