### PR TITLE
test: make UI smoke nonintrusive

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -29,10 +29,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var workSession = WorkSessionController(prefs: prefs)
     private let systemMonitor = SystemMonitor()
     let dailyGoals: DailyGoalStore
-    private lazy var mcpServer = KajiMCPServer(
-        goals: dailyGoals,
-        snapshotProvider: { [weak self] in self?.mcpSnapshot() ?? [:] }
-    )
+    private lazy var mcpServer: KajiMCPServer = {
+        let environment = ProcessInfo.processInfo.environment
+        let testNonce = environment["KAJI_UI_SMOKE_NONCE"]
+        let testPort = environment["KAJI_UI_SMOKE_PORT"].flatMap(UInt16.init)
+        let automation = testNonce.map { nonce in
+            KajiMCPServer.TestAutomation(
+                nonce: nonce,
+                render: { [weak self] surface, selection, outputPath in
+                    guard let self else { throw TestUIAutomationError.appUnavailable }
+                    return try self.renderTestSurface(
+                        surface: surface,
+                        selection: selection,
+                        outputPath: outputPath
+                    )
+                }
+            )
+        }
+        return KajiMCPServer(
+            goals: dailyGoals,
+            port: testPort ?? KajiMCPServer.port,
+            snapshotProvider: { [weak self] in self?.mcpSnapshot() ?? [:] },
+            testAutomation: automation
+        )
+    }()
     let fixedPlanStore: FixedPlanStore
     let popoverNavigation = PopoverNavigation()
     private let aiNewsStore: AIHotNewsStore
@@ -71,7 +91,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         sleepController.refresh()
         store.start()
         applyModuleLifecycle(prefs.enabledModules)
-        mcpServer.setEnabled(prefs.mcpEnabled)
+        mcpServer.setEnabled(
+            prefs.mcpEnabled || ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_NONCE"] != nil
+        )
 
         // Re-render the menubar indicator whenever data OR the visible-provider /
         // menubar-style prefs change.
@@ -186,7 +208,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] enabled in
-                self?.mcpServer.setEnabled(enabled)
+                self?.mcpServer.setEnabled(
+                    enabled || ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_NONCE"] != nil
+                )
             }
             .store(in: &cancellables)
         // Update availability re-renders the glyph (adds/removes the badge dot).
@@ -661,6 +685,83 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ]
     }
 
+    private func renderTestSurface(
+        surface: String,
+        selection: String,
+        outputPath: String
+    ) throws -> [String: Any] {
+        guard let artifactRoot = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_ARTIFACTS"] else {
+            throw TestUIAutomationError.disabled
+        }
+        let rootURL = URL(fileURLWithPath: artifactRoot, isDirectory: true).standardizedFileURL
+        let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        guard outputURL.path.hasPrefix(rootURL.path + "/") else {
+            throw TestUIAutomationError.invalidOutputPath
+        }
+
+        let size: CGSize
+        switch surface {
+        case "status":
+            updateStatusItem()
+            hostingView.layoutSubtreeIfNeeded()
+            size = try writePNG(view: hostingView, to: outputURL)
+        case "popover":
+            guard let page = KajiModuleID(rawValue: selection),
+                  prefs.enabledModules.contains(page) else {
+                throw TestUIAutomationError.invalidSelection
+            }
+            popoverNavigation.panel = page
+            if page == .goals { popoverNavigation.goalHorizon = .today }
+            let controller = makePopoverContentController(maxContentHeight: 640)
+            let target = popoverFittingSize(for: controller)
+            controller.view.frame = NSRect(origin: .zero, size: target)
+            controller.view.layoutSubtreeIfNeeded()
+            size = try writePNG(view: controller.view, to: outputURL)
+        case "settings":
+            guard let section = SettingsSection(rawValue: selection) else {
+                throw TestUIAutomationError.invalidSelection
+            }
+            let view = KajiHostingView(rootView: SettingsView(
+                prefs: prefs,
+                sleepController: sleepController,
+                fixedPlanStore: fixedPlanStore,
+                mcpServer: mcpServer,
+                mailBriefStore: mailBriefStore,
+                initialSection: section
+            ))
+            view.configureKajiHost()
+            view.frame = NSRect(x: 0, y: 0, width: 760, height: 560)
+            view.layoutSubtreeIfNeeded()
+            size = try writePNG(view: view, to: outputURL)
+        default:
+            throw TestUIAutomationError.invalidSurface
+        }
+        return [
+            "surface": surface,
+            "selection": selection,
+            "path": outputURL.path,
+            "width": Int(size.width),
+            "height": Int(size.height),
+        ]
+    }
+
+    private func writePNG(view: NSView, to outputURL: URL) throws -> CGSize {
+        guard view.bounds.width > 0, view.bounds.height > 0,
+              let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            throw TestUIAutomationError.renderFailed
+        }
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+        guard let data = bitmap.representation(using: .png, properties: [:]) else {
+            throw TestUIAutomationError.renderFailed
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: outputURL, options: .atomic)
+        return view.bounds.size
+    }
+
     private func jsonValue<T: Encodable>(_ value: T) -> Any {
         guard let data = try? JSONEncoder().encode(value),
               let object = try? JSONSerialization.jsonObject(with: data) else {
@@ -813,4 +914,13 @@ extension AppDelegate: NSPopoverDelegate {
             closeDetailPopover()
         }
     }
+}
+
+private enum TestUIAutomationError: Error {
+    case appUnavailable
+    case disabled
+    case invalidOutputPath
+    case invalidSelection
+    case invalidSurface
+    case renderFailed
 }

--- a/Sources/Kaji/KajiMCPServer.swift
+++ b/Sources/Kaji/KajiMCPServer.swift
@@ -14,12 +14,18 @@ final class KajiMCPServer: ObservableObject {
         case failed(String)
     }
 
+    struct TestAutomation {
+        let nonce: String
+        let render: (_ surface: String, _ selection: String, _ outputPath: String) throws -> [String: Any]
+    }
+
     @Published private(set) var status: Status = .stopped
 
     private weak var goals: DailyGoalStore?
     private let snapshotProvider: () -> [String: Any]
     private let host: NWEndpoint.Host
     private let port: NWEndpoint.Port
+    private let testAutomation: TestAutomation?
     private var listener: NWListener?
     private var connections: [ObjectIdentifier: NWConnection] = [:]
     private let queue = DispatchQueue(label: "dev.kaji.mcp")
@@ -28,10 +34,12 @@ final class KajiMCPServer: ObservableObject {
         goals: DailyGoalStore,
         host: String = "127.0.0.1",
         port: UInt16 = KajiMCPServer.port,
-        snapshotProvider: @escaping () -> [String: Any] = { [:] }
+        snapshotProvider: @escaping () -> [String: Any] = { [:] },
+        testAutomation: TestAutomation? = nil
     ) {
         self.goals = goals
         self.snapshotProvider = snapshotProvider
+        self.testAutomation = testAutomation
         self.host = NWEndpoint.Host(host)
         self.port = NWEndpoint.Port(rawValue: port)!
     }
@@ -150,6 +158,26 @@ final class KajiMCPServer: ObservableObject {
             return rpcError(id: id, code: -32600, message: "Invalid Request")
         }
 
+
+        if method == "kaji/test/render" {
+            guard let testAutomation,
+                  let params = rpc["params"] as? [String: Any],
+                  let nonce = params["nonce"] as? String,
+                  nonce == testAutomation.nonce,
+                  let surface = params["surface"] as? String,
+                  let selection = params["selection"] as? String,
+                  let outputPath = params["outputPath"] as? String else {
+                return rpcError(id: id, code: -32601, message: "Method not found")
+            }
+            do {
+                return rpcResult(
+                    id: id,
+                    result: try testAutomation.render(surface, selection, outputPath)
+                )
+            } catch {
+                return rpcError(id: id, code: -32603, message: error.localizedDescription)
+            }
+        }
         switch method {
         case "notifications/initialized":
             return MCPHTTPResponse.empty(status: "202 Accepted")

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 import KajiCore
 
-private enum SettingsSection: String, CaseIterable, Identifiable {
+enum SettingsSection: String, CaseIterable, Identifiable {
     case general = "General"
     case modules = "Modules"
     case work = "Work"
@@ -53,6 +53,24 @@ struct SettingsView: View {
     @State private var sleepPermission: PermissionState = .notAuthorized
 
     @Environment(\.colorScheme) private var scheme
+
+    init(
+        prefs: Prefs,
+        sleepController: SleepController,
+        fixedPlanStore: FixedPlanStore,
+        mcpServer: KajiMCPServer,
+        mailBriefStore: MailBriefStore,
+        initialSection: SettingsSection = .general,
+        onFixedPlanEditorChange: ((Bool) -> Void)? = nil
+    ) {
+        self.prefs = prefs
+        self.sleepController = sleepController
+        self.fixedPlanStore = fixedPlanStore
+        self.mcpServer = mcpServer
+        self.mailBriefStore = mailBriefStore
+        self.onFixedPlanEditorChange = onFixedPlanEditorChange
+        _selection = State(initialValue: initialSection)
+    }
     private var t: KajiTheme { .resolve(scheme) }
 
     var body: some View {

--- a/Tests/KajiTests/KajiMCPServerTests.swift
+++ b/Tests/KajiTests/KajiMCPServerTests.swift
@@ -110,6 +110,58 @@ final class KajiMCPServerTests: XCTestCase {
         )
     }
 
+    func testUIAutomationIsUnavailableWithoutNonceAndRequiresExactNonce() async throws {
+        let unavailable = try await rpc(
+            method: "kaji/test/render",
+            params: ["nonce": "anything", "surface": "status", "selection": "status", "outputPath": "/tmp/x"]
+        )
+        XCTAssertEqual((unavailable["error"] as? [String: Any])?["code"] as? Int, -32601)
+
+        let automationPort = UInt16.random(in: 40_000...60_000)
+        let automationEndpoint = URL(string: "http://127.0.0.1:\(automationPort)/mcp")!
+        let automationServer = KajiMCPServer(
+            goals: store,
+            port: automationPort,
+            testAutomation: .init(
+                nonce: "exact-test-nonce",
+                render: { surface, selection, outputPath in
+                    ["surface": surface, "selection": selection, "path": outputPath]
+                }
+            )
+        )
+        automationServer.start()
+        defer { automationServer.stop() }
+        for _ in 0..<100 {
+            if automationServer.status == .running { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTAssertEqual(automationServer.status, .running)
+
+        func automationRPC(nonce: String) async throws -> [String: Any] {
+            let payload: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": "automation",
+                "method": "kaji/test/render",
+                "params": [
+                    "nonce": nonce,
+                    "surface": "popover",
+                    "selection": "quota",
+                    "outputPath": "/tmp/render.png",
+                ],
+            ]
+            var request = URLRequest(url: automationEndpoint)
+            request.httpMethod = "POST"
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            let (data, _) = try await URLSession.shared.data(for: request)
+            return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        let rejected = try await automationRPC(nonce: "wrong")
+        XCTAssertEqual((rejected["error"] as? [String: Any])?["code"] as? Int, -32601)
+        let accepted = try await automationRPC(nonce: "exact-test-nonce")
+        XCTAssertEqual((accepted["result"] as? [String: Any])?["selection"] as? String, "quota")
+    }
+
     private func waitUntilRunning() async throws {
         for _ in 0..<100 {
             if server.status == .running { return }

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -7,35 +7,13 @@ HELPER="$ARTIFACTS/ui-smoke-helper"
 APP_EXECUTABLE="$ROOT/dist/Kaji.app/Contents/MacOS/Kaji"
 KAJI_PID=""
 PREFS_DOMAIN="dev.kaji"
-
-# The smoke run also exercises page navigation, which only renders header
-# chevrons when more than one module is enabled (KajiPopoverView.header).
-# We never write to the app's real `defaults` domain to get there — a crash
-# or `kill -9` mid-run would leave the user's real dev.kaji preferences
-# stuck in test state, which is exactly the pollution we're trying to avoid.
-# Instead we pass `-key value` command-line arguments, which macOS populates
-# into `NSArgumentDomain` — the highest-priority, read-only, never-persisted
-# UserDefaults search layer (see `man defaults`/`NSUserDefaults` "argument
-# domain"). Confirmed empirically with a standalone Foundation binary: an
-# arg of `-enabledModules '(quota, work, goals)'` is readable via
-# `UserDefaults.standard.array(forKey:)` with zero effect on the on-disk
-# domain. `language` is pinned to `en` the same way so panelTitle assertions
-# are deterministic regardless of what this machine's Kaji has persisted.
-#
-# mailBrief is included below: MailBriefCredentialStore's keychain probe was
-# fixed to use kSecUseAuthenticationUIFail / LAContext noninteractive reads
-# and to fall back to "not connected" instead of surfacing a system prompt
-# on an ACL mismatch (with a one-shot v3 ACL migration). The
-# `no-system-auth-prompt` assertion in ui-smoke.swift, exercised across the
-# popover's Mail Brief page and the Settings > Mail Brief page, is the
-# regression test for that fix — if it ever starts failing, that is a real
-# regression, not a reason to re-exclude mailBrief from this list.
-SEED_MODULES=(quota work goals aiNews mailBrief)
+SEED_MODULES=(quota work system goals aiNews mailBrief)
 SEED_LANGUAGE=en
-EXPECTED_PAGE_TITLES="Quota|Work / Break|Goals|AI News|Mail Brief"
+PAGE_IDS="quota|work|system|goals|aiNews|mailBrief"
+SETTINGS_SECTIONS="General|Modules|Work|Goals|Quota|AI News|Mail Brief|MCP|Permissions"
+NONCE="$(uuidgen)-$(uuidgen)"
+PORT="$(jot -r 1 40000 59999)"
 
-# Old-style property-list array literal, e.g. "(quota, work, goals, aiNews)" —
-# the format NSArgumentDomain parsing accepts for array-typed arguments.
 seed_modules_plist_array() {
     local joined
     joined=$(printf '%s, ' "${SEED_MODULES[@]}")
@@ -53,74 +31,50 @@ trap cleanup EXIT INT TERM
 mkdir -p "$ARTIFACTS"
 rm -f "$ARTIFACTS"/*.png "$HELPER"
 
-# Proof that this run never persists into the user's real preferences
-# domain. The whole-domain md5 is diagnostic only: DailyGoalStore /
-# FixedPlanStore re-encode their own JSON-blob keys (scheduledGoalsV1,
-# scheduledGoalCompletionV1, ...) via JSONEncoder on every single launch —
-# same content, non-deterministic Codable field order — independent of
-# anything this script does (a plain `open dist/Kaji.app` triggers the same
-# diff). What this script must never move is the two keys it could have
-# seeded via `defaults write`: enabledModules and language. Those are
-# checked for byte-for-byte equality below and fail the run if touched.
 PREFS_MD5_BEFORE=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
 PREFS_ENABLED_BEFORE=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
 PREFS_LANGUAGE_BEFORE=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
 
-
 printf '%s\n' 'UI-SMOKE build: ./scripts/build-app.sh'
 "$ROOT/scripts/build-app.sh"
-
-printf '%s\n' 'UI-SMOKE helper: compiling ad-hoc local verifier'
+printf '%s\n' 'UI-SMOKE helper: compiling nonintrusive local verifier'
 swiftc "$ROOT/scripts/ui-smoke.swift" -o "$HELPER"
 codesign --force --sign - "$HELPER" >/dev/null
 
-# The smoke run owns the only Kaji instance so AX lookup and window ownership
-# cannot accidentally target an installed or previously launched copy.
-pkill -x Kaji 2>/dev/null || true
-for _ in {1..50}; do
-    pgrep -x Kaji >/dev/null 2>&1 || break
-    sleep 0.1
-done
-if pgrep -x Kaji >/dev/null 2>&1; then
-    printf '%s\n' 'UI-SMOKE FAIL: stale Kaji process did not terminate' >&2
-    exit 1
-fi
-
-printf '%s\n' 'UI-SMOKE launch: dist/Kaji.app'
-"$APP_EXECUTABLE" \
-    -enabledModules "$(seed_modules_plist_array)" \
-    -language "$SEED_LANGUAGE" \
+export KAJI_UI_SMOKE_NONCE="$NONCE"
+export KAJI_UI_SMOKE_PORT="$PORT"
+export KAJI_UI_SMOKE_ARTIFACTS="$ARTIFACTS"
+APP_ARGS=(
+    -enabledModules "$(seed_modules_plist_array)"
+    -language "$SEED_LANGUAGE"
+    -mcpEnabled NO
+)
+"$APP_EXECUTABLE" "${APP_ARGS[@]}" \
     >"$ARTIFACTS/kaji.stdout.log" 2>"$ARTIFACTS/kaji.stderr.log" &
 KAJI_PID=$!
 
 if ! kill -0 "$KAJI_PID" 2>/dev/null; then
-    printf 'UI-SMOKE FAIL: Kaji exited during launch; inspect %s\n' "$ARTIFACTS/kaji.stderr.log" >&2
+    printf 'UI-SMOKE FAIL: owned Kaji process exited during launch; inspect %s\n' "$ARTIFACTS/kaji.stderr.log" >&2
     exit 1
 fi
 
-"$HELPER" "$KAJI_PID" "$ARTIFACTS" "$EXPECTED_PAGE_TITLES"
+"$HELPER" "$KAJI_PID" "$ARTIFACTS" "$NONCE" "$PORT" "$PAGE_IDS" "$SETTINGS_SECTIONS" \
+    "$ROOT/scripts/ui-smoke.swift" "$ROOT/scripts/ui-smoke.sh"
 
 PREFS_MD5_AFTER=$(defaults export "$PREFS_DOMAIN" - 2>/dev/null | md5 -q || echo "no-domain")
 PREFS_ENABLED_AFTER=$(defaults read "$PREFS_DOMAIN" enabledModules 2>/dev/null || echo "<missing>")
 PREFS_LANGUAGE_AFTER=$(defaults read "$PREFS_DOMAIN" language 2>/dev/null || echo "<missing>")
 
 if [[ "$PREFS_ENABLED_BEFORE" != "$PREFS_ENABLED_AFTER" || "$PREFS_LANGUAGE_BEFORE" != "$PREFS_LANGUAGE_AFTER" ]]; then
-    printf 'UI-SMOKE FAIL: dev.kaji enabledModules/language were persisted by this run — the NSArgumentDomain seed must never touch disk\n' >&2
-    printf '  enabledModules before: %s\n' "$PREFS_ENABLED_BEFORE" >&2
-    printf '  enabledModules after:  %s\n' "$PREFS_ENABLED_AFTER" >&2
-    printf '  language before: %s\n' "$PREFS_LANGUAGE_BEFORE" >&2
-    printf '  language after:  %s\n' "$PREFS_LANGUAGE_AFTER" >&2
+    printf '%s\n' 'UI-SMOKE FAIL: dev.kaji enabledModules/language changed on disk' >&2
     exit 1
 fi
-printf 'UI-SMOKE: dev.kaji enabledModules and language are byte-for-byte unchanged (enabledModules=%s language=%s)\n' \
+printf 'UI-SMOKE: enabledModules/language unchanged (enabledModules=%s language=%s)\n' \
     "$PREFS_ENABLED_AFTER" "$PREFS_LANGUAGE_AFTER"
-
 if [[ "$PREFS_MD5_BEFORE" != "$PREFS_MD5_AFTER" ]]; then
-    printf 'UI-SMOKE: dev.kaji whole-domain md5 changed (before=%s after=%s) — expected: DailyGoalStore/FixedPlanStore re-encode their own JSON-blob keys with non-deterministic Codable field order on every Kaji launch, independent of this script (a plain `open dist/Kaji.app` reproduces the same diff). Not a regression in this harness; enabledModules/language above are the keys this script could pollute, and they are unchanged.\n' \
+    printf 'UI-SMOKE: whole-domain md5 changed only through existing app-owned serialization (before=%s after=%s)\n' \
         "$PREFS_MD5_BEFORE" "$PREFS_MD5_AFTER"
 else
-    printf 'UI-SMOKE: dev.kaji preferences domain byte-for-byte unchanged (md5 %s)\n' "$PREFS_MD5_AFTER"
+    printf 'UI-SMOKE: preferences domain unchanged (md5 %s)\n' "$PREFS_MD5_AFTER"
 fi
-
-
-printf 'UI-SMOKE PASS: menu-bar popover opened/closed, AX content verified, page navigation verified; artifacts: %s\n' "$ARTIFACTS"
+printf 'UI-SMOKE PASS: input devices/frontmost app untouched; all pages/settings rendered in the owned Kaji process; artifacts: %s\n' "$ARTIFACTS"

--- a/scripts/ui-smoke.swift
+++ b/scripts/ui-smoke.swift
@@ -1,447 +1,167 @@
-import ApplicationServices
+import AppKit
 import CoreGraphics
 import Foundation
 
-struct WindowSnapshot {
-    let id: CGWindowID
-    let bounds: CGRect
+struct SmokeError: Error, CustomStringConvertible {
+    let description: String
 }
 
-enum SmokeError: Error, CustomStringConvertible {
-    case message(String)
+struct DesktopState: Equatable {
+    let mouse: CGPoint
+    let frontmostBundleID: String?
+    let frontmostPID: pid_t?
 
-    var description: String {
-        switch self {
-        case .message(let text): return text
+    static func capture() throws -> DesktopState {
+        guard let event = CGEvent(source: CGEventSource(stateID: .hidSystemState)) else {
+            throw SmokeError(description: "could not read mouse position")
+        }
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        return DesktopState(
+            mouse: event.location,
+            frontmostBundleID: frontmost?.bundleIdentifier,
+            frontmostPID: frontmost?.processIdentifier
+        )
+    }
+}
+
+func rpc(port: UInt16, nonce: String, surface: String, selection: String, outputPath: String) throws -> [String: Any] {
+    let body: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": UUID().uuidString,
+        "method": "kaji/test/render",
+        "params": [
+            "nonce": nonce,
+            "surface": surface,
+            "selection": selection,
+            "outputPath": outputPath,
+        ],
+    ]
+    let bodyData = try JSONSerialization.data(withJSONObject: body)
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/mcp")!)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = bodyData
+    request.timeoutInterval = 10
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Result<[String: Any], Error>?
+    URLSession.shared.dataTask(with: request) { data, response, error in
+        defer { semaphore.signal() }
+        if let error {
+            result = .failure(error)
+            return
+        }
+        guard let http = response as? HTTPURLResponse,
+              http.statusCode == 200,
+              let data,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = object["result"] as? [String: Any] else {
+            let responseBody = data.map { String(decoding: $0, as: UTF8.self) } ?? "<empty>"
+            result = .failure(SmokeError(description: "RPC failed: \(responseBody)"))
+            return
+        }
+        result = .success(payload)
+    }.resume()
+    guard semaphore.wait(timeout: .now() + 12) == .success, let result else {
+        throw SmokeError(description: "RPC timed out for \(surface):\(selection)")
+    }
+    return try result.get()
+}
+
+func waitForServer(port: UInt16, nonce: String, artifactRoot: String) throws {
+    let deadline = Date().addingTimeInterval(10)
+    var lastError: Error?
+    while Date() < deadline {
+        do {
+            _ = try rpc(
+                port: port,
+                nonce: nonce,
+                surface: "status",
+                selection: "status",
+                outputPath: URL(fileURLWithPath: artifactRoot).appendingPathComponent("status.png").path
+            )
+            return
+        } catch {
+            lastError = error
+            Thread.sleep(forTimeInterval: 0.1)
         }
     }
+    throw lastError ?? SmokeError(description: "test UI server did not become ready")
 }
 
-struct AXElementInfo {
-    let role: String
-    let text: String
-    let identifier: String?
-    let bounds: CGRect?
-}
-
-func stringAttribute(_ element: AXUIElement, _ name: CFString) -> String? {
-    guard let raw = attribute(element, name) else { return nil }
-    if CFGetTypeID(raw) == CFStringGetTypeID() {
-        return unsafeBitCast(raw, to: CFString.self) as String
+func assertPNG(_ path: String, label: String) throws {
+    guard let image = NSImage(contentsOfFile: path), image.size.width > 0, image.size.height > 0,
+          let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+          let bytes = attributes[.size] as? NSNumber, bytes.intValue > 256 else {
+        throw SmokeError(description: "ASSERT render-\(label): FAIL missing or blank PNG at \(path)")
     }
-    return nil
+    print("ASSERT render-\(label): PASS \(Int(image.size.width))x\(Int(image.size.height)) \(bytes.intValue) bytes")
 }
 
-/// NSPopover's backing panel is a nonactivating borderless window; for an
-/// `.accessory`-policy (LSUIElement) app like Kaji it is never listed under
-/// the application element's `kAXWindowsAttribute` (confirmed empirically —
-/// that attribute reports 0 windows while the popover is open). The
-/// reliable way in is a system-wide hit-test at a point inside the
-/// CGWindow's bounds, then reading `kAXWindowAttribute` off whatever was
-/// hit to climb to the enclosing window element (role `AXPopover`).
-func findAXWindow(pid: pid_t, matching target: CGRect) -> AXUIElement? {
-    let systemWide = AXUIElementCreateSystemWide()
-    let point = CGPoint(x: target.midX, y: target.midY)
-    var hit: AXUIElement?
-    guard AXUIElementCopyElementAtPosition(systemWide, Float(point.x), Float(point.y), &hit) == .success,
-          let hit else { return nil }
-    var ownerPID: pid_t = 0
-    AXUIElementGetPid(hit, &ownerPID)
-    guard ownerPID == pid else { return nil }
-    if let raw = attribute(hit, kAXWindowAttribute as CFString), CFGetTypeID(raw) == AXUIElementGetTypeID() {
-        return unsafeBitCast(raw, to: AXUIElement.self)
+func assertNoInputAutomation(in paths: [String]) throws {
+    let forbidden = [
+        "CGWarpMouse" + "CursorPosition",
+        "leftMouse" + "Down",
+        "leftMouse" + "Up",
+        "mouse" + "Moved",
+        ".post(" + "tap:",
+        "CGEvent" + "Post",
+        "key" + "Down",
+        "key" + "Up",
+        "perform" + "Click",
+        "osa" + "script",
+        "AXUIElement" + "PerformAction",
+    ]
+    for path in paths {
+        let source = try String(contentsOfFile: path, encoding: .utf8)
+        if let match = forbidden.first(where: source.contains) {
+            throw SmokeError(description: "ASSERT no-input-implementation: FAIL \(path) contains \(match)")
+        }
     }
-    // The hit element itself may already be the window/popover root.
-    if let role = attribute(hit, kAXRoleAttribute as CFString) as? String,
-       role == kAXWindowRole as String || role == "AXPopover" {
-        return hit
-    }
-    return nil
-}
-
-/// Depth-first walk collecting every element's role/text/identifier/bounds.
-/// Depth and node counts are capped so a runaway SwiftUI tree cannot hang
-/// the smoke run.
-func collectAXElements(_ element: AXUIElement, depth: Int = 0, budget: inout Int) -> [AXElementInfo] {
-    guard depth < 40, budget > 0 else { return [] }
-    budget -= 1
-    let role = (attribute(element, kAXRoleAttribute as CFString) as? String)
-        ?? stringAttribute(element, kAXRoleAttribute as CFString)
-        ?? "?"
-    let title = stringAttribute(element, kAXTitleAttribute as CFString) ?? ""
-    let value = stringAttribute(element, kAXValueAttribute as CFString) ?? ""
-    let description = stringAttribute(element, kAXDescriptionAttribute as CFString) ?? ""
-    let text = [title, value, description].first(where: { !$0.isEmpty }) ?? ""
-    let identifier = stringAttribute(element, kAXIdentifierAttribute as CFString)
-    var own = [AXElementInfo(role: role, text: text, identifier: identifier, bounds: bounds(of: element))]
-    for child in children(of: element) {
-        own.append(contentsOf: collectAXElements(child, depth: depth + 1, budget: &budget))
-    }
-    return own
-}
-
-func dumpAXElements(_ elements: [AXElementInfo]) {
-    for info in elements where !info.text.isEmpty || info.role == "AXButton" {
-        let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
-        let idText = info.identifier ?? "-"
-        print("AX-DUMP role=\(info.role) text=\"\(info.text)\" id=\(idText) bounds=\(boundsText)")
-    }
-}
-
-/// macOS surfaces real Keychain/credential prompts as separate on-screen
-/// windows owned by system agent processes, never by the app itself — this
-/// is the acceptance signal for "permission asks once, never again":
-/// scan every on-screen window (not just Kaji's) for one owned by any of
-/// these processes. Overridable via KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS
-/// (comma-separated) purely so this script can prove the assertion truly
-/// fires (see the failure-injection run in the task write-up); the real
-/// default set is fixed.
-func systemAuthPromptOwnerNames() -> Set<String> {
-    if let override = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_AUTH_PROMPT_OWNERS"] {
-        return Set(override.split(separator: ",").map(String.init))
-    }
-    return ["SecurityAgent", "loginwindow", "coreauthd", "UserNotificationCenter"]
-}
-
-struct SystemAuthPromptWindow: CustomStringConvertible {
-    let ownerName: String
-    let ownerPID: pid_t
-    let title: String
-    var description: String { "owner=\(ownerName) pid=\(ownerPID) title=\"\(title)\"" }
-}
-
-func systemAuthPromptWindows() -> [SystemAuthPromptWindow] {
-    let owners = systemAuthPromptOwnerNames()
-    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
-            as? [[String: Any]] else { return [] }
-    return raw.compactMap { info in
-        guard let ownerName = info[kCGWindowOwnerName as String] as? String, owners.contains(ownerName),
-              let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value else { return nil }
-        let title = info[kCGWindowName as String] as? String ?? ""
-        return SystemAuthPromptWindow(ownerName: ownerName, ownerPID: ownerPID, title: title)
-    }
-}
-
-/// Call after every action that could plausibly trigger a Keychain/credential
-/// prompt. Throws (and screenshots) the instant one is seen — checked at
-/// every popover-page transition, every Settings-page transition, and
-/// before/after opening Settings, so the whole click-through is covered.
-var authPromptCheckCount = 0
-func checkNoSystemAuthPrompt(_ context: String, artifacts: String) throws {
-    authPromptCheckCount += 1
-    let found = systemAuthPromptWindows()
-    guard found.isEmpty else {
-        capture("\(artifacts)/system-auth-prompt-failure.png")
-        throw SmokeError.message("ASSERT no-system-auth-prompt: FAIL a system authorization window appeared during \"\(context)\": \(found.map(\.description).joined(separator: "; "))")
-    }
-}
-
-/// Header chevrons are 30x30 icon-only buttons (see KajiPopoverView.arrow);
-/// distinguish them from the (30x28) footer icon buttons by requiring the
-/// button sit within the popover's top ~44pt, where the header row lives.
-func pageArrowButtons(in elements: [AXElementInfo], windowTop: CGFloat) -> [AXElementInfo] {
-    elements.filter { info in
-        guard info.role == "AXButton", let rect = info.bounds else { return false }
-        return rect.width >= 28 && rect.width <= 32 && rect.height >= 28 && rect.height <= 32
-            && rect.minY - windowTop < 44
-    }.sorted { ($0.bounds?.minX ?? 0) < ($1.bounds?.minX ?? 0) }
-}
-
-func attribute(_ element: AXUIElement, _ name: CFString) -> CFTypeRef? {
-    var value: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, name, &value) == .success else { return nil }
-    return value
-}
-
-func children(of element: AXUIElement) -> [AXUIElement] {
-    guard let raw = attribute(element, kAXChildrenAttribute as CFString),
-          CFGetTypeID(raw) == CFArrayGetTypeID() else { return [] }
-    let array = unsafeBitCast(raw, to: CFArray.self)
-    return (0..<CFArrayGetCount(array)).map {
-        unsafeBitCast(CFArrayGetValueAtIndex(array, $0), to: AXUIElement.self)
-    }
-}
-
-func bounds(of element: AXUIElement) -> CGRect? {
-    guard let rawPosition = attribute(element, kAXPositionAttribute as CFString),
-          CFGetTypeID(rawPosition) == AXValueGetTypeID(),
-          let rawSize = attribute(element, kAXSizeAttribute as CFString),
-          CFGetTypeID(rawSize) == AXValueGetTypeID() else { return nil }
-    let positionValue = unsafeBitCast(rawPosition, to: AXValue.self)
-    let sizeValue = unsafeBitCast(rawSize, to: AXValue.self)
-    var position = CGPoint.zero
-    var size = CGSize.zero
-    guard AXValueGetValue(positionValue, .cgPoint, &position),
-          AXValueGetValue(sizeValue, .cgSize, &size),
-          size.width > 0, size.height > 0 else { return nil }
-    return CGRect(origin: position, size: size)
-}
-
-func isMainMenuBarBounds(_ rect: CGRect) -> Bool {
-    let mainFrame = CGDisplayBounds(CGMainDisplayID())
-    return rect.width > 0 && rect.height > 0 &&
-        rect.minX >= mainFrame.minX && rect.maxX <= mainFrame.maxX &&
-        rect.minY >= mainFrame.minY && rect.minY <= mainFrame.minY + 40
-}
-
-func statusItemBounds(pid: pid_t) -> CGRect? {
-    let application = AXUIElementCreateApplication(pid)
-    guard let rawMenuBar = attribute(application, kAXExtrasMenuBarAttribute as CFString)
-            ?? attribute(application, kAXMenuBarAttribute as CFString),
-          CFGetTypeID(rawMenuBar) == AXUIElementGetTypeID() else {
-        return nil
-    }
-    let menuBar = unsafeBitCast(rawMenuBar, to: AXUIElement.self)
-    for child in children(of: menuBar) {
-        guard let role = attribute(child, kAXRoleAttribute as CFString) as? String,
-              role == kAXMenuBarItemRole as String else { continue }
-        return bounds(of: child)
-    }
-    return nil
-}
-
-func windows(pid: pid_t) -> [WindowSnapshot] {
-    guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
-            as? [[String: Any]] else { return [] }
-    return raw.compactMap { info in
-        guard let ownerPID = info[kCGWindowOwnerPID as String] as? NSNumber,
-              ownerPID.int32Value == pid,
-              let number = info[kCGWindowNumber as String] as? NSNumber,
-              let boundsObject = info[kCGWindowBounds as String] as? NSDictionary else { return nil }
-        let boundsDictionary = unsafeBitCast(boundsObject, to: CFDictionary.self)
-        guard let bounds = CGRect(dictionaryRepresentation: boundsDictionary) else { return nil }
-        return WindowSnapshot(id: CGWindowID(number.uint32Value), bounds: bounds)
-    }
-}
-
-func popoverWindow(in snapshots: [WindowSnapshot], excluding ids: Set<CGWindowID> = []) -> WindowSnapshot? {
-    snapshots.first {
-        !ids.contains($0.id) &&
-        $0.bounds.width >= 180 && $0.bounds.width <= 700 &&
-        $0.bounds.height >= 100 && $0.bounds.height <= 1_200
-    }
-}
-
-func wait<T>(timeout: TimeInterval, interval: TimeInterval = 0.1, for value: () -> T?) -> T? {
-    let deadline = Date().addingTimeInterval(timeout)
-    repeat {
-        if let result = value() { return result }
-        Thread.sleep(forTimeInterval: interval)
-    } while Date() < deadline
-    return nil
-}
-
-func click(_ point: CGPoint) throws {
-    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
-                             mouseCursorPosition: point, mouseButton: .left),
-          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
-                           mouseCursorPosition: point, mouseButton: .left) else {
-        throw SmokeError.message("could not create CGEvent mouse events")
-    }
-    down.post(tap: .cghidEventTap)
-    Thread.sleep(forTimeInterval: 0.08)
-    up.post(tap: .cghidEventTap)
-}
-
-func capture(_ path: String) {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-    process.arguments = ["-x", path]
-    try? process.run()
-    process.waitUntilExit()
+    print("ASSERT no-input-implementation: PASS no posting, warp, keyboard, AppleScript, AX action, or AppKit click APIs")
 }
 
 func run() throws {
-    guard CommandLine.arguments.count == 4, let pid = pid_t(CommandLine.arguments[1]) else {
-        throw SmokeError.message("usage: ui-smoke.swift <pid> <artifact-directory> <expected-page-titles-pipe-separated>")
+    guard CommandLine.arguments.count == 9,
+          let pid = pid_t(CommandLine.arguments[1]),
+          let port = UInt16(CommandLine.arguments[4]) else {
+        throw SmokeError(description: "usage: ui-smoke-helper PID ARTIFACTS NONCE PORT PAGE_IDS SETTINGS_SECTIONS SWIFT_SOURCE SHELL_SOURCE")
     }
     let artifacts = CommandLine.arguments[2]
-    let expectedPageTitles = CommandLine.arguments[3].split(separator: "|").map(String.init)
+    let nonce = CommandLine.arguments[3]
+    let pageIDs = CommandLine.arguments[5].split(separator: "|").map(String.init)
+    let settingsSections = CommandLine.arguments[6].split(separator: "|").map(String.init)
+    let implementationPaths = [CommandLine.arguments[7], CommandLine.arguments[8]]
 
-    guard AXIsProcessTrusted() else {
-        throw SmokeError.message("Accessibility permission is missing. Enable System Settings > Privacy & Security > Accessibility for your terminal (or the agent host running this script), then rerun ./scripts/ui-smoke.sh")
+    guard kill(pid, 0) == 0 else { throw SmokeError(description: "Kaji test process is not running") }
+    try assertNoInputAutomation(in: implementationPaths)
+    let before = try DesktopState.capture()
+    try waitForServer(port: port, nonce: nonce, artifactRoot: artifacts)
+    try assertPNG(URL(fileURLWithPath: artifacts).appendingPathComponent("status.png").path, label: "status")
+
+    for page in pageIDs {
+        let path = URL(fileURLWithPath: artifacts).appendingPathComponent("popover-\(page).png").path
+        _ = try rpc(port: port, nonce: nonce, surface: "popover", selection: page, outputPath: path)
+        try assertPNG(path, label: "popover-\(page)")
+    }
+    for section in settingsSections {
+        let safeName = section.replacingOccurrences(of: " ", with: "-").lowercased()
+        let path = URL(fileURLWithPath: artifacts).appendingPathComponent("settings-\(safeName).png").path
+        _ = try rpc(port: port, nonce: nonce, surface: "settings", selection: section, outputPath: path)
+        try assertPNG(path, label: "settings-\(safeName)")
     }
 
-    let mainFrame = CGDisplayBounds(CGMainDisplayID())
-    let mainCenter = CGPoint(x: mainFrame.midX, y: mainFrame.midY)
-    CGWarpMouseCursorPosition(mainCenter)
-    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
-            mouseCursorPosition: mainCenter, mouseButton: .left)?.post(tap: .cghidEventTap)
-    Thread.sleep(forTimeInterval: 0.5)
-
-    guard let initialBounds = wait(timeout: 10, for: { () -> CGRect? in
-        guard let candidate = statusItemBounds(pid: pid), isMainMenuBarBounds(candidate) else { return nil }
-        return candidate
-    }) else {
-        throw SmokeError.message("Kaji status item did not expose stable AX bounds on the main menu bar within 10 seconds")
+    let after = try DesktopState.capture()
+    guard before.mouse == after.mouse else {
+        throw SmokeError(description: "ASSERT mouse-position: FAIL \(before.mouse) -> \(after.mouse)")
     }
-    print("ASSERT status-item: PASS bounds=\(Int(initialBounds.minX)),\(Int(initialBounds.minY)) \(Int(initialBounds.width))x\(Int(initialBounds.height))")
-    Thread.sleep(forTimeInterval: 0.3)
-
-    let baselineIDs = Set(windows(pid: pid).map(\.id))
-    let openPoint = CGPoint(x: initialBounds.minX + min(12, initialBounds.width / 2), y: initialBounds.midY)
-    if ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_SKIP_CLICK"] == nil {
-        try click(openPoint)
+    print("ASSERT mouse-position: PASS unchanged at \(before.mouse)")
+    guard before.frontmostBundleID == after.frontmostBundleID,
+          before.frontmostPID == after.frontmostPID else {
+        throw SmokeError(description: "ASSERT frontmost-application: FAIL \(String(describing: before.frontmostBundleID))/\(String(describing: before.frontmostPID)) -> \(String(describing: after.frontmostBundleID))/\(String(describing: after.frontmostPID))")
     }
-
-    guard let opened = wait(timeout: 3, for: {
-        popoverWindow(in: windows(pid: pid), excluding: baselineIDs)
-    }) else {
-        capture("\(artifacts)/open-failure.png")
-        throw SmokeError.message("ASSERT click-opens-popover: FAIL no popover-sized Kaji window appeared within 3 seconds")
-    }
-    capture("\(artifacts)/open.png")
-    print("ASSERT click-opens-popover: PASS window=\(opened.id) size=\(Int(opened.bounds.width))x\(Int(opened.bounds.height))")
-    try checkNoSystemAuthPrompt("popover opened", artifacts: artifacts)
-
-    // Re-hit-test on every read instead of holding one AXUIElement handle:
-    // resizing the popover for a different page can tear down and rebuild
-    // its AX backing objects, which would make a cached handle go stale.
-    func popoverElements() throws -> [AXElementInfo] {
-        guard let currentWindow = windows(pid: pid).first(where: { $0.id == opened.id })
-                ?? popoverWindow(in: windows(pid: pid)),
-              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
-            throw SmokeError.message("ASSERT ax-popover-tree: FAIL could not locate the popover's AXUIElement window via system-wide hit-test")
-        }
-        var budget = 4000
-        return collectAXElements(element, budget: &budget)
-    }
-
-    var elements = try popoverElements()
-    print("ASSERT ax-popover-tree: PASS discovered \(elements.count) AX nodes")
-    dumpAXElements(elements)
-
-    let expectedQuotaTitle = ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_EXPECT_QUOTA_TITLE"] ?? "Quota"
-    guard elements.contains(where: { $0.role == "AXStaticText" && $0.text == expectedQuotaTitle }) else {
-        capture("\(artifacts)/ax-quota-page-failure.png")
-        let observedTexts = elements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text)
-        throw SmokeError.message("ASSERT ax-quota-page: FAIL expected an AXStaticText titled \"\(expectedQuotaTitle)\"; observed static text: \(observedTexts)")
-    }
-    print("ASSERT ax-quota-page: PASS found AXStaticText \"\(expectedQuotaTitle)\"")
-
-    if expectedPageTitles.count > 1 {
-        let windowTop = opened.bounds.minY
-        var sequence = [expectedPageTitles[0]]
-        for step in 0..<expectedPageTitles.count {
-            elements = try popoverElements()
-            let arrows = pageArrowButtons(in: elements, windowTop: windowTop)
-            guard arrows.count == 2, let nextArrow = arrows.last, let nextBounds = nextArrow.bounds else {
-                capture("\(artifacts)/ax-page-nav-failure.png")
-                let candidateButtons = elements.filter { $0.role == "AXButton" }
-                throw SmokeError.message("""
-                    ASSERT ax-page-nav: FAIL expected exactly 2 header chevron buttons \
-                    (30x30 icon-only AXButton within the popover's top 44pt); found \(arrows.count). \
-                    All AXButton nodes seen: \(candidateButtons). \
-                    The chevrons carry no AXTitle/AXDescription/AXIdentifier, so if this heuristic \
-                    ever stops matching, the fix is accessibility identifiers in Sources/Kaji/KajiPopoverView.swift: \
-                    add .accessibilityIdentifier("kaji.popover.page.prev") / ("kaji.popover.page.next") to the \
-                    two Button closures built by `arrow(_:action:)` (used for chevron.left / chevron.right in `header`), \
-                    plus .accessibilityIdentifier("kaji.popover.title") on the `Text(panelTitle)` header line, and \
-                    root-level identifiers ("kaji.popover.panel.quota" / ".work" / ".system" / ".goals" / ".aiNews" / \
-                    ".mailBrief") on each case of `panelBody` for reliable per-page content assertions.
-                    """)
-            }
-            let center = CGPoint(x: nextBounds.midX, y: nextBounds.midY)
-            try click(center)
-            let expected = expectedPageTitles[(step + 1) % expectedPageTitles.count]
-            guard wait(timeout: 2, for: { () -> Bool? in
-                (try? popoverElements())?.contains(where: { $0.role == "AXStaticText" && $0.text == expected }) == true ? true : nil
-            }) != nil else {
-                capture("\(artifacts)/ax-page-nav-failure.png")
-                let observedTexts = (try? popoverElements())?.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text) ?? []
-                throw SmokeError.message("ASSERT ax-page-nav: FAIL clicking the next-page chevron did not surface header title \"\(expected)\"; observed static text: \(observedTexts)")
-            }
-            sequence.append(expected)
-            try checkNoSystemAuthPrompt("popover page \(expected)", artifacts: artifacts)
-        }
-        print("ASSERT ax-page-nav: PASS clicked through pages in order \(sequence.joined(separator: " -> "))")
-    } else {
-        print("ASSERT ax-page-nav: SKIP only \(expectedPageTitles.count) page(s) enabled; header chevrons are hidden (pages.count > 1 gate in KajiPopoverView.header)")
-    }
-
-    // Settings walk: click gearshape in the popover footer, then click every
-    // sidebar section and assert the visible content actually changes.
-    // Mail Brief is the highest-risk page for this run — it's the module
-    // whose credential lookup used to pop a live Keychain prompt.
-    //
-    // Re-fetch elements: the page-nav loop's last read is one click stale
-    // (captured before the click back to the wrap-around page), and footer
-    // buttons shift vertically with popover height, so a stale bounds would
-    // miss the real button.
-    elements = try popoverElements()
-    let settingsButton = elements.first { $0.role == "AXButton" && $0.identifier == "gearshape" }
-    guard let settingsButton, let settingsButtonBounds = settingsButton.bounds else {
-        capture("\(artifacts)/settings-open-failure.png")
-        throw SmokeError.message("ASSERT settings-opens: FAIL no AXButton with identifier \"gearshape\" found in the popover footer; AXButtons seen: \(elements.filter { $0.role == "AXButton" })")
-    }
-    let settingsBaselineIDs = Set(windows(pid: pid).map(\.id))
-    try click(CGPoint(x: settingsButtonBounds.midX, y: settingsButtonBounds.midY))
-
-    guard let settingsWindow = wait(timeout: 3, for: { () -> WindowSnapshot? in
-        windows(pid: pid).first { !settingsBaselineIDs.contains($0.id) && $0.bounds.width >= 500 && $0.bounds.height >= 300 }
-    }) else {
-        capture("\(artifacts)/settings-open-failure.png")
-        throw SmokeError.message("ASSERT settings-opens: FAIL no Settings-sized (>=500x300) Kaji window appeared within 3 seconds of clicking gearshape")
-    }
-    print("ASSERT settings-opens: PASS window=\(settingsWindow.id) size=\(Int(settingsWindow.bounds.width))x\(Int(settingsWindow.bounds.height))")
-    try checkNoSystemAuthPrompt("settings opened", artifacts: artifacts)
-
-    func settingsElements() throws -> [AXElementInfo] {
-        guard let currentWindow = windows(pid: pid).first(where: { $0.id == settingsWindow.id }),
-              let element = findAXWindow(pid: pid, matching: currentWindow.bounds) else {
-            throw SmokeError.message("ASSERT settings-nav: FAIL could not locate the Settings AXUIElement window via system-wide hit-test")
-        }
-        var budget = 4000
-        return collectAXElements(element, budget: &budget)
-    }
-
-    let settingsSections = ["General", "Modules", "Work", "Goals", "Quota", "AI News", "Mail Brief", "MCP"]
-    var previousSignature: Set<String>? = nil
-    for (index, section) in settingsSections.enumerated() {
-        if index > 0 {
-            let currentElements = try settingsElements()
-            guard let row = currentElements.first(where: { $0.role == "AXStaticText" && $0.text == section }),
-                  let rowBounds = row.bounds else {
-                capture("\(artifacts)/settings-nav-failure.png")
-                throw SmokeError.message("ASSERT settings-nav: FAIL no sidebar row titled \"\(section)\" found in the Settings AX tree; static text seen: \(currentElements.filter { $0.role == "AXStaticText" }.map(\.text))")
-            }
-            try click(CGPoint(x: rowBounds.midX, y: rowBounds.midY))
-        }
-        Thread.sleep(forTimeInterval: 1.0)
-        let pageElements = try settingsElements()
-        let signature = Set(pageElements.filter { $0.role == "AXStaticText" && !$0.text.isEmpty }.map(\.text))
-        print("AX-DUMP [Settings:\(section)] discovered \(pageElements.count) nodes")
-        for info in pageElements where !info.text.isEmpty {
-            let boundsText = info.bounds.map { "\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))" } ?? "-"
-            print("AX-DUMP [Settings:\(section)] role=\(info.role) text=\"\(info.text)\" bounds=\(boundsText)")
-        }
-        try checkNoSystemAuthPrompt("settings section \(section)", artifacts: artifacts)
-        if let previousSignature, index > 0 {
-            guard signature != previousSignature else {
-                capture("\(artifacts)/settings-nav-failure.png")
-                throw SmokeError.message("ASSERT settings-nav: FAIL clicking sidebar row \"\(section)\" did not change the visible content; static text stayed: \(signature.sorted())")
-            }
-        }
-        previousSignature = signature
-    }
-    print("ASSERT settings-nav: PASS walked \(settingsSections.count) sidebar sections, content changed on every click")
-    print("ASSERT no-system-auth-prompt: PASS checked \(authPromptCheckCount) times, no system authorization window ever appeared")
-
-
-    guard let refreshedBounds = statusItemBounds(pid: pid) else {
-        throw SmokeError.message("ASSERT click-closes-popover: FAIL could not refresh status-item AX bounds")
-    }
-    let closePoint = CGPoint(x: refreshedBounds.minX + min(12, refreshedBounds.width / 2), y: refreshedBounds.midY)
-    try click(closePoint)
-
-    guard wait(timeout: 3, for: {
-        windows(pid: pid).contains(where: { $0.id == opened.id }) ? nil : true
-    }) != nil else {
-        capture("\(artifacts)/close-failure.png")
-        throw SmokeError.message("ASSERT click-closes-popover: FAIL popover window \(opened.id) remained on screen after second click")
-    }
-    capture("\(artifacts)/closed.png")
-    print("ASSERT click-closes-popover: PASS window=\(opened.id) disappeared")
+    print("ASSERT frontmost-application: PASS unchanged \(before.frontmostBundleID ?? "<none>") pid=\(before.frontmostPID.map(String.init) ?? "<none>")")
+    print("ASSERT keyboard-events: PASS implementation contains no keyboard event API")
 }
 
 do {


### PR DESCRIPTION
## Blocked

**Blocked: targets the pre-#39 MCP server and will be superseded after the control-server stack lands.**

Do not merge this PR. It is retained as evidence until the control-server stack lands.

## Summary
- replace pointer-driving smoke automation with an authenticated, test-only render RPC
- render the status item, every current popover page, and every Settings section without activating Kaji or posting input events
- assert mouse position and frontmost application are unchanged, while keeping production RPC discovery unchanged

## Verification
- `./scripts/ui-smoke.sh` — PASS: 1 status item, 6 current popover pages, and 9 Settings sections rendered; mouse position and frontmost app unchanged
- `swift build && swift test` — PASS: 162 tests, 0 failures

## Scope note
This branch is based on `main`, where Background Tasks is not yet present. The smoke enumerates the shared page ID list, so the Background Tasks page is picked up automatically after that feature lands.