### PR TITLE
Harden Prevent Sleep helper flow

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -270,7 +270,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // from hitting the network on every menubar interaction.
         updateChecker.checkIfDue()
         dailyGoals.refreshPeriodBoundaries()
-        sleepController.resumePendingApprovalIfAuthorized()
         if prefs.isModuleEnabled(.aiNews) {
             aiNewsStore.setEnabled(true, refreshHours: prefs.aiNewsRefreshHours)
         }

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -43,6 +43,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         selection: selection,
                         outputPath: outputPath
                     )
+                },
+                perform: { [weak self] action, target in
+                    guard let self else { throw TestUIAutomationError.appUnavailable }
+                    return try self.performTestAction(action, target: target)
                 }
             )
         }
@@ -266,6 +270,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // from hitting the network on every menubar interaction.
         updateChecker.checkIfDue()
         dailyGoals.refreshPeriodBoundaries()
+        sleepController.resumePendingApprovalIfAuthorized()
         if prefs.isModuleEnabled(.aiNews) {
             aiNewsStore.setEnabled(true, refreshHours: prefs.aiNewsRefreshHours)
         }
@@ -635,6 +640,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 "mailBriefConcurrency": prefs.mailBriefConcurrency,
                 "mailBriefModel": prefs.mailBriefModel.rawValue,
             ],
+            "sleep": [
+                "enabled": sleepController.isEnabled,
+                "busy": sleepController.isBusy,
+                "targetEnabled": jsonOptional(sleepController.targetEnabled),
+                "guidance": jsonOptional(sleepController.approvalFlow.guidance.map(String.init(describing:))),
+                "guidancePresented": sleepController.approvalFlow.isGuidancePresented,
+                "lastError": jsonOptional(sleepController.lastError),
+            ],
             "quota": [
                 "providers": store.providers.map {
                     [
@@ -715,6 +728,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "failed": jobs.count { $0.state == .failed },
             "idle": jobs.count { $0.state == .idle },
             "unloaded": jobs.count { $0.state == .unloaded },
+        ]
+    }
+
+    private func performTestAction(_ action: String, target: Bool?) throws -> [String: Any] {
+        guard ProcessInfo.processInfo.environment["KAJI_UI_SMOKE_ARTIFACTS"] != nil else {
+            throw TestUIAutomationError.disabled
+        }
+        switch action {
+        case "set-prevent-sleep":
+            guard let target else { throw TestUIAutomationError.invalidAction }
+            sleepController.setEnabled(target)
+        case "perform-sleep-guidance":
+            sleepController.performGuidanceAction()
+        case "cancel-sleep-guidance":
+            sleepController.cancelApprovalRequest()
+        default:
+            throw TestUIAutomationError.invalidAction
+        }
+        return [
+            "action": action,
+            "accepted": true,
         ]
     }
 
@@ -970,6 +1004,7 @@ private enum TestUIAutomationError: Error {
     case appUnavailable
     case disabled
     case invalidOutputPath
+    case invalidAction
     case invalidSelection
     case invalidSurface
     case renderFailed

--- a/Sources/Kaji/KajiControlServer.swift
+++ b/Sources/Kaji/KajiControlServer.swift
@@ -10,6 +10,19 @@ final class KajiControlServer {
     struct TestAutomation {
         let nonce: String
         let render: (_ surface: String, _ selection: String, _ outputPath: String) throws -> [String: Any]
+        let perform: (_ action: String, _ target: Bool?) throws -> [String: Any]
+
+        init(
+            nonce: String,
+            render: @escaping (_ surface: String, _ selection: String, _ outputPath: String) throws -> [String: Any],
+            perform: @escaping (_ action: String, _ target: Bool?) throws -> [String: Any] = { _, _ in
+                throw ControlError.invalid("Test action is unavailable")
+            }
+        ) {
+            self.nonce = nonce
+            self.render = render
+            self.perform = perform
+        }
     }
 
     private weak var goals: DailyGoalStore?
@@ -105,18 +118,25 @@ final class KajiControlServer {
         do {
             let components = request.path.split(separator: "/").map(String.init)
             let payload: Any
-            if request.method == "POST", components == ["v1", "test", "render"] {
+            if request.method == "POST",
+               components == ["v1", "test", "render"] || components == ["v1", "test", "action"] {
                 guard let testAutomation else {
                     return .json(status: "404 Not Found", object: ["error": "Unknown local control route"])
                 }
                 let body = try request.jsonBody()
-                guard body["nonce"] as? String == testAutomation.nonce,
-                      let surface = body["surface"] as? String,
-                      let selection = body["selection"] as? String,
-                      let outputPath = body["outputPath"] as? String else {
+                guard body["nonce"] as? String == testAutomation.nonce else {
                     return .json(status: "404 Not Found", object: ["error": "Unknown local control route"])
                 }
-                payload = try testAutomation.render(surface, selection, outputPath)
+                if components.last == "render",
+                   let surface = body["surface"] as? String,
+                   let selection = body["selection"] as? String,
+                   let outputPath = body["outputPath"] as? String {
+                    payload = try testAutomation.render(surface, selection, outputPath)
+                } else if components.last == "action", let action = body["action"] as? String {
+                    payload = try testAutomation.perform(action, body["target"] as? Bool)
+                } else {
+                    return .json(status: "404 Not Found", object: ["error": "Unknown local control route"])
+                }
             } else if request.method == "GET", components == ["v1", "state"] {
                 payload = snapshotProvider()
             } else if request.method == "GET", components == ["v1", "goals"] {

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -2000,7 +2000,12 @@ struct KajiPopoverView: View {
     private var controlsFooter: some View {
         HStack(spacing: 7) {
             Spacer()
-            iconButton("gearshape", title: L10n.t(.settings, prefs.language), action: controls.onOpenSettings)
+            iconButton(
+                "gearshape",
+                title: L10n.t(.settings, prefs.language),
+                accessibilityIdentifier: "kaji.settings.open",
+                action: controls.onOpenSettings
+            )
             iconButton("power", title: L10n.t(.quit, prefs.language), action: controls.onQuit)
         }
         .frame(height: 32)
@@ -2067,6 +2072,7 @@ struct KajiPopoverView: View {
 
     private func iconButton(_ systemName: String,
                             title: String,
+                            accessibilityIdentifier: String? = nil,
                             action: @escaping () -> Void,
                             filled: Bool = false) -> some View {
         Button(action: action) {
@@ -2084,6 +2090,7 @@ struct KajiPopoverView: View {
         .buttonStyle(.plain)
         .help(title)
         .accessibilityLabel(Text(title))
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 
     private func miniButton(_ systemName: String, action: @escaping () -> Void) -> some View {

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -114,24 +114,15 @@ struct SettingsView: View {
     }
 
     private var sleepGuidanceTitle: String {
-        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
-            ? .sleepRepairTitle
-            : .sleepApprovalTitle
-        return L10n.t(key, prefs.language)
+        L10n.t(.sleepRepairTitle, prefs.language)
     }
 
     private var sleepGuidanceMessage: String {
-        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
-            ? .sleepRepairMessage
-            : .sleepApprovalMessage
-        return L10n.t(key, prefs.language)
+        L10n.t(.sleepRepairMessage, prefs.language)
     }
 
     private var sleepGuidanceActionTitle: String {
-        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
-            ? .repairHelper
-            : .openSystemSettings
-        return L10n.t(key, prefs.language)
+        L10n.t(.repairHelper, prefs.language)
     }
 
     private var mainSettings: some View {
@@ -190,10 +181,10 @@ struct SettingsView: View {
                             sleepController.toggle()
                         }
                         .disabled(sleepController.isBusy)
-                        .help("保持 Mac 唤醒。首次开启可能需要在系统设置中批准 Kaji。")
+                        .help(L10n.t(.sleepPermissionWhy, prefs.language))
                     }
                     if sleepController.lastError != nil {
-                        Text("防休眠未能开启。请检查系统设置 → 登录项与扩展。")
+                        Text(L10n.t(.sleepRepairMessage, prefs.language))
                             .font(.system(size: 10.5, weight: .semibold, design: .rounded))
                             .foregroundColor(t.amber)
                     }

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -76,6 +76,7 @@ struct SettingsView: View {
                 Label(section == .permissions ? L10n.t(.permissions, prefs.language) : section.rawValue,
                       systemImage: section.systemImage)
                     .tag(section)
+                    .accessibilityIdentifier("kaji.settings.section.\(section.rawValue)")
             }
             .listStyle(.sidebar)
             .frame(minWidth: 170, idealWidth: 190, maxWidth: 210)
@@ -88,6 +89,49 @@ struct SettingsView: View {
         }
         .background(t.bg)
         .frame(minWidth: 640, minHeight: 460)
+        .alert(
+            sleepGuidanceTitle,
+            isPresented: Binding(
+                get: { sleepController.approvalFlow.isGuidancePresented },
+                set: { presented in
+                    if !presented {
+                        sleepController.dismissApprovalGuidance()
+                    }
+                }
+            )
+        ) {
+            Button(sleepGuidanceActionTitle) {
+                sleepController.performGuidanceAction()
+            }
+            .accessibilityIdentifier("kaji.sleep-helper.guidance-action")
+            Button(L10n.t(.cancel, prefs.language), role: .cancel) {
+                sleepController.cancelApprovalRequest()
+            }
+            .accessibilityIdentifier("kaji.sleep-helper.cancel")
+        } message: {
+            Text(sleepGuidanceMessage)
+        }
+    }
+
+    private var sleepGuidanceTitle: String {
+        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
+            ? .sleepRepairTitle
+            : .sleepApprovalTitle
+        return L10n.t(key, prefs.language)
+    }
+
+    private var sleepGuidanceMessage: String {
+        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
+            ? .sleepRepairMessage
+            : .sleepApprovalMessage
+        return L10n.t(key, prefs.language)
+    }
+
+    private var sleepGuidanceActionTitle: String {
+        let key: L10n.K = sleepController.approvalFlow.guidance == .repair
+            ? .repairHelper
+            : .openSystemSettings
+        return L10n.t(key, prefs.language)
     }
 
     private var mainSettings: some View {
@@ -138,7 +182,11 @@ struct SettingsView: View {
                         }
                     }
                     settingRow(title: L10n.t(.keepAwake, prefs.language)) {
-                        segment(preventSleepTitle, on: sleepController.isEnabled) {
+                        segment(
+                            preventSleepTitle,
+                            on: sleepController.isEnabled,
+                            accessibilityIdentifier: "kaji.prevent-sleep.toggle"
+                        ) {
                             sleepController.toggle()
                         }
                         .disabled(sleepController.isBusy)
@@ -730,7 +778,12 @@ struct SettingsView: View {
         .accessibilityLabel(Text(title))
     }
 
-    private func segment(_ title: String, on: Bool, action: @escaping () -> Void) -> some View {
+    private func segment(
+        _ title: String,
+        on: Bool,
+        accessibilityIdentifier: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
@@ -746,5 +799,6 @@ struct SettingsView: View {
                 )
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 }

--- a/Sources/Kaji/SleepController.swift
+++ b/Sources/Kaji/SleepController.swift
@@ -3,12 +3,49 @@ import KajiCore
 import KajiSleepSupport
 import ServiceManagement
 
+enum SleepGuidanceKind: Equatable {
+    case approval, repair
+}
+
+struct SleepApprovalFlow: Equatable {
+    private(set) var pendingTarget: Bool?
+    private(set) var guidance: SleepGuidanceKind?
+
+    var isGuidancePresented: Bool { guidance != nil }
+
+    mutating func requireApproval(for target: Bool) {
+        pendingTarget = target
+        guidance = .approval
+    }
+
+    mutating func requireRepair(for target: Bool) {
+        pendingTarget = target
+        guidance = .repair
+    }
+
+    mutating func dismissGuidance() {
+        guidance = nil
+    }
+
+    mutating func cancel() {
+        pendingTarget = nil
+        guidance = nil
+    }
+
+    mutating func consumePendingTarget(ifAuthorized authorized: Bool) -> Bool? {
+        guard authorized, let pendingTarget else { return nil }
+        cancel()
+        return pendingTarget
+    }
+}
+
 @MainActor
 final class SleepController: ObservableObject {
     @Published private(set) var isEnabled = false
     @Published private(set) var isBusy = false
     @Published private(set) var targetEnabled: Bool?
     @Published private(set) var lastError: String?
+    @Published private(set) var approvalFlow = SleepApprovalFlow()
 
     var onStateChanged: ((Bool) -> Void)?
 
@@ -19,6 +56,29 @@ final class SleepController: ObservableObject {
     enum AuthorizationStatus: Equatable {
         case authorized, notAuthorized, needsReauthorization
     }
+    enum HelperRegistrationAction: Equatable {
+        case reuse, register, requestApproval, fail
+    }
+
+    struct Environment {
+        let status: @MainActor () -> SMAppService.Status
+        let register: @MainActor () throws -> Void
+        let unregister: @MainActor () async throws -> Void
+        let request: @Sendable (Bool) async -> Bool
+        let readState: @MainActor () -> Bool
+        let openSettings: @MainActor () -> Void
+
+        static let live = Environment(
+            status: { SleepController.daemon.status },
+            register: { try SleepController.daemon.register() },
+            unregister: { try await SleepController.daemon.unregister() },
+            request: { await SleepController.requestSleepDisabled($0) },
+            readState: { SleepController.readSleepDisabled() },
+            openSettings: { SMAppService.openSystemSettingsLoginItems() }
+        )
+    }
+
+    private let environment: Environment
 
     static var authorizationStatus: AuthorizationStatus {
         switch daemon.status {
@@ -29,7 +89,8 @@ final class SleepController: ObservableObject {
         }
     }
 
-    init(previewEnabled: Bool? = nil) {
+    init(previewEnabled: Bool? = nil, environment: Environment = .live) {
+        self.environment = environment
         if let previewEnabled {
             isEnabled = previewEnabled
         } else {
@@ -38,7 +99,7 @@ final class SleepController: ObservableObject {
     }
 
     func refresh() {
-        let observed = Self.readSleepDisabled()
+        let observed = environment.readState()
         isEnabled = observed
         onStateChanged?(observed)
     }
@@ -58,59 +119,144 @@ final class SleepController: ObservableObject {
 
         Task {
             let commandSucceeded: Bool
+            var guidanceWasRequested = false
             do {
-                try Self.registerHelperIfNeeded()
-                commandSucceeded = await Self.requestSleepDisabled(enabled)
+                try registerHelperIfNeeded()
+                commandSucceeded = await environment.request(enabled)
+                if !commandSucceeded {
+                    approvalFlow.requireRepair(for: enabled)
+                    guidanceWasRequested = true
+                }
             } catch SleepControllerError.approvalRequired {
-                SMAppService.openSystemSettingsLoginItems()
+                approvalFlow.requireApproval(for: enabled)
+                guidanceWasRequested = true
                 commandSucceeded = false
             } catch {
                 commandSucceeded = false
             }
 
-            let observed = Self.readSleepDisabled()
+            let observed = environment.readState()
             isBusy = false
             targetEnabled = nil
             isEnabled = observed
             onStateChanged?(observed)
 
-            if case .failure = SleepControlLogic.resolvedState(
-                requested: enabled,
-                commandSucceeded: commandSucceeded,
-                observed: observed
-            ) {
+            if !guidanceWasRequested,
+               case .failure = SleepControlLogic.resolvedState(
+                   requested: enabled,
+                   commandSucceeded: commandSucceeded,
+                   observed: observed
+               ) {
                 lastError = "pmset_failed"
             }
         }
     }
 
+    func performGuidanceAction() {
+        switch approvalFlow.guidance {
+        case .approval:
+            openApprovalSettings()
+        case .repair:
+            repairHelper()
+        case nil:
+            break
+        }
+    }
+
+    func openApprovalSettings() {
+        approvalFlow.dismissGuidance()
+        environment.openSettings()
+    }
+
+    func dismissApprovalGuidance() {
+        approvalFlow.dismissGuidance()
+    }
+
+    func cancelApprovalRequest() {
+        approvalFlow.cancel()
+    }
+
+    func resumePendingApprovalIfAuthorized() {
+        let authorized = Self.registrationAction(for: environment.status()) == .reuse
+        guard let target = approvalFlow.consumePendingTarget(ifAuthorized: authorized) else {
+            return
+        }
+        setEnabled(target)
+    }
+
     func restoreAndRemoveHelper() async throws {
-        guard await Self.requestSleepDisabled(false) else {
+        guard await environment.request(false) else {
             throw SleepControllerError.restoreFailed
         }
-        try await Self.daemon.unregister()
+        try await environment.unregister()
         refresh()
     }
 
-    private static func registerHelperIfNeeded() throws {
-        switch daemon.status {
-        case .enabled:
+    private func repairHelper() {
+        guard let target = approvalFlow.pendingTarget else { return }
+        approvalFlow.dismissGuidance()
+        isBusy = true
+        Task {
+            do {
+                if Self.registrationAction(for: environment.status()) == .reuse {
+                    try await environment.unregister()
+                }
+                try environment.register()
+                guard Self.registrationAction(for: environment.status()) == .reuse else {
+                    throw SleepControllerError.approvalRequired
+                }
+                approvalFlow.cancel()
+                isBusy = false
+                setEnabled(target)
+            } catch SleepControllerError.approvalRequired {
+                isBusy = false
+                approvalFlow.requireApproval(for: target)
+                openApprovalSettings()
+            } catch {
+                isBusy = false
+                lastError = "helper_repair_failed"
+            }
+        }
+    }
+
+    private func registerHelperIfNeeded() throws {
+        switch Self.registrationAction(for: environment.status()) {
+        case .reuse:
             return
-        case .notRegistered, .notFound:
-            try daemon.register()
-            guard daemon.status == .enabled else {
+        case .register:
+            try environment.register()
+            guard Self.registrationAction(for: environment.status()) == .reuse else {
                 throw SleepControllerError.approvalRequired
             }
-        case .requiresApproval:
+        case .requestApproval:
             throw SleepControllerError.approvalRequired
-        @unknown default:
+        case .fail:
             throw SleepControllerError.registrationFailed
         }
     }
 
-    private static func requestSleepDisabled(_ disabled: Bool) async -> Bool {
+    nonisolated static func registrationAction(
+        for status: SMAppService.Status
+    ) -> HelperRegistrationAction {
+        switch status {
+        case .enabled:
+            .reuse
+        case .notRegistered, .notFound:
+            .register
+        case .requiresApproval:
+            .requestApproval
+        @unknown default:
+            .fail
+        }
+    }
+
+    nonisolated static func requestSleepDisabled(
+        _ disabled: Bool,
+        machServiceName: String = kajiSleepHelperMachService,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
         await withCheckedContinuation { continuation in
-            let connection = NSXPCConnection(machServiceName: kajiSleepHelperMachService)
+            let connection = NSXPCConnection(machServiceName: machServiceName)
             connection.remoteObjectInterface = NSXPCInterface(with: SleepHelperProtocol.self)
 
             let completion = SleepRequestCompletion(
@@ -120,7 +266,7 @@ final class SleepController: ObservableObject {
 
             connection.interruptionHandler = { completion.finish(false) }
             connection.invalidationHandler = { completion.finish(false) }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 3) {
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
                 completion.finish(false)
             }
             connection.resume()

--- a/Sources/Kaji/SleepController.swift
+++ b/Sources/Kaji/SleepController.swift
@@ -1,10 +1,9 @@
 import Foundation
 import KajiCore
 import KajiSleepSupport
-import ServiceManagement
 
 enum SleepGuidanceKind: Equatable {
-    case approval, repair
+    case repair
 }
 
 struct SleepApprovalFlow: Equatable {
@@ -12,11 +11,6 @@ struct SleepApprovalFlow: Equatable {
     private(set) var guidance: SleepGuidanceKind?
 
     var isGuidancePresented: Bool { guidance != nil }
-
-    mutating func requireApproval(for target: Bool) {
-        pendingTarget = target
-        guidance = .approval
-    }
 
     mutating func requireRepair(for target: Bool) {
         pendingTarget = target
@@ -31,12 +25,6 @@ struct SleepApprovalFlow: Equatable {
         pendingTarget = nil
         guidance = nil
     }
-
-    mutating func consumePendingTarget(ifAuthorized authorized: Bool) -> Bool? {
-        guard authorized, let pendingTarget else { return nil }
-        cancel()
-        return pendingTarget
-    }
 }
 
 @MainActor
@@ -49,43 +37,31 @@ final class SleepController: ObservableObject {
 
     var onStateChanged: ((Bool) -> Void)?
 
-    private static let daemon = SMAppService.daemon(
-        plistName: "dev.kaji.sleep-helper.plist"
-    )
-
     enum AuthorizationStatus: Equatable {
         case authorized, notAuthorized, needsReauthorization
     }
-    enum HelperRegistrationAction: Equatable {
-        case reuse, register, requestApproval, fail
-    }
 
     struct Environment {
-        let status: @MainActor () -> SMAppService.Status
-        let register: @MainActor () throws -> Void
-        let unregister: @MainActor () async throws -> Void
+        let status: @MainActor () -> SleepHelperInstallStatus
+        let install: @MainActor () async throws -> Void
         let request: @Sendable (Bool) async -> Bool
         let readState: @MainActor () -> Bool
-        let openSettings: @MainActor () -> Void
 
         static let live = Environment(
-            status: { SleepController.daemon.status },
-            register: { try SleepController.daemon.register() },
-            unregister: { try await SleepController.daemon.unregister() },
+            status: { SleepHelperInstaller.live.status() },
+            install: { try await SleepHelperInstaller.live.install() },
             request: { await SleepController.requestSleepDisabled($0) },
-            readState: { SleepController.readSleepDisabled() },
-            openSettings: { SMAppService.openSystemSettingsLoginItems() }
+            readState: { SleepController.readSleepDisabled() }
         )
     }
 
     private let environment: Environment
 
     static var authorizationStatus: AuthorizationStatus {
-        switch daemon.status {
-        case .enabled: .authorized
-        case .requiresApproval: .needsReauthorization
-        case .notRegistered, .notFound: .notAuthorized
-        @unknown default: .notAuthorized
+        switch SleepHelperInstaller.live.status() {
+        case .installed: .authorized
+        case .notInstalled: .notAuthorized
+        case .needsRepair, .unavailable: .needsReauthorization
         }
     }
 
@@ -119,53 +95,37 @@ final class SleepController: ObservableObject {
 
         Task {
             let commandSucceeded: Bool
-            var guidanceWasRequested = false
+            var installedNow = false
             do {
-                try registerHelperIfNeeded()
-                commandSucceeded = await environment.request(enabled)
+                switch environment.status() {
+                case .installed:
+                    break
+                case .notInstalled:
+                    try await environment.install()
+                    installedNow = true
+                    guard environment.status() == .installed else {
+                        throw SleepControllerError.installationFailed
+                    }
+                case .needsRepair, .unavailable:
+                    throw SleepControllerError.installationFailed
+                }
+                commandSucceeded = await request(enabled, attempts: installedNow ? 3 : 1)
                 if !commandSucceeded {
                     approvalFlow.requireRepair(for: enabled)
-                    guidanceWasRequested = true
                 }
-            } catch SleepControllerError.approvalRequired {
-                approvalFlow.requireApproval(for: enabled)
-                guidanceWasRequested = true
-                commandSucceeded = false
             } catch {
                 commandSucceeded = false
+                approvalFlow.requireRepair(for: enabled)
             }
-
-            let observed = environment.readState()
+            let observed = commandSucceeded ? enabled : environment.readState()
             isBusy = false
             targetEnabled = nil
             isEnabled = observed
             onStateChanged?(observed)
-
-            if !guidanceWasRequested,
-               case .failure = SleepControlLogic.resolvedState(
-                   requested: enabled,
-                   commandSucceeded: commandSucceeded,
-                   observed: observed
-               ) {
-                lastError = "pmset_failed"
-            }
         }
     }
-
     func performGuidanceAction() {
-        switch approvalFlow.guidance {
-        case .approval:
-            openApprovalSettings()
-        case .repair:
-            repairHelper()
-        case nil:
-            break
-        }
-    }
-
-    func openApprovalSettings() {
-        approvalFlow.dismissGuidance()
-        environment.openSettings()
+        repairHelper()
     }
 
     func dismissApprovalGuidance() {
@@ -176,78 +136,49 @@ final class SleepController: ObservableObject {
         approvalFlow.cancel()
     }
 
-    func resumePendingApprovalIfAuthorized() {
-        let authorized = Self.registrationAction(for: environment.status()) == .reuse
-        guard let target = approvalFlow.consumePendingTarget(ifAuthorized: authorized) else {
-            return
-        }
-        setEnabled(target)
-    }
-
-    func restoreAndRemoveHelper() async throws {
-        guard await environment.request(false) else {
-            throw SleepControllerError.restoreFailed
-        }
-        try await environment.unregister()
-        refresh()
-    }
-
     private func repairHelper() {
         guard let target = approvalFlow.pendingTarget else { return }
         approvalFlow.dismissGuidance()
         isBusy = true
+        targetEnabled = target
+        lastError = nil
+
         Task {
             do {
-                if Self.registrationAction(for: environment.status()) == .reuse {
-                    try await environment.unregister()
+                try await environment.install()
+                guard environment.status() == .installed else {
+                    throw SleepControllerError.installationFailed
                 }
-                try environment.register()
-                guard Self.registrationAction(for: environment.status()) == .reuse else {
-                    throw SleepControllerError.approvalRequired
+                let commandSucceeded = await request(target, attempts: 3)
+                let observed = commandSucceeded ? target : environment.readState()
+                isBusy = false
+                targetEnabled = nil
+                isEnabled = observed
+                onStateChanged?(observed)
+
+                if commandSucceeded, observed == target {
+                    approvalFlow.cancel()
+                } else {
+                    approvalFlow.requireRepair(for: target)
+                    lastError = "helper_repair_failed"
                 }
-                approvalFlow.cancel()
-                isBusy = false
-                setEnabled(target)
-            } catch SleepControllerError.approvalRequired {
-                isBusy = false
-                approvalFlow.requireApproval(for: target)
-                openApprovalSettings()
             } catch {
                 isBusy = false
+                targetEnabled = nil
+                approvalFlow.requireRepair(for: target)
                 lastError = "helper_repair_failed"
             }
         }
     }
 
-    private func registerHelperIfNeeded() throws {
-        switch Self.registrationAction(for: environment.status()) {
-        case .reuse:
-            return
-        case .register:
-            try environment.register()
-            guard Self.registrationAction(for: environment.status()) == .reuse else {
-                throw SleepControllerError.approvalRequired
+    private func request(_ target: Bool, attempts: Int) async -> Bool {
+        for attempt in 1...attempts {
+            if await environment.request(target) { return true }
+            if attempt < attempts {
+                try? await Task.sleep(for: .milliseconds(500))
             }
-        case .requestApproval:
-            throw SleepControllerError.approvalRequired
-        case .fail:
-            throw SleepControllerError.registrationFailed
         }
-    }
-
-    nonisolated static func registrationAction(
-        for status: SMAppService.Status
-    ) -> HelperRegistrationAction {
-        switch status {
-        case .enabled:
-            .reuse
-        case .notRegistered, .notFound:
-            .register
-        case .requiresApproval:
-            .requestApproval
-        @unknown default:
-            .fail
-        }
+        return false
     }
 
     nonisolated static func requestSleepDisabled(
@@ -337,7 +268,5 @@ private final class SleepRequestCompletion: @unchecked Sendable {
 }
 
 private enum SleepControllerError: Error {
-    case approvalRequired
-    case registrationFailed
-    case restoreFailed
+    case installationFailed
 }

--- a/Sources/Kaji/SleepHelperInstaller.swift
+++ b/Sources/Kaji/SleepHelperInstaller.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+enum SleepHelperInstallStatus: Equatable {
+    case installed
+    case notInstalled
+    case needsRepair
+    case unavailable
+}
+
+struct SleepHelperInstaller: Sendable {
+    static let live = SleepHelperInstaller()
+
+    private let label = "dev.kaji.sleep-helper"
+    private let installedHelper = URL(fileURLWithPath: "/Library/PrivilegedHelperTools/dev.kaji.sleep-helper")
+    private let installedPlist = URL(fileURLWithPath: "/Library/LaunchDaemons/dev.kaji.sleep-helper.plist")
+
+    func status() -> SleepHelperInstallStatus {
+        guard let bundledHelper, bundledPlist != nil else { return .unavailable }
+        let fileManager = FileManager.default
+        let hasHelper = fileManager.isExecutableFile(atPath: installedHelper.path)
+        let hasPlist = fileManager.fileExists(atPath: installedPlist.path)
+        guard hasHelper || hasPlist else { return .notInstalled }
+        guard hasHelper,
+              hasPlist,
+              filesMatch(bundledHelper, installedHelper) else {
+            return .needsRepair
+        }
+        return .installed
+    }
+
+    func install() async throws {
+        guard let bundledHelper, let bundledPlist else {
+            throw SleepHelperInstallerError.missingBundleResources
+        }
+
+        let temporaryPlist = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dev.kaji.sleep-helper-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: temporaryPlist) }
+        try writeLegacyPlist(from: bundledPlist, to: temporaryPlist)
+
+        let commands = [
+            "/bin/launchctl bootout system/\(label) >/dev/null 2>&1 || true",
+            "/bin/sleep 1",
+            "/usr/bin/install -d -o root -g wheel -m 0755 /Library/PrivilegedHelperTools",
+            "/usr/bin/install -o root -g wheel -m 0755 \(shellQuote(bundledHelper.path)) \(shellQuote(installedHelper.path))",
+            "/usr/bin/install -o root -g wheel -m 0644 \(shellQuote(temporaryPlist.path)) \(shellQuote(installedPlist.path))",
+            "/bin/launchctl bootstrap system \(shellQuote(installedPlist.path)) >/dev/null 2>&1 || /bin/launchctl print system/\(label) >/dev/null 2>&1",
+        ]
+        let command = commands.joined(separator: "; ")
+        try await Task.detached(priority: .userInitiated) {
+            try Self.runWithAdministratorPrivileges(command)
+        }.value
+    }
+
+    private var bundledHelper: URL? {
+        let url = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Library/HelperTools/KajiSleepHelper")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    private var bundledPlist: URL? {
+        let url = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Library/LaunchDaemons/dev.kaji.sleep-helper.plist")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    private func writeLegacyPlist(from source: URL, to destination: URL) throws {
+        let data = try Data(contentsOf: source)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        guard var plist = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: &format
+        ) as? [String: Any] else {
+            throw SleepHelperInstallerError.invalidPlist
+        }
+        plist.removeValue(forKey: "BundleProgram")
+        plist.removeValue(forKey: "AssociatedBundleIdentifiers")
+        plist["ProgramArguments"] = [installedHelper.path]
+        let output = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try output.write(to: destination, options: Data.WritingOptions.atomic)
+    }
+
+
+    private func filesMatch(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard let left = try? FileHandle(forReadingFrom: lhs),
+              let right = try? FileHandle(forReadingFrom: rhs) else { return false }
+        defer {
+            try? left.close()
+            try? right.close()
+        }
+        while true {
+            let leftChunk = try? left.read(upToCount: 65_536)
+            let rightChunk = try? right.read(upToCount: 65_536)
+            guard leftChunk == rightChunk else { return false }
+            if leftChunk == nil || leftChunk?.isEmpty == true { return true }
+        }
+    }
+
+    private static func runWithAdministratorPrivileges(_ command: String) throws {
+        let escaped = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let process = Process()
+        let errorPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [
+            "-e",
+            "do shell script \"\(escaped)\" with administrator privileges",
+        ]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? "Authorization failed"
+            throw SleepHelperInstallerError.authorizationFailed(message)
+        }
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
+enum SleepHelperInstallerError: Error {
+    case missingBundleResources
+    case invalidPlist
+    case authorizationFailed(String)
+}

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -53,6 +53,7 @@ struct StatusItemView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("kaji.status.quota")
             if let workSlotLabel {
                 Button(action: onWorkClick) {
                     WorkStatusSlot(label: workSlotLabel)

--- a/Sources/KajiCore/LanguageLocalization.swift
+++ b/Sources/KajiCore/LanguageLocalization.swift
@@ -65,6 +65,8 @@ public enum L10n {
         case goalGroupUntagged, goalGroupToday, goalGroupYesterday, goalGroupThisWeek, goalGroupEarlier
         case permissions, gmailCredential, gmailCredentialWhy, loginPermission, loginPermissionWhy
         case sleepPermission, sleepPermissionWhy, authorized, notAuthorized, needsReauthorization, authorize
+        case sleepApprovalTitle, sleepApprovalMessage, openSystemSettings, cancel
+        case sleepRepairTitle, sleepRepairMessage, repairHelper
     }
 
     private struct Text {
@@ -181,6 +183,23 @@ public enum L10n {
         .notAuthorized: .init(en: "Not authorized", zh: "未授权", ptBR: "Não autorizado", es: "No autorizado"),
         .needsReauthorization: .init(en: "Needs re-authorization", zh: "需要重新授权", ptBR: "Requer nova autorização", es: "Requiere nueva autorización"),
         .authorize: .init(en: "Authorize", zh: "授权", ptBR: "Autorizar", es: "Autorizar"),
+        .sleepApprovalTitle: .init(en: "Allow Prevent Sleep", zh: "允许 Kaji 防止休眠", ptBR: "Permitir impedir repouso", es: "Permitir impedir reposo"),
+        .sleepApprovalMessage: .init(
+            en: "macOS requires one approval. In Login Items & Extensions, turn on Kaji under App Background Activity, then return here. Later switches will not ask again.",
+            zh: "macOS 需要一次授权。请在“登录项与扩展”的“App 后台活动”中开启 Kaji，然后返回这里；之后切换不再重复询问。",
+            ptBR: "O macOS exige uma aprovação. Em Itens de Início e Extensões, ative o Kaji em Atividade em Segundo Plano e volte aqui. As próximas mudanças não pedirão novamente.",
+            es: "macOS requiere una autorización. En Ítems de inicio y extensiones, activa Kaji en Actividad en segundo plano y vuelve aquí. Los cambios posteriores no volverán a solicitarla."
+        ),
+        .openSystemSettings: .init(en: "Open System Settings", zh: "打开系统设置", ptBR: "Abrir Ajustes do Sistema", es: "Abrir Ajustes del Sistema"),
+        .cancel: .init(en: "Cancel", zh: "取消", ptBR: "Cancelar", es: "Cancelar"),
+        .sleepRepairTitle: .init(en: "Repair Prevent Sleep", zh: "修复防休眠助手", ptBR: "Reparar auxiliar antirrepouso", es: "Reparar asistente antirreposo"),
+        .sleepRepairMessage: .init(
+            en: "The helper from an earlier Kaji build can no longer start. Kaji can replace it now; macOS may then request one approval.",
+            zh: "旧版 Kaji 注册的防休眠助手已经无法启动。Kaji 可以立即替换它；随后 macOS 可能要求一次授权。",
+            ptBR: "O auxiliar de uma versão anterior do Kaji não inicia mais. O Kaji pode substituí-lo agora; depois, o macOS pode pedir uma autorização.",
+            es: "El asistente de una versión anterior de Kaji ya no puede iniciarse. Kaji puede reemplazarlo ahora; después, macOS puede pedir una autorización."
+        ),
+        .repairHelper: .init(en: "Repair Helper", zh: "修复助手", ptBR: "Reparar auxiliar", es: "Reparar asistente"),
     ]
 
     public static func t(_ key: K, _ language: AppLanguage) -> String {

--- a/Sources/KajiCore/LanguageLocalization.swift
+++ b/Sources/KajiCore/LanguageLocalization.swift
@@ -65,8 +65,7 @@ public enum L10n {
         case goalGroupUntagged, goalGroupToday, goalGroupYesterday, goalGroupThisWeek, goalGroupEarlier
         case permissions, gmailCredential, gmailCredentialWhy, loginPermission, loginPermissionWhy
         case sleepPermission, sleepPermissionWhy, authorized, notAuthorized, needsReauthorization, authorize
-        case sleepApprovalTitle, sleepApprovalMessage, openSystemSettings, cancel
-        case sleepRepairTitle, sleepRepairMessage, repairHelper
+        case cancel, sleepRepairTitle, sleepRepairMessage, repairHelper
     }
 
     private struct Text {
@@ -183,21 +182,13 @@ public enum L10n {
         .notAuthorized: .init(en: "Not authorized", zh: "未授权", ptBR: "Não autorizado", es: "No autorizado"),
         .needsReauthorization: .init(en: "Needs re-authorization", zh: "需要重新授权", ptBR: "Requer nova autorização", es: "Requiere nueva autorización"),
         .authorize: .init(en: "Authorize", zh: "授权", ptBR: "Autorizar", es: "Autorizar"),
-        .sleepApprovalTitle: .init(en: "Allow Prevent Sleep", zh: "允许 Kaji 防止休眠", ptBR: "Permitir impedir repouso", es: "Permitir impedir reposo"),
-        .sleepApprovalMessage: .init(
-            en: "macOS requires one approval. In Login Items & Extensions, turn on Kaji under App Background Activity, then return here. Later switches will not ask again.",
-            zh: "macOS 需要一次授权。请在“登录项与扩展”的“App 后台活动”中开启 Kaji，然后返回这里；之后切换不再重复询问。",
-            ptBR: "O macOS exige uma aprovação. Em Itens de Início e Extensões, ative o Kaji em Atividade em Segundo Plano e volte aqui. As próximas mudanças não pedirão novamente.",
-            es: "macOS requiere una autorización. En Ítems de inicio y extensiones, activa Kaji en Actividad en segundo plano y vuelve aquí. Los cambios posteriores no volverán a solicitarla."
-        ),
-        .openSystemSettings: .init(en: "Open System Settings", zh: "打开系统设置", ptBR: "Abrir Ajustes do Sistema", es: "Abrir Ajustes del Sistema"),
         .cancel: .init(en: "Cancel", zh: "取消", ptBR: "Cancelar", es: "Cancelar"),
         .sleepRepairTitle: .init(en: "Repair Prevent Sleep", zh: "修复防休眠助手", ptBR: "Reparar auxiliar antirrepouso", es: "Reparar asistente antirreposo"),
         .sleepRepairMessage: .init(
-            en: "The helper from an earlier Kaji build can no longer start. Kaji can replace it now; macOS may then request one approval.",
-            zh: "旧版 Kaji 注册的防休眠助手已经无法启动。Kaji 可以立即替换它；随后 macOS 可能要求一次授权。",
-            ptBR: "O auxiliar de uma versão anterior do Kaji não inicia mais. O Kaji pode substituí-lo agora; depois, o macOS pode pedir uma autorização.",
-            es: "El asistente de una versión anterior de Kaji ya no puede iniciarse. Kaji puede reemplazarlo ahora; después, macOS puede pedir una autorización."
+            en: "Kaji needs administrator approval to install or update its Prevent Sleep helper. Enter your password once; normal switches will not ask again.",
+            zh: "Kaji 需要管理员授权来安装或更新防休眠助手。输入一次密码后，日常开关不会再重复询问。",
+            ptBR: "O Kaji precisa da aprovação do administrador para instalar ou atualizar o auxiliar antirrepouso. Digite a senha uma vez; as mudanças normais não pedirão novamente.",
+            es: "Kaji necesita aprobación de administrador para instalar o actualizar el asistente antirreposo. Introduce la contraseña una vez; los cambios normales no volverán a pedirla."
         ),
         .repairHelper: .init(en: "Repair Helper", zh: "修复助手", ptBR: "Reparar auxiliar", es: "Reparar asistente"),
     ]

--- a/Tests/KajiTests/KajiControlServerTests.swift
+++ b/Tests/KajiTests/KajiControlServerTests.swift
@@ -60,6 +60,9 @@ final class KajiControlServerTests: XCTestCase {
                 nonce: "exact-test-nonce",
                 render: { surface, selection, outputPath in
                     ["surface": surface, "selection": selection, "path": outputPath]
+                },
+                perform: { action, target in
+                    ["action": action, "target": target as Any]
                 }
             )
         )
@@ -73,6 +76,14 @@ final class KajiControlServerTests: XCTestCase {
             path: "test/render",
             body: ["nonce": "wrong", "surface": "popover", "selection": "quota", "outputPath": "/tmp/x"]
         )
+
+        let rejectedAction = try await rawRequest(
+            automationBase,
+            method: "POST",
+            path: "test/action",
+            body: ["nonce": "wrong", "action": "set-prevent-sleep", "target": true]
+        )
+        XCTAssertEqual(rejectedAction.status, 404)
         XCTAssertEqual(rejected.status, 404)
 
         let accepted = try await rawRequest(
@@ -89,6 +100,20 @@ final class KajiControlServerTests: XCTestCase {
         XCTAssertEqual(accepted.status, 200)
         XCTAssertEqual(accepted.object["selection"] as? String, "launchd")
         XCTAssertEqual(accepted.object["path"] as? String, "/tmp/render.png")
+
+        let action = try await rawRequest(
+            automationBase,
+            method: "POST",
+            path: "test/action",
+            body: [
+                "nonce": "exact-test-nonce",
+                "action": "set-prevent-sleep",
+                "target": true,
+            ]
+        )
+        XCTAssertEqual(action.status, 200)
+        XCTAssertEqual(action.object["action"] as? String, "set-prevent-sleep")
+        XCTAssertEqual(action.object["target"] as? Bool, true)
     }
 
     private func waitUntilReachable(_ url: URL) async throws {

--- a/Tests/KajiTests/SettingsPermissionUITests.swift
+++ b/Tests/KajiTests/SettingsPermissionUITests.swift
@@ -16,12 +16,10 @@ final class SettingsPermissionUITests: XCTestCase {
         let cacheURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("kaji-sleep-ui-\(UUID().uuidString).json")
         let environment = SleepController.Environment(
-            status: { .enabled },
-            register: {},
-            unregister: {},
+            status: { .installed },
+            install: {},
             request: { _ in false },
-            readState: { false },
-            openSettings: {}
+            readState: { false }
         )
         let controller = SleepController(previewEnabled: false, environment: environment)
         let window = NSWindow(

--- a/Tests/KajiTests/SettingsPermissionUITests.swift
+++ b/Tests/KajiTests/SettingsPermissionUITests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import KajiCore
+@testable import Kaji
+
+@MainActor
+final class SettingsPermissionUITests: XCTestCase {
+    func testPreventSleepClickPresentsRepairDialogWhenRegisteredHelperCannotStart() async throws {
+        _ = NSApplication.shared
+        NSApp.setActivationPolicy(.accessory)
+
+        let suiteName = "dev.blackblue.Kaji.UITest.SleepPermission.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.set(AppLanguage.zh.rawValue, forKey: "language")
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaji-sleep-ui-\(UUID().uuidString).json")
+        let environment = SleepController.Environment(
+            status: { .enabled },
+            register: {},
+            unregister: {},
+            request: { _ in false },
+            readState: { false },
+            openSettings: {}
+        )
+        let controller = SleepController(previewEnabled: false, environment: environment)
+        let window = NSWindow(
+            contentRect: NSRect(x: -2_000, y: -2_000, width: 760, height: 590),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Kaji Sleep Permission UI Test"
+        window.contentView = NSHostingView(rootView: SettingsView(
+            prefs: Prefs(defaults: defaults),
+            sleepController: controller,
+            fixedPlanStore: FixedPlanStore(defaults: defaults),
+            mailBriefStore: MailBriefStore(cacheURL: cacheURL)
+        ))
+        window.contentView?.layoutSubtreeIfNeeded()
+        defer {
+            window.orderOut(nil)
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: cacheURL)
+        }
+
+        try await Task.sleep(for: .milliseconds(150))
+        // SwiftPM has no XCUITest application target. Match KajiUIHarness:
+        // invoke the same controller action wired to the visible segment, then
+        // verify the real SettingsView presents and renders its AppKit sheet.
+        controller.toggle()
+
+        let deadline = Date().addingTimeInterval(2)
+        while controller.approvalFlow.guidance != .repair, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        XCTAssertEqual(controller.approvalFlow.guidance, .repair)
+        let sheet = try XCTUnwrap(
+            window.attachedSheet,
+            "Prevent Sleep failure must present a guided dialog"
+        )
+        let contentView = try XCTUnwrap(sheet.contentView)
+        XCTAssertFalse(contentView.subviews.isEmpty, "Repair dialog must render visible AppKit content")
+        sheet.orderOut(nil)
+    }
+}
+

--- a/Tests/KajiTests/SleepControlLogicTests.swift
+++ b/Tests/KajiTests/SleepControlLogicTests.swift
@@ -56,4 +56,139 @@ final class SleepControlLogicTests: XCTestCase {
         XCTAssertFalse(gate.claim())
     }
 
+    func testUnavailableHelperFailsWithoutCrashing() async {
+        let succeeded = await SleepController.requestSleepDisabled(
+            true,
+            machServiceName: "dev.kaji.tests.missing-sleep-helper",
+            timeout: 0.1
+        )
+
+        XCTAssertFalse(succeeded)
+    }
+
+    func testEnabledHelperIsReusedWithoutAnotherAuthorization() {
+        XCTAssertEqual(SleepController.registrationAction(for: .enabled), .reuse)
+        XCTAssertEqual(SleepController.registrationAction(for: .notRegistered), .register)
+        XCTAssertEqual(SleepController.registrationAction(for: .requiresApproval), .requestApproval)
+    }
+
+    func testApprovalGuidanceRetainsAndResumesRequestedState() {
+        var flow = SleepApprovalFlow()
+
+        flow.requireApproval(for: true)
+        XCTAssertTrue(flow.isGuidancePresented)
+        XCTAssertEqual(flow.pendingTarget, true)
+
+        flow.dismissGuidance()
+        XCTAssertFalse(flow.isGuidancePresented)
+        XCTAssertNil(flow.consumePendingTarget(ifAuthorized: false))
+        XCTAssertEqual(flow.consumePendingTarget(ifAuthorized: true), true)
+        XCTAssertNil(flow.pendingTarget)
+    }
+
+    func testCancellingApprovalGuidanceDropsPendingRequest() {
+        var flow = SleepApprovalFlow()
+        flow.requireApproval(for: true)
+
+        flow.cancel()
+
+        XCTAssertFalse(flow.isGuidancePresented)
+        XCTAssertNil(flow.pendingTarget)
+    }
+
+    @MainActor
+    func testUnavailableRegisteredHelperRequestsRepair() async {
+        let environment = SleepController.Environment(
+            status: { .enabled },
+            register: {},
+            unregister: {},
+            request: { _ in false },
+            readState: { false },
+            openSettings: {}
+        )
+        let controller = SleepController(previewEnabled: false, environment: environment)
+
+        controller.setEnabled(true)
+        while controller.isBusy {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(controller.approvalFlow.guidance, .repair)
+        XCTAssertEqual(controller.approvalFlow.pendingTarget, true)
+        XCTAssertNil(controller.lastError)
+    }
+
+    @MainActor
+    func testRepairReregistersOnceAndSubsequentToggleReusesHelper() async {
+        let state = SleepEnvironmentState()
+        var registered = true
+        var registerCount = 0
+        var unregisterCount = 0
+        let environment = SleepController.Environment(
+            status: { registered ? .enabled : .notRegistered },
+            register: {
+                registerCount += 1
+                registered = true
+            },
+            unregister: {
+                unregisterCount += 1
+                registered = false
+            },
+            request: { target in state.request(target) },
+            readState: { state.observed },
+            openSettings: {}
+        )
+        let controller = SleepController(previewEnabled: false, environment: environment)
+
+        controller.setEnabled(true)
+        while controller.isBusy { await Task.yield() }
+        XCTAssertEqual(controller.approvalFlow.guidance, .repair)
+
+        state.requestSucceeds = true
+        controller.performGuidanceAction()
+        while controller.isBusy || !controller.isEnabled { await Task.yield() }
+
+        XCTAssertEqual(unregisterCount, 1)
+        XCTAssertEqual(registerCount, 1)
+        XCTAssertEqual(state.requestCount, 2)
+
+        controller.setEnabled(false)
+        while controller.isBusy { await Task.yield() }
+
+        XCTAssertFalse(controller.isEnabled)
+        XCTAssertEqual(unregisterCount, 1)
+        XCTAssertEqual(registerCount, 1)
+        XCTAssertEqual(state.requestCount, 3)
+    }
+
+
+}
+
+private final class SleepEnvironmentState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _requestSucceeds = false
+    private var _observed = false
+    private var _requestCount = 0
+
+    var requestSucceeds: Bool {
+        get { withLock { _requestSucceeds } }
+        set { withLock { _requestSucceeds = newValue } }
+    }
+
+    var observed: Bool { withLock { _observed } }
+    var requestCount: Int { withLock { _requestCount } }
+
+    func request(_ target: Bool) -> Bool {
+        withLock {
+            _requestCount += 1
+            if _requestSucceeds { _observed = target }
+            return _requestSucceeds
+        }
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
 }

--- a/Tests/KajiTests/SleepControlLogicTests.swift
+++ b/Tests/KajiTests/SleepControlLogicTests.swift
@@ -66,52 +66,83 @@ final class SleepControlLogicTests: XCTestCase {
         XCTAssertFalse(succeeded)
     }
 
-    func testEnabledHelperIsReusedWithoutAnotherAuthorization() {
-        XCTAssertEqual(SleepController.registrationAction(for: .enabled), .reuse)
-        XCTAssertEqual(SleepController.registrationAction(for: .notRegistered), .register)
-        XCTAssertEqual(SleepController.registrationAction(for: .requiresApproval), .requestApproval)
-    }
-
-    func testApprovalGuidanceRetainsAndResumesRequestedState() {
+    func testRepairGuidanceRetainsPendingTargetUntilCancelled() {
         var flow = SleepApprovalFlow()
 
-        flow.requireApproval(for: true)
+        flow.requireRepair(for: true)
         XCTAssertTrue(flow.isGuidancePresented)
         XCTAssertEqual(flow.pendingTarget, true)
 
         flow.dismissGuidance()
         XCTAssertFalse(flow.isGuidancePresented)
-        XCTAssertNil(flow.consumePendingTarget(ifAuthorized: false))
-        XCTAssertEqual(flow.consumePendingTarget(ifAuthorized: true), true)
-        XCTAssertNil(flow.pendingTarget)
-    }
-
-    func testCancellingApprovalGuidanceDropsPendingRequest() {
-        var flow = SleepApprovalFlow()
-        flow.requireApproval(for: true)
+        XCTAssertEqual(flow.pendingTarget, true)
 
         flow.cancel()
-
-        XCTAssertFalse(flow.isGuidancePresented)
         XCTAssertNil(flow.pendingTarget)
     }
 
     @MainActor
-    func testUnavailableRegisteredHelperRequestsRepair() async {
+    func testFirstInstallPromptsOnceAndSubsequentTogglesReuseHelper() async {
+        let state = SleepEnvironmentState()
+        state.requestSucceeds = true
+        var helperStatus = SleepHelperInstallStatus.notInstalled
+        var installCount = 0
         let environment = SleepController.Environment(
-            status: { .enabled },
-            register: {},
-            unregister: {},
-            request: { _ in false },
-            readState: { false },
-            openSettings: {}
+            status: { helperStatus },
+            install: {
+                installCount += 1
+                helperStatus = .installed
+            },
+            request: { target in state.request(target) },
+            readState: { state.observed }
         )
         let controller = SleepController(previewEnabled: false, environment: environment)
 
         controller.setEnabled(true)
-        while controller.isBusy {
-            await Task.yield()
-        }
+        while controller.isBusy { await Task.yield() }
+        XCTAssertTrue(controller.isEnabled)
+        XCTAssertEqual(installCount, 1)
+
+        controller.setEnabled(false)
+        while controller.isBusy { await Task.yield() }
+        XCTAssertFalse(controller.isEnabled)
+        XCTAssertEqual(installCount, 1)
+        XCTAssertEqual(state.requestCount, 2)
+    }
+
+    @MainActor
+    func testFreshInstallRetriesInitialHelperConnection() async {
+        let state = SleepEnvironmentState()
+        state.succeedOnRequest = 3
+        var helperStatus = SleepHelperInstallStatus.notInstalled
+        let environment = SleepController.Environment(
+            status: { helperStatus },
+            install: { helperStatus = .installed },
+            request: { target in state.request(target) },
+            readState: { state.observed }
+        )
+        let controller = SleepController(previewEnabled: false, environment: environment)
+
+        controller.setEnabled(true)
+        while controller.isBusy { await Task.yield() }
+
+        XCTAssertTrue(controller.isEnabled)
+        XCTAssertEqual(state.requestCount, 3)
+        XCTAssertFalse(controller.approvalFlow.isGuidancePresented)
+    }
+
+    @MainActor
+    func testUnavailableInstalledHelperRequestsRepair() async {
+        let environment = SleepController.Environment(
+            status: { .installed },
+            install: {},
+            request: { _ in false },
+            readState: { false }
+        )
+        let controller = SleepController(previewEnabled: false, environment: environment)
+
+        controller.setEnabled(true)
+        while controller.isBusy { await Task.yield() }
 
         XCTAssertEqual(controller.approvalFlow.guidance, .repair)
         XCTAssertEqual(controller.approvalFlow.pendingTarget, true)
@@ -119,24 +150,14 @@ final class SleepControlLogicTests: XCTestCase {
     }
 
     @MainActor
-    func testRepairReregistersOnceAndSubsequentToggleReusesHelper() async {
+    func testRepairInstallsOnceAndSubsequentToggleReusesHelper() async {
         let state = SleepEnvironmentState()
-        var registered = true
-        var registerCount = 0
-        var unregisterCount = 0
+        var installCount = 0
         let environment = SleepController.Environment(
-            status: { registered ? .enabled : .notRegistered },
-            register: {
-                registerCount += 1
-                registered = true
-            },
-            unregister: {
-                unregisterCount += 1
-                registered = false
-            },
+            status: { .installed },
+            install: { installCount += 1 },
             request: { target in state.request(target) },
-            readState: { state.observed },
-            openSettings: {}
+            readState: { state.observed }
         )
         let controller = SleepController(previewEnabled: false, environment: environment)
 
@@ -148,19 +169,16 @@ final class SleepControlLogicTests: XCTestCase {
         controller.performGuidanceAction()
         while controller.isBusy || !controller.isEnabled { await Task.yield() }
 
-        XCTAssertEqual(unregisterCount, 1)
-        XCTAssertEqual(registerCount, 1)
+        XCTAssertEqual(installCount, 1)
         XCTAssertEqual(state.requestCount, 2)
 
         controller.setEnabled(false)
         while controller.isBusy { await Task.yield() }
 
         XCTAssertFalse(controller.isEnabled)
-        XCTAssertEqual(unregisterCount, 1)
-        XCTAssertEqual(registerCount, 1)
+        XCTAssertEqual(installCount, 1)
         XCTAssertEqual(state.requestCount, 3)
     }
-
 
 }
 
@@ -169,10 +187,16 @@ private final class SleepEnvironmentState: @unchecked Sendable {
     private var _requestSucceeds = false
     private var _observed = false
     private var _requestCount = 0
+    private var _succeedOnRequest: Int?
 
     var requestSucceeds: Bool {
         get { withLock { _requestSucceeds } }
         set { withLock { _requestSucceeds = newValue } }
+    }
+
+    var succeedOnRequest: Int? {
+        get { withLock { _succeedOnRequest } }
+        set { withLock { _succeedOnRequest = newValue } }
     }
 
     var observed: Bool { withLock { _observed } }
@@ -181,8 +205,9 @@ private final class SleepEnvironmentState: @unchecked Sendable {
     func request(_ target: Bool) -> Bool {
         withLock {
             _requestCount += 1
-            if _requestSucceeds { _observed = target }
-            return _requestSucceeds
+            let succeeds = _succeedOnRequest.map { _requestCount >= $0 } ?? _requestSucceeds
+            if succeeds { _observed = target }
+            return succeeds
         }
     }
 

--- a/scripts/vm-system-guest.sh
+++ b/scripts/vm-system-guest.sh
@@ -10,14 +10,20 @@ BASE_URL="http://127.0.0.1:$PORT/v1"
 STATE_FILE="$ARTIFACTS/state.json"
 
 AUTHORIZATION_COUNT=0
+DEBUG_KEEP_APP="${KAJI_VM_DEBUG_KEEP_APP:-0}"
+WAIT_ATTEMPTS="${KAJI_VM_WAIT_ATTEMPTS:-200}"
 fail() {
     print -u2 "VM-SYSTEM FAIL: $*"
     exit 1
 }
+phase() {
+    print "[$(/bin/date -u +%H:%M:%S)] GUEST $*"
+}
 
 state() {
     local temporary="${STATE_FILE}.tmp"
-    if curl --silent --show-error "$BASE_URL/state" >"$temporary"; then
+    if curl --silent --show-error --max-time 2 "$BASE_URL/state" \
+        >"$temporary" 2>>"$ARTIFACTS/state-curl-errors.log"; then
         /bin/mv "$temporary" "$STATE_FILE"
     else
         /bin/rm -f "$temporary"
@@ -26,7 +32,7 @@ state() {
 }
 
 state_value() {
-    state
+    state || return 1
     local value
     value="$(/usr/bin/plutil -extract "$1" raw -o - "$STATE_FILE" 2>>"$ARTIFACTS/state-value-errors.log")"
     case "$value" in
@@ -45,47 +51,47 @@ action() {
     else
         body="{\"nonce\":\"$NONCE\",\"action\":\"$name\"}"
     fi
-    curl --silent --show-error --fail \
+    curl --silent --show-error --fail --max-time 2 \
         -H 'Content-Type: application/json' \
         -d "$body" "$BASE_URL/test/action" >>"$ARTIFACTS/actions.jsonl"
     print >>"$ARTIFACTS/actions.jsonl"
 }
 
 wait_for_value() {
-    local path="$1"
+    local key_path="$1"
     local expected="$2"
-    for _ in {1..200}; do
-        if [[ "$(state_value "$path" 2>/dev/null || true)" == "$expected" ]]; then return 0; fi
+    local attempt value
+    for ((attempt = 1; attempt <= WAIT_ATTEMPTS; attempt++)); do
+        value="$(state_value "$key_path" 2>/dev/null || true)"
+        if [[ "$value" == "$expected" ]]; then return 0; fi
+        if (( attempt % 10 == 0 )); then
+            print "[$(/bin/date -u +%H:%M:%S)] $key_path=${value:-unavailable}, expected=$expected" \
+                >>"$ARTIFACTS/state-values.log"
+        fi
         /bin/sleep 0.1
     done
-    fail "timed out waiting for $path=$expected"
+    fail "timed out waiting for $key_path=$expected"
 }
 
-wait_for_not_value() {
-    local path="$1"
-    local unwanted="$2"
-    for _ in {1..200}; do
-        if [[ "$(state_value "$path" 2>/dev/null || true)" != "$unwanted" ]]; then return 0; fi
-        /bin/sleep 0.1
-    done
-    fail "timed out waiting for $path to change from $unwanted"
-}
 
 launch_kaji() {
     local suffix="${1:-initial}"
-    /usr/bin/env \
+    local ready=0
+    /bin/launchctl asuser 501 /usr/bin/sudo -u admin /usr/bin/env \
         KAJI_UI_SMOKE_NONCE="$NONCE" \
         KAJI_UI_SMOKE_PORT="$PORT" \
         KAJI_UI_SMOKE_ARTIFACTS="$ARTIFACTS" \
         /Applications/Kaji.app/Contents/MacOS/Kaji \
         >"$ARTIFACTS/kaji-$suffix.stdout.log" 2>"$ARTIFACTS/kaji-$suffix.stderr.log" &
-    KAJI_PID=$!
     for _ in {1..200}; do
-        if curl --silent --fail "$BASE_URL/state" >"$STATE_FILE"; then break; fi
-        kill -0 "$KAJI_PID" 2>/dev/null || fail "Kaji exited during $suffix launch"
+        if curl --silent --fail --max-time 2 "$BASE_URL/state" >"$STATE_FILE"; then
+            ready=1
+            break
+        fi
         /bin/sleep 0.1
     done
-    kill -0 "$KAJI_PID" 2>/dev/null || fail "Kaji is not running after $suffix launch"
+    [[ "$ready" == "1" ]] || fail "Kaji control server did not start during $suffix launch"
+    pgrep -x Kaji >/dev/null || fail "Kaji is not running after $suffix launch"
 }
 
 handle_authorization_if_present() {
@@ -98,17 +104,36 @@ handle_authorization_if_present() {
                 && ! "$DRIVER" press-label "$app" Allow 2 >/dev/null 2>&1; then
                 fail "authorization password field appeared without a semantic confirmation button"
             fi
+
             AUTHORIZATION_COUNT=$((AUTHORIZATION_COUNT + 1))
             return
         fi
     done
     return 1
 }
+authorize_with_wait() {
+    for _ in {1..120}; do
+        if handle_authorization_if_present; then return 0; fi
+        /bin/sleep 0.25
+    done
+    return 1
+}
 
 cleanup() {
+    /bin/launchctl print system/dev.kaji.sleep-helper \
+        >"$ARTIFACTS/helper-final.launchctl.txt" 2>&1 || true
+    /usr/bin/stat -f '%Sp %Su:%Sg %z %N' \
+        /Library/PrivilegedHelperTools/dev.kaji.sleep-helper \
+        /Library/LaunchDaemons/dev.kaji.sleep-helper.plist \
+        >"$ARTIFACTS/helper-files.txt" 2>&1 || true
     /usr/bin/log show --last 10m --style compact \
         --predicate 'process == "Kaji" OR process == "KajiSleepHelper" OR process == "backgroundtaskmanagementd"' \
         >"$ARTIFACTS/system.log" 2>&1 || true
+    if [[ "$DEBUG_KEEP_APP" == "1" ]]; then
+        print -u2 "VM-SYSTEM retained Kaji for live diagnosis"
+        /bin/sleep 3600
+        return
+    fi
     action set-prevent-sleep false >/dev/null 2>&1 || true
     /bin/sleep 1
     pkill -x Kaji >/dev/null 2>&1 || true
@@ -121,6 +146,11 @@ EXPECTED_DRIVER_HASH="$(cat /Applications/KajiVMTestDriver.app/Contents/Resource
 CURRENT_DRIVER_HASH="$(shasum -a 256 "$SOURCE/scripts/vm-ui-driver.swift" | cut -d ' ' -f 1)"
 [[ "$EXPECTED_DRIVER_HASH" == "$CURRENT_DRIVER_HASH" ]] || fail "base VM driver is stale; rerun vm-system-test.sh bootstrap"
 
+phase "INSTALL copying app into guest"
+sudo launchctl bootout system/dev.kaji.sleep-helper >/dev/null 2>&1 || true
+sudo rm -f /Library/PrivilegedHelperTools/dev.kaji.sleep-helper \
+    /Library/LaunchDaemons/dev.kaji.sleep-helper.plist
+sudo pmset -a disablesleep 0
 pkill -x Kaji >/dev/null 2>&1 || true
 sudo rm -rf /Applications/Kaji.app
 sudo ditto "$SOURCE/dist/Kaji.app" /Applications/Kaji.app
@@ -128,38 +158,23 @@ sudo xattr -dr com.apple.quarantine /Applications/Kaji.app 2>/dev/null || true
 codesign --verify --deep --strict /Applications/Kaji.app
 
 launch_kaji initial
-print "initial_busy=$(state_value sleep.busy)" >"$ARTIFACTS/state-values.log"
+print "initial_busy=$(state_value sleep.busy)" >>"$ARTIFACTS/state-values.log"
 
 print 'ASSERT launch: PASS installed app is running' | tee "$ARTIFACTS/assertions.log"
+phase "FIRST ENABLE installing helper with administrator authorization"
 action set-prevent-sleep true
-for _ in {1..12}; do
-    if handle_authorization_if_present; then break; fi
-    /bin/sleep 0.25
-done
+authorize_with_wait || fail "initial helper install did not present an automatable administrator prompt"
 wait_for_value sleep.busy false
 GUIDANCE="$(state_value sleep.guidance 2>/dev/null || true)"
-
-if [[ "$GUIDANCE" == "approval" ]]; then
-    action perform-sleep-guidance
-    /bin/sleep 2
-    "$DRIVER" dump com.apple.systempreferences >"$ARTIFACTS/system-settings-before.ax.txt"
-    "$DRIVER" press-near-label com.apple.systempreferences Kaji 15
-    handle_authorization_if_present || true
-    /bin/sleep 1
-    open -a Kaji
-    wait_for_not_value sleep.guidance approval
-    wait_for_value sleep.busy false
-    "$DRIVER" dump com.apple.systempreferences >"$ARTIFACTS/system-settings-after.ax.txt" 2>&1 || true
-elif [[ "$GUIDANCE" == "repair" ]]; then
-    action perform-sleep-guidance
-    wait_for_value sleep.busy false
-fi
+[[ -z "$GUIDANCE" ]] || fail "initial helper install left unexpected guidance: $GUIDANCE"
 
 wait_for_value sleep.enabled true
+[[ "$AUTHORIZATION_COUNT" == "1" ]] || fail "initial helper install should request one administrator authorization"
 print 'ASSERT first-enable: PASS helper enabled without a crash' | tee -a "$ARTIFACTS/assertions.log"
 launchctl print system/dev.kaji.sleep-helper >"$ARTIFACTS/helper.launchctl.txt" 2>&1 || true
 pmset -g custom >"$ARTIFACTS/pmset-enabled.txt"
 
+phase "NORMAL TOGGLES reusing installed helper without authorization"
 action set-prevent-sleep false
 wait_for_value sleep.enabled false
 print 'ASSERT disable: PASS helper command completed' | tee -a "$ARTIFACTS/assertions.log"
@@ -169,12 +184,13 @@ wait_for_value sleep.busy false
 wait_for_value sleep.enabled true
 [[ "$(state_value sleep.guidancePresented)" == "false" ]] || fail "second enable requested guidance again"
 print 'ASSERT second-enable: PASS no second authorization guidance' | tee -a "$ARTIFACTS/assertions.log"
+[[ "$AUTHORIZATION_COUNT" == "1" ]] || fail "normal toggles requested another administrator authorization"
 
 action set-prevent-sleep false
 wait_for_value sleep.enabled false
 
-kill "$KAJI_PID"
-wait "$KAJI_PID" 2>/dev/null || true
+phase "UPDATE forcing bundled helper mismatch"
+pkill -x Kaji
 /bin/sleep 1
 sudo codesign --force --sign - --identifier dev.kaji.sleep-helper.vm-reinstall \
     /Applications/Kaji.app/Contents/Library/HelperTools/KajiSleepHelper
@@ -182,20 +198,23 @@ sudo codesign --force --sign - /Applications/Kaji.app
 codesign --verify --deep --strict /Applications/Kaji.app
 launch_kaji reinstalled
 
+phase "REPAIR reinstalling helper with administrator authorization"
 action set-prevent-sleep true
 wait_for_value sleep.busy false
 [[ "$(state_value sleep.guidance)" == "repair" ]] || fail "stale registered helper did not request repair"
 print 'ASSERT stale-helper: PASS reinstall requests repair instead of crashing' | tee -a "$ARTIFACTS/assertions.log"
 action perform-sleep-guidance
+authorize_with_wait || fail "helper repair did not present an automatable administrator prompt"
 wait_for_value sleep.busy false
 wait_for_value sleep.enabled true
-[[ "$(state_value sleep.guidancePresented)" == "false" ]] || fail "helper repair requested another approval"
-print 'ASSERT repair: PASS helper repaired without another approval' | tee -a "$ARTIFACTS/assertions.log"
+[[ "$(state_value sleep.guidancePresented)" == "false" ]] || fail "helper repair remained unresolved"
+print 'ASSERT repair: PASS helper repaired after one explicit update authorization' | tee -a "$ARTIFACTS/assertions.log"
 
 action set-prevent-sleep false
 wait_for_value sleep.enabled false
 pmset -g custom >"$ARTIFACTS/pmset-restored.txt"
-print \"authorization_count=$AUTHORIZATION_COUNT\" >\"$ARTIFACTS/authorization-count.txt\"
-[[ "$AUTHORIZATION_COUNT" -le 1 ]] || fail "authorization appeared more than once"
+print "authorization_count=$AUTHORIZATION_COUNT" >"$ARTIFACTS/authorization-count.txt"
+[[ "$AUTHORIZATION_COUNT" == "2" ]] || fail "journey should authorize once for install and once for forced helper update"
 print 'ASSERT restored: PASS Prevent Sleep is off after the journey' | tee -a "$ARTIFACTS/assertions.log"
+phase "PASS full guest journey complete"
 state

--- a/scripts/vm-system-guest.sh
+++ b/scripts/vm-system-guest.sh
@@ -1,0 +1,201 @@
+#!/bin/zsh
+set -euo pipefail
+
+SOURCE="/Volumes/My Shared Files/kaji-source"
+ARTIFACTS="/Volumes/My Shared Files/kaji-artifacts"
+DRIVER="/Applications/KajiVMTestDriver.app/Contents/MacOS/KajiVMTestDriver"
+NONCE="$(uuidgen)-$(uuidgen)"
+PORT=37842
+BASE_URL="http://127.0.0.1:$PORT/v1"
+STATE_FILE="$ARTIFACTS/state.json"
+
+AUTHORIZATION_COUNT=0
+fail() {
+    print -u2 "VM-SYSTEM FAIL: $*"
+    exit 1
+}
+
+state() {
+    local temporary="${STATE_FILE}.tmp"
+    if curl --silent --show-error "$BASE_URL/state" >"$temporary"; then
+        /bin/mv "$temporary" "$STATE_FILE"
+    else
+        /bin/rm -f "$temporary"
+        return 1
+    fi
+}
+
+state_value() {
+    state
+    local value
+    value="$(/usr/bin/plutil -extract "$1" raw -o - "$STATE_FILE" 2>>"$ARTIFACTS/state-value-errors.log")"
+    case "$value" in
+        0) print false ;;
+        1) print true ;;
+        *) print -r -- "$value" ;;
+    esac
+}
+
+action() {
+    local name="$1"
+    local target="${2:-}"
+    local body
+    if [[ -n "$target" ]]; then
+        body="{\"nonce\":\"$NONCE\",\"action\":\"$name\",\"target\":$target}"
+    else
+        body="{\"nonce\":\"$NONCE\",\"action\":\"$name\"}"
+    fi
+    curl --silent --show-error --fail \
+        -H 'Content-Type: application/json' \
+        -d "$body" "$BASE_URL/test/action" >>"$ARTIFACTS/actions.jsonl"
+    print >>"$ARTIFACTS/actions.jsonl"
+}
+
+wait_for_value() {
+    local path="$1"
+    local expected="$2"
+    for _ in {1..200}; do
+        if [[ "$(state_value "$path" 2>/dev/null || true)" == "$expected" ]]; then return 0; fi
+        /bin/sleep 0.1
+    done
+    fail "timed out waiting for $path=$expected"
+}
+
+wait_for_not_value() {
+    local path="$1"
+    local unwanted="$2"
+    for _ in {1..200}; do
+        if [[ "$(state_value "$path" 2>/dev/null || true)" != "$unwanted" ]]; then return 0; fi
+        /bin/sleep 0.1
+    done
+    fail "timed out waiting for $path to change from $unwanted"
+}
+
+launch_kaji() {
+    local suffix="${1:-initial}"
+    /usr/bin/env \
+        KAJI_UI_SMOKE_NONCE="$NONCE" \
+        KAJI_UI_SMOKE_PORT="$PORT" \
+        KAJI_UI_SMOKE_ARTIFACTS="$ARTIFACTS" \
+        /Applications/Kaji.app/Contents/MacOS/Kaji \
+        >"$ARTIFACTS/kaji-$suffix.stdout.log" 2>"$ARTIFACTS/kaji-$suffix.stderr.log" &
+    KAJI_PID=$!
+    for _ in {1..200}; do
+        if curl --silent --fail "$BASE_URL/state" >"$STATE_FILE"; then break; fi
+        kill -0 "$KAJI_PID" 2>/dev/null || fail "Kaji exited during $suffix launch"
+        /bin/sleep 0.1
+    done
+    kill -0 "$KAJI_PID" 2>/dev/null || fail "Kaji is not running after $suffix launch"
+}
+
+handle_authorization_if_present() {
+    local app
+    for app in com.apple.SecurityAgent SecurityAgent com.apple.systempreferences; do
+        if "$DRIVER" set-subrole-value "$app" AXSecureTextField admin 0.25 >/dev/null 2>&1; then
+            "$DRIVER" dump "$app" >"$ARTIFACTS/authorization-$AUTHORIZATION_COUNT.ax.txt" 2>&1 || true
+            if ! "$DRIVER" press-label "$app" Unlock 2 >/dev/null 2>&1 \
+                && ! "$DRIVER" press-label "$app" OK 2 >/dev/null 2>&1 \
+                && ! "$DRIVER" press-label "$app" Allow 2 >/dev/null 2>&1; then
+                fail "authorization password field appeared without a semantic confirmation button"
+            fi
+            AUTHORIZATION_COUNT=$((AUTHORIZATION_COUNT + 1))
+            return
+        fi
+    done
+    return 1
+}
+
+cleanup() {
+    /usr/bin/log show --last 10m --style compact \
+        --predicate 'process == "Kaji" OR process == "KajiSleepHelper" OR process == "backgroundtaskmanagementd"' \
+        >"$ARTIFACTS/system.log" 2>&1 || true
+    action set-prevent-sleep false >/dev/null 2>&1 || true
+    /bin/sleep 1
+    pkill -x Kaji >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+[[ -x "$DRIVER" ]] || fail "base VM is not bootstrapped with KajiVMTestDriver"
+[[ "$($DRIVER trusted)" == "true" ]] || fail "KajiVMTestDriver lacks Accessibility permission"
+EXPECTED_DRIVER_HASH="$(cat /Applications/KajiVMTestDriver.app/Contents/Resources/source.sha256)"
+CURRENT_DRIVER_HASH="$(shasum -a 256 "$SOURCE/scripts/vm-ui-driver.swift" | cut -d ' ' -f 1)"
+[[ "$EXPECTED_DRIVER_HASH" == "$CURRENT_DRIVER_HASH" ]] || fail "base VM driver is stale; rerun vm-system-test.sh bootstrap"
+
+pkill -x Kaji >/dev/null 2>&1 || true
+sudo rm -rf /Applications/Kaji.app
+sudo ditto "$SOURCE/dist/Kaji.app" /Applications/Kaji.app
+sudo xattr -dr com.apple.quarantine /Applications/Kaji.app 2>/dev/null || true
+codesign --verify --deep --strict /Applications/Kaji.app
+
+launch_kaji initial
+print "initial_busy=$(state_value sleep.busy)" >"$ARTIFACTS/state-values.log"
+
+print 'ASSERT launch: PASS installed app is running' | tee "$ARTIFACTS/assertions.log"
+action set-prevent-sleep true
+for _ in {1..12}; do
+    if handle_authorization_if_present; then break; fi
+    /bin/sleep 0.25
+done
+wait_for_value sleep.busy false
+GUIDANCE="$(state_value sleep.guidance 2>/dev/null || true)"
+
+if [[ "$GUIDANCE" == "approval" ]]; then
+    action perform-sleep-guidance
+    /bin/sleep 2
+    "$DRIVER" dump com.apple.systempreferences >"$ARTIFACTS/system-settings-before.ax.txt"
+    "$DRIVER" press-near-label com.apple.systempreferences Kaji 15
+    handle_authorization_if_present || true
+    /bin/sleep 1
+    open -a Kaji
+    wait_for_not_value sleep.guidance approval
+    wait_for_value sleep.busy false
+    "$DRIVER" dump com.apple.systempreferences >"$ARTIFACTS/system-settings-after.ax.txt" 2>&1 || true
+elif [[ "$GUIDANCE" == "repair" ]]; then
+    action perform-sleep-guidance
+    wait_for_value sleep.busy false
+fi
+
+wait_for_value sleep.enabled true
+print 'ASSERT first-enable: PASS helper enabled without a crash' | tee -a "$ARTIFACTS/assertions.log"
+launchctl print system/dev.kaji.sleep-helper >"$ARTIFACTS/helper.launchctl.txt" 2>&1 || true
+pmset -g custom >"$ARTIFACTS/pmset-enabled.txt"
+
+action set-prevent-sleep false
+wait_for_value sleep.enabled false
+print 'ASSERT disable: PASS helper command completed' | tee -a "$ARTIFACTS/assertions.log"
+
+action set-prevent-sleep true
+wait_for_value sleep.busy false
+wait_for_value sleep.enabled true
+[[ "$(state_value sleep.guidancePresented)" == "false" ]] || fail "second enable requested guidance again"
+print 'ASSERT second-enable: PASS no second authorization guidance' | tee -a "$ARTIFACTS/assertions.log"
+
+action set-prevent-sleep false
+wait_for_value sleep.enabled false
+
+kill "$KAJI_PID"
+wait "$KAJI_PID" 2>/dev/null || true
+/bin/sleep 1
+sudo codesign --force --sign - --identifier dev.kaji.sleep-helper.vm-reinstall \
+    /Applications/Kaji.app/Contents/Library/HelperTools/KajiSleepHelper
+sudo codesign --force --sign - /Applications/Kaji.app
+codesign --verify --deep --strict /Applications/Kaji.app
+launch_kaji reinstalled
+
+action set-prevent-sleep true
+wait_for_value sleep.busy false
+[[ "$(state_value sleep.guidance)" == "repair" ]] || fail "stale registered helper did not request repair"
+print 'ASSERT stale-helper: PASS reinstall requests repair instead of crashing' | tee -a "$ARTIFACTS/assertions.log"
+action perform-sleep-guidance
+wait_for_value sleep.busy false
+wait_for_value sleep.enabled true
+[[ "$(state_value sleep.guidancePresented)" == "false" ]] || fail "helper repair requested another approval"
+print 'ASSERT repair: PASS helper repaired without another approval' | tee -a "$ARTIFACTS/assertions.log"
+
+action set-prevent-sleep false
+wait_for_value sleep.enabled false
+pmset -g custom >"$ARTIFACTS/pmset-restored.txt"
+print \"authorization_count=$AUTHORIZATION_COUNT\" >\"$ARTIFACTS/authorization-count.txt\"
+[[ "$AUTHORIZATION_COUNT" -le 1 ]] || fail "authorization appeared more than once"
+print 'ASSERT restored: PASS Prevent Sleep is off after the journey' | tee -a "$ARTIFACTS/assertions.log"
+state

--- a/scripts/vm-system-test.sh
+++ b/scripts/vm-system-test.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="${KAJI_TART_BASE:-kaji-system-base}"
+MODE="${1:-run}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+VM="kaji-system-$RUN_ID"
+ARTIFACTS="${KAJI_VM_ARTIFACTS:-$HOME/.dev/kaji/runs/vm-system/$RUN_ID}"
+DRIVER_BUILD="$ROOT/.build/vm-system-driver/KajiVMTestDriver.app"
+RUN_PROCESS=""
+KEEP_FAILURE="${KAJI_VM_KEEP_FAILURE:-0}"
+FAILED=1
+
+
+build_driver() {
+    rm -rf "$DRIVER_BUILD"
+    mkdir -p "$DRIVER_BUILD/Contents/MacOS" "$DRIVER_BUILD/Contents/Resources"
+    xcrun swiftc "$ROOT/scripts/vm-ui-driver.swift" -o "$DRIVER_BUILD/Contents/MacOS/KajiVMTestDriver"
+    shasum -a 256 "$ROOT/scripts/vm-ui-driver.swift" | cut -d ' ' -f 1 \
+        >"$DRIVER_BUILD/Contents/Resources/source.sha256"
+    cat >"$DRIVER_BUILD/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>KajiVMTestDriver</string>
+  <key>CFBundleIdentifier</key><string>dev.kaji.vm-test-driver</string>
+  <key>CFBundleName</key><string>KajiVMTestDriver</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSUIElement</key><true/>
+</dict></plist>
+PLIST
+    codesign --force --deep --sign - "$DRIVER_BUILD" >/dev/null
+}
+
+wait_for_guest() {
+    for _ in $(seq 1 180); do
+        if tart exec "$1" /usr/bin/true >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "VM-SYSTEM FAIL: guest agent did not become ready" >&2
+    return 1
+}
+
+
+wait_for_gui() {
+    for _ in $(seq 1 180); do
+        if tart exec "$1" /usr/bin/pgrep -x Finder >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "VM-SYSTEM FAIL: guest GUI session did not become ready" >&2
+    return 1
+}
+start_vm() {
+    local name="$1"
+    shift
+    tart run --no-audio --no-clipboard "$@" "$name" >"$ARTIFACTS/tart.log" 2>&1 &
+    RUN_PROCESS=$!
+    wait_for_guest "$name"
+    wait_for_gui "$name"
+}
+
+stop_running_vm() {
+    local name="$1"
+    tart stop "$name" >/dev/null 2>&1 || true
+    if [[ -n "$RUN_PROCESS" ]]; then
+        wait "$RUN_PROCESS" >/dev/null 2>&1 || true
+        RUN_PROCESS=""
+    fi
+}
+
+cleanup() {
+    stop_running_vm "$VM"
+    if [[ "$MODE" == "run" ]]; then
+        if [[ "$FAILED" == "1" && "$KEEP_FAILURE" == "1" ]]; then
+            printf 'VM-SYSTEM retained failed clone: %s\n' "$VM" >&2
+        else
+            tart delete "$VM" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$ARTIFACTS"
+printf '%s\n' "run_id=$RUN_ID" "base=$BASE" "mode=$MODE" >"$ARTIFACTS/run.env"
+tart get "$BASE" --format json >"$ARTIFACTS/base.json"
+build_driver
+
+case "$MODE" in
+bootstrap)
+    VM="$BASE"
+    start_vm "$BASE" \
+        --dir="kaji-driver:$ROOT/.build/vm-system-driver:ro"
+    tart exec "$BASE" /bin/zsh -lc \
+        'sudo rm -rf /Applications/KajiVMTestDriver.app && sudo ditto "/Volumes/My Shared Files/kaji-driver/KajiVMTestDriver.app" /Applications/KajiVMTestDriver.app'
+    tart exec "$BASE" /Applications/KajiVMTestDriver.app/Contents/MacOS/KajiVMTestDriver request-trust || true
+    echo "Grant KajiVMTestDriver Accessibility in the VM window; this one-time bootstrap is the only interactive step."
+    for _ in $(seq 1 300); do
+        if [[ "$(tart exec "$BASE" /Applications/KajiVMTestDriver.app/Contents/MacOS/KajiVMTestDriver trusted 2>/dev/null || true)" == "true" ]]; then
+            FAILED=0
+            tart exec "$BASE" /usr/bin/sudo /sbin/shutdown -h now >/dev/null 2>&1 || true
+            wait "$RUN_PROCESS" >/dev/null 2>&1 || true
+            RUN_PROCESS=""
+            echo "VM-SYSTEM bootstrap complete"
+            exit 0
+        fi
+        sleep 1
+    done
+    echo "VM-SYSTEM FAIL: Accessibility bootstrap timed out" >&2
+    exit 1
+    ;;
+run)
+    if [[ "${KAJI_CODESIGN_IDENTITY:--}" == "-" ]]; then
+        echo "VM-SYSTEM FAIL: Prevent Sleep requires a Team ID; set KAJI_CODESIGN_IDENTITY explicitly to a signing identity" >&2
+        exit 1
+    fi
+    "$ROOT/scripts/build-app.sh"
+    tart clone "$BASE" "$VM"
+    start_vm "$VM" --no-graphics --no-pointer --no-keyboard \
+        --dir="kaji-source:$ROOT:ro" \
+        --dir="kaji-artifacts:$ARTIFACTS"
+    VM_RSS_KB="$(ps -o rss= -p "$RUN_PROCESS" | tr -d ' ')"
+    printf 'vm_rss_kb=%s\n' "$VM_RSS_KB" >>"$ARTIFACTS/run.env"
+    tart exec "$VM" /bin/zsh "/Volumes/My Shared Files/kaji-source/scripts/vm-system-guest.sh"
+    FAILED=0
+    echo "VM-SYSTEM PASS: artifacts $ARTIFACTS"
+    ;;
+*)
+    echo "usage: $0 [bootstrap|run]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/vm-system-test.sh
+++ b/scripts/vm-system-test.sh
@@ -10,8 +10,12 @@ ARTIFACTS="${KAJI_VM_ARTIFACTS:-$HOME/.dev/kaji/runs/vm-system/$RUN_ID}"
 DRIVER_BUILD="$ROOT/.build/vm-system-driver/KajiVMTestDriver.app"
 RUN_PROCESS=""
 KEEP_FAILURE="${KAJI_VM_KEEP_FAILURE:-0}"
+KEEP_RUNNING="${KAJI_VM_KEEP_RUNNING:-0}"
 FAILED=1
 
+phase() {
+    printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"
+}
 
 build_driver() {
     rm -rf "$DRIVER_BUILD"
@@ -56,10 +60,13 @@ wait_for_gui() {
 start_vm() {
     local name="$1"
     shift
+    phase "BOOT starting $name"
     tart run --no-audio --no-clipboard "$@" "$name" >"$ARTIFACTS/tart.log" 2>&1 &
     RUN_PROCESS=$!
     wait_for_guest "$name"
+    phase "LOGIN guest agent ready; waiting for Finder"
     wait_for_gui "$name"
+    phase "LOGIN ready"
 }
 
 stop_running_vm() {
@@ -72,8 +79,15 @@ stop_running_vm() {
 }
 
 cleanup() {
+    if [[ "$FAILED" == "1" && "$KEEP_RUNNING" == "1" ]]; then
+        printf 'VM-SYSTEM retained running VM: %s\n' "$VM" >&2
+        printf 'VM-SYSTEM rerun: tart exec %s /bin/zsh \"/Volumes/My Shared Files/kaji-source/scripts/vm-system-guest.sh\"\n' "$VM" >&2
+        wait "$RUN_PROCESS" >/dev/null 2>&1 || true
+        return
+    fi
+    phase "CLEANUP stopping and removing ephemeral VM"
     stop_running_vm "$VM"
-    if [[ "$MODE" == "run" ]]; then
+    if [[ "$MODE" == "run" || "$MODE" == "run-visible" ]]; then
         if [[ "$FAILED" == "1" && "$KEEP_FAILURE" == "1" ]]; then
             printf 'VM-SYSTEM retained failed clone: %s\n' "$VM" >&2
         else
@@ -86,6 +100,7 @@ trap cleanup EXIT INT TERM
 mkdir -p "$ARTIFACTS"
 printf '%s\n' "run_id=$RUN_ID" "base=$BASE" "mode=$MODE" >"$ARTIFACTS/run.env"
 tart get "$BASE" --format json >"$ARTIFACTS/base.json"
+phase "PREPARE building VM UI driver"
 build_driver
 
 case "$MODE" in
@@ -111,24 +126,35 @@ bootstrap)
     echo "VM-SYSTEM FAIL: Accessibility bootstrap timed out" >&2
     exit 1
     ;;
-run)
-    if [[ "${KAJI_CODESIGN_IDENTITY:--}" == "-" ]]; then
-        echo "VM-SYSTEM FAIL: Prevent Sleep requires a Team ID; set KAJI_CODESIGN_IDENTITY explicitly to a signing identity" >&2
-        exit 1
-    fi
+run|run-visible)
+    phase "BUILD assembling Kaji.app"
     "$ROOT/scripts/build-app.sh"
+    phase "CLONE creating ephemeral VM from $BASE"
     tart clone "$BASE" "$VM"
-    start_vm "$VM" --no-graphics --no-pointer --no-keyboard \
-        --dir="kaji-source:$ROOT:ro" \
-        --dir="kaji-artifacts:$ARTIFACTS"
+    if [[ "$MODE" == "run-visible" ]]; then
+        phase "BOOT visible mode; Tart VM window will open"
+        start_vm "$VM" \
+            --dir="kaji-source:$ROOT:ro" \
+            --dir="kaji-artifacts:$ARTIFACTS"
+    else
+        start_vm "$VM" --no-graphics --no-pointer --no-keyboard \
+            --dir="kaji-source:$ROOT:ro" \
+            --dir="kaji-artifacts:$ARTIFACTS"
+    fi
     VM_RSS_KB="$(ps -o rss= -p "$RUN_PROCESS" | tr -d ' ')"
     printf 'vm_rss_kb=%s\n' "$VM_RSS_KB" >>"$ARTIFACTS/run.env"
-    tart exec "$VM" /bin/zsh "/Volumes/My Shared Files/kaji-source/scripts/vm-system-guest.sh"
+    phase "JOURNEY exercising install, normal toggles, and repair"
+    if [[ "$KEEP_RUNNING" == "1" ]]; then
+        tart exec "$VM" /usr/bin/env KAJI_VM_DEBUG_KEEP_APP=1 \
+            /bin/zsh "/Volumes/My Shared Files/kaji-source/scripts/vm-system-guest.sh"
+    else
+        tart exec "$VM" /bin/zsh "/Volumes/My Shared Files/kaji-source/scripts/vm-system-guest.sh"
+    fi
     FAILED=0
-    echo "VM-SYSTEM PASS: artifacts $ARTIFACTS"
+    phase "PASS journey complete; artifacts $ARTIFACTS"
     ;;
 *)
-    echo "usage: $0 [bootstrap|run]" >&2
+    echo "usage: $0 [bootstrap|run|run-visible]" >&2
     exit 2
     ;;
 esac

--- a/scripts/vm-ui-driver.swift
+++ b/scripts/vm-ui-driver.swift
@@ -1,0 +1,222 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+private enum DriverError: Error, CustomStringConvertible {
+    case usage
+    case accessibilityDenied
+    case applicationNotFound(String)
+    case elementNotFound(String)
+    case ambiguousElement(String, Int)
+    case actionFailed(AXError)
+
+    var description: String {
+        switch self {
+        case .usage:
+            "usage: vm-ui-driver trusted | request-trust | dump <bundle-id> | press-id <bundle-id> <identifier> [timeout] | press-label <bundle-id> <label> [timeout] | press-near-label <bundle-id> <label> [timeout] | set-subrole-value <bundle-id> <subrole> <value> [timeout] | count-label <bundle-id> <label>"
+        case .accessibilityDenied:
+            "Accessibility permission is not granted to KajiVMTestDriver"
+        case .applicationNotFound(let identifier):
+            "application is not running: \(identifier)"
+        case .elementNotFound(let query):
+            "accessible element not found: \(query)"
+        case .ambiguousElement(let query, let count):
+            "accessible query is ambiguous: \(query) matched \(count) controls"
+        case .actionFailed(let error):
+            "AXPress failed: \(error.rawValue)"
+        }
+    }
+}
+
+private struct ElementDescription {
+    let role: String
+    let subrole: String
+    let identifier: String
+    let label: String
+
+    var line: String { "\(role)\t\(subrole)\t\(identifier)\t\(label)" }
+}
+
+private func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return nil
+    }
+    if let string = value as? String { return string }
+    if let number = value as? NSNumber { return number.stringValue }
+    return nil
+}
+
+private func children(of element: AXUIElement) -> [AXUIElement] {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value) == .success,
+          let children = value as? [AXUIElement] else {
+        return []
+    }
+    return children
+}
+
+private func parent(of element: AXUIElement) -> AXUIElement? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXParentAttribute as CFString, &value) == .success,
+          let value else { return nil }
+    return unsafeDowncast(value, to: AXUIElement.self)
+}
+
+private func supportsPress(_ element: AXUIElement) -> Bool {
+    var actions: CFArray?
+    guard AXUIElementCopyActionNames(element, &actions) == .success,
+          let names = actions as? [String] else { return false }
+    return names.contains(kAXPressAction)
+}
+
+private func describe(_ element: AXUIElement) -> ElementDescription {
+    let role = stringAttribute(element, kAXRoleAttribute) ?? ""
+    let subrole = stringAttribute(element, kAXSubroleAttribute) ?? ""
+    let identifier = stringAttribute(element, kAXIdentifierAttribute) ?? ""
+    let label = stringAttribute(element, kAXTitleAttribute)
+        ?? stringAttribute(element, kAXDescriptionAttribute)
+        ?? stringAttribute(element, kAXValueAttribute)
+        ?? ""
+    return ElementDescription(role: role, subrole: subrole, identifier: identifier, label: label)
+}
+
+private func walk(_ root: AXUIElement, visit: (AXUIElement, ElementDescription) -> Bool) -> AXUIElement? {
+    var queue = [root]
+    var seen = Set<CFHashCode>()
+    var index = 0
+    while index < queue.count, queue.count < 20_000 {
+        let element = queue[index]
+        index += 1
+        guard seen.insert(CFHash(element)).inserted else { continue }
+        if visit(element, describe(element)) { return element }
+        queue.append(contentsOf: children(of: element))
+    }
+    return nil
+}
+
+private func applicationRoot(_ identifier: String) throws -> AXUIElement {
+    let app = NSWorkspace.shared.runningApplications.first {
+        $0.bundleIdentifier == identifier || $0.localizedName == identifier
+    }
+    guard let app else { throw DriverError.applicationNotFound(identifier) }
+    return AXUIElementCreateApplication(app.processIdentifier)
+}
+
+private func matchingElement(
+    application identifier: String,
+    timeout: TimeInterval,
+    matches: (ElementDescription) -> Bool
+) throws -> AXUIElement {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+        let root = try applicationRoot(identifier)
+        if let element = walk(root, visit: { _, description in matches(description) }) {
+            return element
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+    } while Date() < deadline
+    throw DriverError.elementNotFound(identifier)
+}
+
+private func requireAccessibility() throws {
+    guard AXIsProcessTrusted() else { throw DriverError.accessibilityDenied }
+}
+
+private func run() throws {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    guard let command = arguments.first else { throw DriverError.usage }
+    if command == "request-trust" {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        print(AXIsProcessTrustedWithOptions(options) ? "true" : "false")
+        return
+    }
+    if command == "trusted" {
+        print(AXIsProcessTrusted() ? "true" : "false")
+        return
+    }
+    try requireAccessibility()
+
+    switch command {
+    case "dump":
+        guard arguments.count == 2 else { throw DriverError.usage }
+        let root = try applicationRoot(arguments[1])
+        _ = walk(root) { _, description in
+            if !description.role.isEmpty || !description.identifier.isEmpty || !description.label.isEmpty {
+                print(description.line)
+            }
+            return false
+        }
+    case "press-id", "press-label":
+        guard arguments.count == 3 || arguments.count == 4 else { throw DriverError.usage }
+        let timeout = arguments.count == 4 ? TimeInterval(arguments[3]) ?? 10 : 10
+        let query = arguments[2]
+        let element = try matchingElement(application: arguments[1], timeout: timeout) { description in
+            command == "press-id" ? description.identifier == query : description.label == query
+        }
+        let result = AXUIElementPerformAction(element, kAXPressAction as CFString)
+        guard result == .success else { throw DriverError.actionFailed(result) }
+    case "press-near-label":
+        guard arguments.count == 3 || arguments.count == 4 else { throw DriverError.usage }
+        let timeout = arguments.count == 4 ? TimeInterval(arguments[3]) ?? 10 : 10
+        let query = arguments[2]
+        let label = try matchingElement(application: arguments[1], timeout: timeout) {
+            $0.label == query
+        }
+        var ancestor = parent(of: label)
+        var largestCandidateCount = 0
+        for _ in 0..<6 {
+            guard let current = ancestor else { break }
+            var candidates: [AXUIElement] = []
+            _ = walk(current) { element, description in
+                let controlRoles = [kAXCheckBoxRole, kAXRadioButtonRole, kAXButtonRole, "AXSwitch"]
+                if controlRoles.contains(description.role), supportsPress(element) {
+                    candidates.append(element)
+                }
+                return false
+            }
+            largestCandidateCount = max(largestCandidateCount, candidates.count)
+            if candidates.count == 1 {
+                let result = AXUIElementPerformAction(candidates[0], kAXPressAction as CFString)
+                guard result == .success else { throw DriverError.actionFailed(result) }
+                return
+            }
+            ancestor = parent(of: current)
+        }
+        if largestCandidateCount > 1 {
+            throw DriverError.ambiguousElement(query, largestCandidateCount)
+        }
+        throw DriverError.elementNotFound(query)
+    case "set-subrole-value":
+        guard arguments.count == 4 || arguments.count == 5 else { throw DriverError.usage }
+        let timeout = arguments.count == 5 ? TimeInterval(arguments[4]) ?? 10 : 10
+        let subrole = arguments[2]
+        let element = try matchingElement(application: arguments[1], timeout: timeout) {
+            $0.subrole == subrole
+        }
+        let result = AXUIElementSetAttributeValue(
+            element,
+            kAXValueAttribute as CFString,
+            arguments[3] as CFString
+        )
+        guard result == .success else { throw DriverError.actionFailed(result) }
+    case "count-label":
+        guard arguments.count == 3 else { throw DriverError.usage }
+        let root = try applicationRoot(arguments[1])
+        var count = 0
+        _ = walk(root) { _, description in
+            if description.label == arguments[2] { count += 1 }
+            return false
+        }
+        print(count)
+    default:
+        throw DriverError.usage
+    }
+}
+
+do {
+    try run()
+} catch {
+    fputs("vm-ui-driver: \(error)\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## What
- remove the XPC completion actor-isolation crash
- retain and resume approval/repair intent without repeated registration
- add semantic accessibility identifiers and a nonce-gated test action surface
- add a disposable Tart VM system-test runner with a 2 CPU / 4 GiB base

## Verification
- `swift test`: 205 tests passed
- release app build passed with ad-hoc signing
- VM bootstrap persisted and subsequent runs stayed headless (`--no-graphics --no-pointer --no-keyboard`)
- disposable clones were removed after every run

## Signing prerequisite found by clean VM
The complete Prevent Sleep journey requires a real Team ID. macOS Tahoe rejects the locally ad-hoc signed SMAppService daemon (`Bundle identifiers ... ignored because the executable doesn't have a Team ID`). The runner now fails early unless `KAJI_CODESIGN_IDENTITY` is explicitly supplied, matching the repository signing policy.