### PR TITLE
feat(exposure): menu bar exposure experiment — single entry + Primary/More

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -62,6 +62,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let aiNewsStore: AIHotNewsStore
     private let mailBriefStore: MailBriefStore
     private let launchdJobStore = LaunchdJobStore()
+    private let exposureStudy: ExposureStudyStore
     private var breakWindows: [NSWindow] = []
     private var breakWatchdogTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
@@ -81,12 +82,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mailBriefStore = MailBriefStore(
             cacheURL: cacheDirectory?.appendingPathComponent("mail-brief-cache-v1.json")
         )
+        exposureStudy = ExposureStudyStore(
+            fileURL: cacheDirectory?.appendingPathComponent("exposure-study-v1.json")
+        )
         super.init()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Establish the visible app surface before any optional module can probe
         // credentials. A stale keychain ACL must never prevent the status item.
+        exposureStudy.startIfNeeded()
         setupStatusItem()
         setupPopover()
 
@@ -125,6 +130,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.updateStatusItem()
                 self?.rebuildPopoverContentIfShown()
             }
+            .store(in: &cancellables)
+        prefs.$primaryFavorites
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.rebuildExposureSurfaces() }
+            .store(in: &cancellables)
+        prefs.$showsWorkCompactSignal
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateStatusItem() }
+            .store(in: &cancellables)
+        exposureStudy.didChangePhase
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.rebuildExposureSurfaces() }
             .store(in: &cancellables)
         prefs.$aiNewsRefreshHours
             .removeDuplicates()
@@ -285,12 +302,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let view = StatusItemView(providers: visibleProviders,
                                   showRemaining: prefs.showRemaining,
                                   updateAvailable: updateChecker.available != nil,
-                                  workSlotLabel: workStatusSlotLabel,
-                                  goalsSlotLabel: goalsStatusSlotLabel,
-                                  showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
-                                  mailBriefSlotLabel: MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount),
-                                  showsMailBriefSlot: prefs.isModuleEnabled(.mailBrief),
-                                  launchdStatus: launchdStatus,
+                                  workSlotLabel: presentedWorkSlotLabel,
+                                  goalsSlotLabel: usesLegacyExposure ? goalsStatusSlotLabel : nil,
+                                  showsAINewsSlot: usesLegacyExposure && prefs.isModuleEnabled(.aiNews),
+                                  mailBriefSlotLabel: usesLegacyExposure ? MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount) : nil,
+                                  showsMailBriefSlot: usesLegacyExposure && prefs.isModuleEnabled(.mailBrief),
+                                  launchdStatus: usesLegacyExposure ? launchdStatus : nil,
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
                                   onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
@@ -313,12 +330,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hostingView?.rootView = StatusItemView(providers: visibleProviders,
                                                showRemaining: prefs.showRemaining,
                                                updateAvailable: updateChecker.available != nil,
-                                               workSlotLabel: workStatusSlotLabel,
-                                               goalsSlotLabel: goalsStatusSlotLabel,
-                                               showsAINewsSlot: prefs.isModuleEnabled(.aiNews),
-                                               mailBriefSlotLabel: MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount),
-                                               showsMailBriefSlot: prefs.isModuleEnabled(.mailBrief),
-                                               launchdStatus: launchdStatus,
+                                               workSlotLabel: presentedWorkSlotLabel,
+                                               goalsSlotLabel: usesLegacyExposure ? goalsStatusSlotLabel : nil,
+                                               showsAINewsSlot: usesLegacyExposure && prefs.isModuleEnabled(.aiNews),
+                                               mailBriefSlotLabel: usesLegacyExposure ? MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount) : nil,
+                                               showsMailBriefSlot: usesLegacyExposure && prefs.isModuleEnabled(.mailBrief),
+                                               launchdStatus: usesLegacyExposure ? launchdStatus : nil,
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
                                                onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
@@ -326,6 +343,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                onMailBriefClick: { [weak self] in self?.showPopover(.mailBrief) },
                                                onLaunchdClick: { [weak self] in self?.showPopover(.launchd) })
         statusItem.length = statusItemLength
+    }
+
+    private var usesLegacyExposure: Bool { exposureStudy.phase.usesLegacyExposure }
+
+    private var presentedWorkSlotLabel: String? {
+        guard usesLegacyExposure || prefs.showsWorkCompactSignal else { return nil }
+        return workStatusSlotLabel
+    }
+
+    private func rebuildExposureSurfaces() {
+        updateStatusItem()
+        rebuildPopoverContentIfShown()
     }
 
     /// Menu-bar work countdown from `WorkStatusSlotModel` (nil when work off).
@@ -367,18 +396,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let count = max(1, min(4, visibleProviders.count))
         var length = CGFloat(count) * 26 + 6
         // Compact monospaced `MM:SS` to the right of the rings (~40pt).
-        if workStatusSlotLabel != nil {
+        if presentedWorkSlotLabel != nil {
             length += 40
         }
-        if let goalsStatusSlotLabel {
-            length += 20 + CGFloat(goalsStatusSlotLabel.count) * 7
-        }
-        if prefs.isModuleEnabled(.aiNews) { length += 20 }
-        if prefs.isModuleEnabled(.mailBrief) {
-            length += 22 + CGFloat(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: mailBriefStore.actCount)?.count ?? 0) * 7
-        }
-        if let launchdStatus {
-            length += 22 + CGFloat(String(launchdStatus.count).count) * 7
+        if usesLegacyExposure {
+            if let goalsStatusSlotLabel {
+                length += 20 + CGFloat(goalsStatusSlotLabel.count) * 7
+            }
+            if prefs.isModuleEnabled(.aiNews) { length += 20 }
+            if prefs.isModuleEnabled(.mailBrief) {
+                length += 22 + CGFloat(MenuBarSlotLogic.mailBriefLabel(enabled: true, actCount: mailBriefStore.actCount)?.count ?? 0) * 7
+            }
+            if let launchdStatus {
+                length += 22 + CGFloat(String(launchdStatus.count).count) * 7
+            }
         }
         return length
     }
@@ -409,6 +440,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             applyPopoverDestination(destination)
             return
         }
+        let openedModule = module(for: destination)
+        exposureStudy.record(.popoverOpen, module: openedModule, source: .statusItem)
+        exposureStudy.recordStatusWidth(Int(statusItemLength.rounded(.up)))
         popoverNavigation.launchdCategory = .userAgent
 
 
@@ -524,7 +558,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func module(for destination: MenuBarDestination) -> KajiModuleID {
+        switch destination {
+        case .quota: .quota
+        case .work: .work
+        case .goalsToday: .goals
+        case .aiNews: .aiNews
+        case .mailBrief: .mailBrief
+        case .launchd: .launchd
+        }
+    }
+
     private func makePopoverContentController(maxContentHeight: CGFloat? = nil) -> NSHostingController<AnyView> {
+
         let controls = KajiPopoverControls(
             onOpenSettings: { [weak self] in self?.openSettings() },
             onQuit: { NSApp.terminate(nil) },
@@ -547,6 +593,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                       maxContentHeight: maxContentHeight ?? maxPopoverHeight(on: statusItem.button?.window?.screen),
                                       onContentSizeChange: { [weak self] size in
                                           self?.resizePopoverContent(to: size)
+                                      },
+                                      exposurePhase: exposureStudy.phase,
+                                      onExposureEvent: { [weak self] event, module, source in
+                                          self?.exposureStudy.record(event, module: module, source: source)
                                       })
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         let controller = KajiHostingController(rootView: AnyView(content))
@@ -804,7 +854,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 sleepController: sleepController,
                 fixedPlanStore: fixedPlanStore,
                 mailBriefStore: mailBriefStore,
-                initialSection: section
+                initialSection: section,
+                exposurePhase: exposureStudy.phase,
+                onRollbackExposure: { [weak self] in self?.rollbackExposureExperiment() },
+                onClearExposureData: { [weak self] in self?.exposureStudy.clearAggregates() }
             ))
             view.configureKajiHost()
             view.frame = NSRect(x: 0, y: 0, width: 760, height: 560)
@@ -852,6 +905,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return NSNull()
     }
 
+    private func rollbackExposureExperiment() {
+        exposureStudy.rollback()
+        closeDetailPopover()
+        if popover.isShown { popover.performClose(nil) }
+        settingsWindow?.close()
+        settingsWindow = nil
+        rebuildExposureSurfaces()
+    }
+
     private func openSettings() {
         if let settingsWindow {
             settingsWindow.makeKeyAndOrderFront(nil)
@@ -859,10 +921,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let controller = KajiHostingController(rootView: SettingsView(prefs: prefs,
-                                                                       sleepController: sleepController,
-                                                                       fixedPlanStore: fixedPlanStore,
-                                                                       mailBriefStore: mailBriefStore))
+        let controller = KajiHostingController(rootView: SettingsView(
+            prefs: prefs,
+            sleepController: sleepController,
+            fixedPlanStore: fixedPlanStore,
+            mailBriefStore: mailBriefStore,
+            exposurePhase: exposureStudy.phase,
+            onRollbackExposure: { [weak self] in self?.rollbackExposureExperiment() },
+            onClearExposureData: { [weak self] in self?.exposureStudy.clearAggregates() }
+        ))
 
         controller.view.configureKajiHost()
         let window = NSWindow(contentViewController: controller)

--- a/Sources/Kaji/ExposureStudyStore.swift
+++ b/Sources/Kaji/ExposureStudyStore.swift
@@ -1,0 +1,129 @@
+import Combine
+import Foundation
+import KajiCore
+
+@MainActor
+final class ExposureStudyStore: ObservableObject {
+    typealias Clock = () -> Date
+
+    private(set) var record: ExposureStudyRecord
+
+    /// Emits ONLY when the experiment phase actually changes (progression,
+    /// completion, rollback), never on aggregate writes, so recording an
+    /// event cannot rebuild product surfaces as a side effect.
+    let didChangePhase: AnyPublisher<ExposureExperimentPhase, Never>
+
+    private let fileURL: URL
+    private let clock: Clock
+    private var phaseTimer: Timer?
+    private let didChangePhaseSubject = PassthroughSubject<ExposureExperimentPhase, Never>()
+    private var lastReportedPhase: ExposureExperimentPhase = .notStarted
+
+    init(fileURL: URL? = nil, clock: @escaping Clock = Date.init) {
+        self.clock = clock
+        self.fileURL = fileURL ?? Self.defaultFileURL()
+        record = Self.load(from: self.fileURL) ?? ExposureStudyRecord()
+        didChangePhase = didChangePhaseSubject.eraseToAnyPublisher()
+    }
+
+    var phase: ExposureExperimentPhase {
+        ExposureExperimentLogic.phase(state: record.experiment, now: clock())
+    }
+
+    func startIfNeeded() {
+        if record.experiment.startedAt == nil {
+            ExposureExperimentLogic.start(state: &record.experiment, now: clock())
+            persist()
+        }
+        startPhaseTimer()
+        reportPhaseIfChanged()
+    }
+
+    func rollback() {
+        ExposureExperimentLogic.rollback(state: &record.experiment, now: clock())
+        persist()
+        reportPhaseIfChanged()
+    }
+
+    func clearAggregates() {
+        record.days = []
+        persist()
+    }
+
+    func record(
+        _ event: ExposureStudyEvent,
+        module: KajiModuleID? = nil,
+        source: ExposureEntrySource? = nil,
+        statusWidth: Int? = nil
+    ) {
+        record.record(event: event, module: module, source: source, statusWidth: statusWidth, now: clock())
+        persist()
+    }
+
+    func recordStatusWidth(_ width: Int) {
+        record.recordStatusWidth(width, now: clock())
+        persist()
+    }
+
+    private func startPhaseTimer() {
+        guard phaseTimer == nil else { return }
+        phaseTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.reportPhaseIfChanged() }
+        }
+    }
+
+    private func reportPhaseIfChanged() {
+        let current = phase
+        guard current != lastReportedPhase else { return }
+        lastReportedPhase = current
+        didChangePhaseSubject.send(current)
+    }
+
+    private func persist() {
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder.studyEncoder.encode(record)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // The study must never make the product unavailable. A later event
+            // retries the same bounded aggregate write.
+        }
+    }
+
+    private static func load(from url: URL) -> ExposureStudyRecord? {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder.studyDecoder.decode(ExposureStudyRecord.self, from: data),
+              decoded.version == ExposureStudyRecord.currentVersion else { return nil }
+        return ExposureStudyRecord(
+            version: decoded.version,
+            experiment: decoded.experiment,
+            days: decoded.days
+        )
+    }
+
+    private static func defaultFileURL() -> URL {
+        let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return root.appendingPathComponent("Kaji", isDirectory: true)
+            .appendingPathComponent("exposure-study-v1.json")
+    }
+}
+
+private extension JSONEncoder {
+    static var studyEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var studyDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -88,6 +88,8 @@ struct KajiPopoverView: View {
     let controls: KajiPopoverControls
     let maxContentHeight: CGFloat
     let onContentSizeChange: ((CGSize) -> Void)?
+    var exposurePhase: ExposureExperimentPhase = .notStarted
+    var onExposureEvent: (ExposureStudyEvent, KajiModuleID?, ExposureEntrySource?) -> Void = { _, _, _ in }
     /// Offscreen snapshots (ImageRenderer) often paint ScrollView as empty —
     /// pass `false` for screenshot harnesses.
     var scrollsContent: Bool = true
@@ -115,6 +117,8 @@ struct KajiPopoverView: View {
     @State private var measuredTotalHeight: CGFloat = 0
     @State private var measuredScrollHeight: CGFloat = 0
     @FocusState private var noteFieldFocused: Bool
+    @State private var previousPanel: KajiModuleID?
+    @State private var previousPanelOpenedAt: Date?
     @Environment(\.colorScheme) private var scheme
 
     private var t: KajiTheme { .resolve(scheme) }
@@ -128,7 +132,13 @@ struct KajiPopoverView: View {
             measuredChrome: panelChromeHeight
         )
     }
-    private var pages: [KajiModuleID] { prefs.popoverModulePages }
+    private var pages: [KajiModuleID] {
+        ExposureExperimentLogic.visiblePopoverModules(
+            phase: exposurePhase,
+            enabled: prefs.enabledModules,
+            favorites: prefs.primaryFavorites
+        )
+    }
     private var panel: KajiModuleID {
         get { navigation.panel }
         nonmutating set { navigation.panel = newValue }
@@ -166,10 +176,19 @@ struct KajiPopoverView: View {
         .onChange(of: prefs.enabledModules) { _ in
             clampPanelToEnabledPages()
         }
-        .onChange(of: panel) { _ in
+        .onChange(of: panel) { newPanel in
             controls.onDismissDetail()
             noteHoverGeneration += 1
             dismissNoteCard()
+            let now = Date()
+            if previousPanel != nil,
+               previousPanel != newPanel,
+               let openedAt = previousPanelOpenedAt,
+               now.timeIntervalSince(openedAt) <= 5 {
+                onExposureEvent(.quickSwitch, newPanel, nil)
+            }
+            previousPanel = newPanel
+            previousPanelOpenedAt = now
         }
         .onChange(of: focusedGoalID) { newValue in
             if let previousFocusedGoalID,
@@ -228,7 +247,16 @@ struct KajiPopoverView: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
+    @ViewBuilder
     private var header: some View {
+        if exposurePhase == .treatment {
+            treatmentHeader
+        } else {
+            legacyHeader
+        }
+    }
+
+    private var legacyHeader: some View {
         HStack(spacing: 8) {
             if pages.count > 1 {
                 arrow("chevron.left") { move(-1) }
@@ -243,6 +271,43 @@ struct KajiPopoverView: View {
                 .foregroundColor(t.ash)
             if pages.count > 1 {
                 arrow("chevron.right") { move(1) }
+            }
+        }
+    }
+
+    private var treatmentHeader: some View {
+        HStack(spacing: 5) {
+            ForEach(pages, id: \.self) { module in
+                Button(moduleTitle(module)) {
+                    panel = module
+                    onExposureEvent(.popoverOpen, module, .primary)
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 10.5, weight: panel == module ? .bold : .semibold, design: .rounded))
+                .foregroundColor(panel == module ? t.cream : t.ash)
+                .accessibilityIdentifier("kaji.primary.\(module.rawValue)")
+            }
+            Spacer(minLength: 4)
+            let more = ExposureExperimentLogic.moreModules(
+                enabled: prefs.enabledModules,
+                favorites: prefs.primaryFavorites
+            )
+            if !more.isEmpty {
+                Menu {
+                    ForEach(more, id: \.self) { module in
+                        Button(moduleTitle(module)) {
+                            panel = module
+                            onExposureEvent(.popoverOpen, module, .more)
+                        }
+                    }
+                } label: {
+                    Text("More")
+                        .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .onTapGesture { onExposureEvent(.moreOpen, nil, nil) }
+                .accessibilityIdentifier("kaji.more")
             }
         }
     }
@@ -2011,8 +2076,10 @@ struct KajiPopoverView: View {
         .frame(height: 32)
     }
 
-    private var panelTitle: String {
-        switch panel {
+    private var panelTitle: String { moduleTitle(panel) }
+
+    private func moduleTitle(_ module: KajiModuleID) -> String {
+        switch module {
         case .quota: return "Quota"
         case .work: return "Work / Break"
         case .system: return "System"
@@ -2048,6 +2115,9 @@ struct KajiPopoverView: View {
     }
 
     private func clampPanelToEnabledPages() {
+        if exposurePhase == .treatment, prefs.enabledModules.contains(panel) {
+            return
+        }
         let list = pages
         if list.isEmpty {
             panel = .quota

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -28,6 +28,19 @@ final class Prefs: ObservableObject {
             defaults.set(raw, forKey: Key.enabledModules)
         }
     }
+    @Published var primaryFavorites: [KajiModuleID] {
+        didSet {
+            let normalized = ExposureExperimentLogic.normalizedFavorites(
+                primaryFavorites,
+                enabled: enabledModules
+            )
+            if normalized != primaryFavorites { primaryFavorites = normalized; return }
+            defaults.set(normalized.map(\.rawValue), forKey: Key.primaryFavorites)
+        }
+    }
+    @Published var showsWorkCompactSignal: Bool {
+        didSet { defaults.set(showsWorkCompactSignal, forKey: Key.showsWorkCompactSignal) }
+    }
     @Published var language: Lang {
         didSet { defaults.set(language.rawValue, forKey: Key.language) }
     }
@@ -98,6 +111,8 @@ final class Prefs: ObservableObject {
     enum Key {
         static let visibleProviders = "visibleProviders"
         static let enabledModules = "enabledModules"
+        static let primaryFavorites = "exposureExperimentPrimaryFavorites"
+        static let showsWorkCompactSignal = "exposureExperimentShowsWorkCompactSignal"
         static let language = "language"
         static let menubarStyle = "menubarStyle"
         static let showRemaining = "showRemaining"
@@ -126,7 +141,8 @@ final class Prefs: ObservableObject {
             allowBreakSkip, breakOverlayEnabled, visibleProvidersV2,
             visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep,
             aiNewsRefreshHours, mailBriefHour, mailBriefMinute,
-            mailBriefBatchSize, mailBriefConcurrency, mailBriefModel, goalGrouping
+            mailBriefBatchSize, mailBriefConcurrency, mailBriefModel, goalGrouping,
+            primaryFavorites, showsWorkCompactSignal
         ]
     }
 
@@ -159,13 +175,25 @@ final class Prefs: ObservableObject {
         d.set(true, forKey: Key.visibleProvidersV2)
 
         // lean-modules-v1: first time key is missing → slim default (quota only).
+        let normalizedEnabled: Set<KajiModuleID>
         if d.object(forKey: Key.enabledModules) == nil {
-            enabledModules = ModulePrefsLogic.slimDefault
+            normalizedEnabled = ModulePrefsLogic.slimDefault
             d.set(Array(ModulePrefsLogic.slimDefault.map(\.rawValue)), forKey: Key.enabledModules)
         } else {
             let raw = d.array(forKey: Key.enabledModules) as? [String]
-            enabledModules = ModulePrefsLogic.normalizeEnabledModules(raw)
+            normalizedEnabled = ModulePrefsLogic.normalizeEnabledModules(raw)
         }
+        enabledModules = normalizedEnabled
+
+        let savedFavorites = (d.array(forKey: Key.primaryFavorites) as? [String])?
+            .compactMap(KajiModuleID.init(rawValue:)) ?? [.goals, .work]
+        primaryFavorites = ExposureExperimentLogic.normalizedFavorites(
+            savedFavorites,
+            enabled: normalizedEnabled
+        )
+        showsWorkCompactSignal = d.object(forKey: Key.showsWorkCompactSignal) == nil
+            ? true
+            : d.bool(forKey: Key.showsWorkCompactSignal)
 
         let languageResolution = LanguagePrefsLogic.resolve(
             storedRawValue: d.string(forKey: Key.language),
@@ -262,6 +290,10 @@ final class Prefs: ObservableObject {
             next.remove(id)
         }
         enabledModules = ModulePrefsLogic.normalizeEnabledModules(Array(next.map(\.rawValue)))
+        primaryFavorites = ExposureExperimentLogic.normalizedFavorites(
+            primaryFavorites,
+            enabled: enabledModules
+        )
     }
 
     var popoverModulePages: [KajiModuleID] {

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -43,6 +43,9 @@ struct SettingsView: View {
     @ObservedObject var fixedPlanStore: FixedPlanStore
     @ObservedObject var mailBriefStore: MailBriefStore
     var onFixedPlanEditorChange: ((Bool) -> Void)? = nil
+    var exposurePhase: ExposureExperimentPhase
+    var onRollbackExposure: () -> Void
+    var onClearExposureData: () -> Void
 
     @State private var selectedScheduleID: UUID?
     @State private var selection: SettingsSection = .general
@@ -58,21 +61,41 @@ struct SettingsView: View {
         fixedPlanStore: FixedPlanStore,
         mailBriefStore: MailBriefStore,
         initialSection: SettingsSection = .general,
+        exposurePhase: ExposureExperimentPhase = .notStarted,
+        onRollbackExposure: @escaping () -> Void = {},
+        onClearExposureData: @escaping () -> Void = {},
         onFixedPlanEditorChange: ((Bool) -> Void)? = nil
     ) {
         self.prefs = prefs
         self.sleepController = sleepController
         self.fixedPlanStore = fixedPlanStore
         self.mailBriefStore = mailBriefStore
+        self.exposurePhase = exposurePhase
+        self.onRollbackExposure = onRollbackExposure
+        self.onClearExposureData = onClearExposureData
         self.onFixedPlanEditorChange = onFixedPlanEditorChange
         _selection = State(initialValue: initialSection)
     }
     @Environment(\.colorScheme) private var scheme
     private var t: KajiTheme { .resolve(scheme) }
 
+    private var visibleSections: [SettingsSection] {
+        guard exposurePhase == .treatment else { return SettingsSection.allCases }
+        return SettingsSection.allCases.filter { section in
+            switch section {
+            case .general, .modules, .quota, .cli, .permissions:
+                return true
+            case .work: return prefs.isModuleEnabled(.work)
+            case .goals: return prefs.isModuleEnabled(.goals)
+            case .aiNews: return prefs.isModuleEnabled(.aiNews)
+            case .mailBrief: return prefs.isModuleEnabled(.mailBrief)
+            }
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            List(SettingsSection.allCases, selection: $selection) { section in
+            List(visibleSections, selection: $selection) { section in
                 Label(section == .permissions ? L10n.t(.permissions, prefs.language) : section.rawValue,
                       systemImage: section.systemImage)
                     .tag(section)
@@ -110,6 +133,9 @@ struct SettingsView: View {
             .accessibilityIdentifier("kaji.sleep-helper.cancel")
         } message: {
             Text(sleepGuidanceMessage)
+        }
+        .onChange(of: prefs.enabledModules) { _ in
+            if !visibleSections.contains(selection) { selection = .modules }
         }
     }
 
@@ -187,6 +213,19 @@ struct SettingsView: View {
                         Text(L10n.t(.sleepRepairMessage, prefs.language))
                             .font(.system(size: 10.5, weight: .semibold, design: .rounded))
                             .foregroundColor(t.amber)
+                    }
+                }
+                if exposurePhase == .baseline || exposurePhase == .treatment {
+                    settingRow(title: "Exposure study") {
+                        Text(exposurePhase == .baseline ? "Baseline" : "Treatment")
+                            .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                            .foregroundColor(t.mute)
+                        Button("Roll back", action: onRollbackExposure)
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("kaji.exposure.rollback")
+                        Button("Clear data", action: onClearExposureData)
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("kaji.exposure.clear")
                     }
                 }
             }
@@ -528,7 +567,41 @@ struct SettingsView: View {
                 if !lockedOn { prefs.setModule(id, enabled: false) }
             }
             .disabled(lockedOn)
+            if exposurePhase == .treatment, id != .quota, on {
+                Button {
+                    togglePrimaryFavorite(id)
+                } label: {
+                    Image(systemName: prefs.primaryFavorites.contains(id) ? "star.fill" : "star")
+                }
+                .buttonStyle(.plain)
+                .help("Primary favorite")
+                .accessibilityIdentifier("kaji.module.\(id.rawValue).primary")
+            }
+            if exposurePhase == .treatment, id == .work, on {
+                Button {
+                    prefs.showsWorkCompactSignal.toggle()
+                } label: {
+                    Image(systemName: prefs.showsWorkCompactSignal ? "menubar.rectangle" : "rectangle")
+                }
+                .buttonStyle(.plain)
+                .help("Show compact Work signal")
+                .accessibilityIdentifier("kaji.module.work.status-signal")
+            }
         }
+    }
+
+    private func togglePrimaryFavorite(_ id: KajiModuleID) {
+        if let index = prefs.primaryFavorites.firstIndex(of: id) {
+            prefs.primaryFavorites.remove(at: index)
+            return
+        }
+        var favorites = prefs.primaryFavorites
+        if favorites.count == 2 { favorites.removeFirst() }
+        favorites.append(id)
+        prefs.primaryFavorites = ExposureExperimentLogic.normalizedFavorites(
+            favorites,
+            enabled: prefs.enabledModules
+        )
     }
 
     private var header: some View {

--- a/Sources/KajiCore/ExposureExperimentLogic.swift
+++ b/Sources/KajiCore/ExposureExperimentLogic.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+public enum ExposureExperimentPhase: String, Codable, Sendable {
+    case notStarted
+    case baseline
+    case treatment
+    case completed
+    case rolledBack
+
+    public var usesLegacyExposure: Bool {
+        self != .treatment
+    }
+}
+
+public struct ExposureExperimentState: Codable, Equatable, Sendable {
+    public var startedAt: Date?
+    public var rolledBackAt: Date?
+
+    public init(startedAt: Date? = nil, rolledBackAt: Date? = nil) {
+        self.startedAt = startedAt
+        self.rolledBackAt = rolledBackAt
+    }
+}
+
+public enum ExposureEntrySource: String, Codable, CaseIterable, Sendable {
+    case statusItem
+    case primary
+    case more
+    case cli
+}
+
+public enum ExposureExperimentLogic {
+    public static let baselineDuration: TimeInterval = 72 * 60 * 60
+    public static let treatmentDuration: TimeInterval = 14 * 24 * 60 * 60
+
+    public static func phase(state: ExposureExperimentState, now: Date) -> ExposureExperimentPhase {
+        guard let start = state.startedAt else { return .notStarted }
+        if let rollback = state.rolledBackAt, rollback <= now { return .rolledBack }
+        let elapsed = now.timeIntervalSince(start)
+        if elapsed < 0 || elapsed < baselineDuration { return .baseline }
+        if elapsed < baselineDuration + treatmentDuration { return .treatment }
+        return .completed
+    }
+
+    public static func start(state: inout ExposureExperimentState, now: Date) {
+        guard state.startedAt == nil else { return }
+        state.startedAt = now
+        state.rolledBackAt = nil
+    }
+
+    public static func rollback(state: inout ExposureExperimentState, now: Date) {
+        guard state.startedAt != nil, phase(state: state, now: now) != .completed else { return }
+        state.rolledBackAt = now
+    }
+
+    public static func normalizedFavorites(
+        _ favorites: [KajiModuleID],
+        enabled: Set<KajiModuleID>
+    ) -> [KajiModuleID] {
+        var seen = Set<KajiModuleID>()
+        return favorites.filter { module in
+            module != .quota && enabled.contains(module) && seen.insert(module).inserted
+        }.prefix(2).map { $0 }
+    }
+
+    public static func primaryModules(
+        enabled: Set<KajiModuleID>,
+        favorites: [KajiModuleID]
+    ) -> [KajiModuleID] {
+        [.quota] + normalizedFavorites(favorites, enabled: enabled)
+    }
+
+    public static func moreModules(
+        enabled: Set<KajiModuleID>,
+        favorites: [KajiModuleID]
+    ) -> [KajiModuleID] {
+        let primary = Set(primaryModules(enabled: enabled, favorites: favorites))
+        return KajiModuleID.stableOrder.filter { enabled.contains($0) && !primary.contains($0) }
+    }
+
+    public static func visiblePopoverModules(
+        phase: ExposureExperimentPhase,
+        enabled: Set<KajiModuleID>,
+        favorites: [KajiModuleID]
+    ) -> [KajiModuleID] {
+        if phase.usesLegacyExposure {
+            return ModulePrefsLogic.popoverPages(enabled: enabled)
+        }
+        return primaryModules(enabled: enabled, favorites: favorites)
+    }
+}

--- a/Sources/KajiCore/ExposureStudyRecord.swift
+++ b/Sources/KajiCore/ExposureStudyRecord.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public enum ExposureStudyEvent: String, Codable, CaseIterable, Sendable {
+    case popoverOpen
+    case quickSwitch
+    case moreOpen
+    case cantFind
+}
+
+public struct ExposureStudyDailyBucket: Codable, Equatable, Sendable {
+    public let dayStartUTC: Date
+    public var events: [ExposureStudyEvent: Int]
+    public var moduleEntries: [KajiModuleID: Int]
+    public var entriesBySource: [ExposureEntrySource: Int]
+    public var maximumStatusWidth: Int
+
+    public init(
+        dayStartUTC: Date,
+        events: [ExposureStudyEvent: Int] = [:],
+        moduleEntries: [KajiModuleID: Int] = [:],
+        entriesBySource: [ExposureEntrySource: Int] = [:],
+        maximumStatusWidth: Int = 0
+    ) {
+        self.dayStartUTC = dayStartUTC
+        self.events = events
+        self.moduleEntries = moduleEntries
+        self.entriesBySource = entriesBySource
+        self.maximumStatusWidth = maximumStatusWidth
+    }
+}
+
+public struct ExposureStudyRecord: Codable, Equatable, Sendable {
+    public static let currentVersion = 1
+    public static let maximumDailyBuckets = 31
+
+    public var version: Int
+    public var experiment: ExposureExperimentState
+    public var days: [ExposureStudyDailyBucket]
+
+    public init(
+        version: Int = currentVersion,
+        experiment: ExposureExperimentState = .init(),
+        days: [ExposureStudyDailyBucket] = []
+    ) {
+        self.version = version
+        self.experiment = experiment
+        self.days = Array(days.sorted { $0.dayStartUTC < $1.dayStartUTC }.suffix(Self.maximumDailyBuckets))
+    }
+
+    public mutating func record(
+        event: ExposureStudyEvent,
+        module: KajiModuleID? = nil,
+        source: ExposureEntrySource? = nil,
+        statusWidth: Int? = nil,
+        now: Date
+    ) {
+        let day = Self.utcDayStart(now)
+        if let index = days.firstIndex(where: { $0.dayStartUTC == day }) {
+            updateBucket(at: index, event: event, module: module, source: source, statusWidth: statusWidth)
+        } else {
+            days.append(ExposureStudyDailyBucket(dayStartUTC: day))
+            days.sort { $0.dayStartUTC < $1.dayStartUTC }
+            if days.count > Self.maximumDailyBuckets {
+                days.removeFirst(days.count - Self.maximumDailyBuckets)
+            }
+            guard let index = days.firstIndex(where: { $0.dayStartUTC == day }) else { return }
+            updateBucket(at: index, event: event, module: module, source: source, statusWidth: statusWidth)
+        }
+    }
+
+    private mutating func updateBucket(
+        at index: Int,
+        event: ExposureStudyEvent,
+        module: KajiModuleID?,
+        source: ExposureEntrySource?,
+        statusWidth: Int?
+    ) {
+        days[index].events[event, default: 0] += 1
+        if let module { days[index].moduleEntries[module, default: 0] += 1 }
+        if let source { days[index].entriesBySource[source, default: 0] += 1 }
+        if let statusWidth { days[index].maximumStatusWidth = max(days[index].maximumStatusWidth, statusWidth) }
+    }
+
+    public mutating func recordStatusWidth(_ width: Int, now: Date) {
+        let day = Self.utcDayStart(now)
+        if let index = days.firstIndex(where: { $0.dayStartUTC == day }) {
+            days[index].maximumStatusWidth = max(days[index].maximumStatusWidth, width)
+            return
+        }
+        days.append(ExposureStudyDailyBucket(dayStartUTC: day, maximumStatusWidth: width))
+        days.sort { $0.dayStartUTC < $1.dayStartUTC }
+        if days.count > Self.maximumDailyBuckets {
+            days.removeFirst(days.count - Self.maximumDailyBuckets)
+        }
+    }
+
+    public static func utcDayStart(_ date: Date) -> Date {
+        let seconds = floor(date.timeIntervalSince1970 / 86_400) * 86_400
+        return Date(timeIntervalSince1970: seconds)
+    }
+}

--- a/Tests/KajiTests/ExposureExperimentLogicTests.swift
+++ b/Tests/KajiTests/ExposureExperimentLogicTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import Kaji
+@testable import KajiCore
+
+final class ExposureExperimentLogicTests: XCTestCase {
+    private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testExactElapsedPhaseBoundariesAndAutomaticCompletion() {
+        let state = ExposureExperimentState(startedAt: start)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start), .baseline)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(72 * 60 * 60 - 0.001)), .baseline)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(72 * 60 * 60)), .treatment)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval((72 + 14 * 24) * 60 * 60 - 0.001)), .treatment)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval((72 + 14 * 24) * 60 * 60)), .completed)
+    }
+
+    func testRollbackImmediatelyRestoresLegacyAndCannotRestart() {
+        var state = ExposureExperimentState()
+        ExposureExperimentLogic.start(state: &state, now: start)
+        let originalStart = state.startedAt
+        let treatment = start.addingTimeInterval(72 * 60 * 60)
+        ExposureExperimentLogic.rollback(state: &state, now: treatment)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: treatment), .rolledBack)
+        XCTAssertTrue(ExposureExperimentLogic.phase(state: state, now: treatment).usesLegacyExposure)
+        ExposureExperimentLogic.start(state: &state, now: treatment.addingTimeInterval(1))
+        XCTAssertEqual(state.startedAt, originalStart)
+    }
+
+    func testBaselineAndCompletedPreserveExistingPagesExactly() {
+        let enabled = Set(KajiModuleID.allCases)
+        for phase in [ExposureExperimentPhase.notStarted, .baseline, .completed, .rolledBack] {
+            XCTAssertEqual(
+                ExposureExperimentLogic.visiblePopoverModules(phase: phase, enabled: enabled, favorites: [.goals, .work]),
+                ModulePrefsLogic.popoverPages(enabled: enabled)
+            )
+        }
+    }
+
+    func testTreatmentPrimaryAndMoreAreStableBoundedAndExcludeDisabled() {
+        let enabled: Set<KajiModuleID> = [.quota, .work, .system, .goals, .aiNews]
+        XCTAssertEqual(
+            ExposureExperimentLogic.primaryModules(enabled: enabled, favorites: [.goals, .work, .aiNews]),
+            [.quota, .goals, .work]
+        )
+        XCTAssertEqual(
+            ExposureExperimentLogic.moreModules(enabled: enabled, favorites: [.goals, .work]),
+            [.system, .aiNews]
+        )
+        XCTAssertEqual(
+            ExposureExperimentLogic.primaryModules(enabled: [.quota, .goals], favorites: [.work, .goals]),
+            [.quota, .goals]
+        )
+    }
+
+    func testAggregateSchemaIsBoundedAndContainsNoContentFields() throws {
+        var record = ExposureStudyRecord(experiment: .init(startedAt: start))
+        for day in 0..<40 {
+            let now = start.addingTimeInterval(TimeInterval(day * 86_400))
+            record.record(event: .popoverOpen, module: .goals, source: .more, now: now)
+            record.recordStatusWidth(120 + day, now: now)
+        }
+        XCTAssertEqual(record.days.count, ExposureStudyRecord.maximumDailyBuckets)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let json = String(decoding: try encoder.encode(record), as: UTF8.self)
+        for forbidden in ["title", "text", "subject", "process", "label", "feedback", "mailMetadata", "news"] {
+            XCTAssertFalse(json.localizedCaseInsensitiveContains(forbidden), "unexpected content field: \(forbidden)")
+        }
+        XCTAssertTrue(json.contains("moduleEntries"))
+        XCTAssertTrue(json.contains("maximumStatusWidth"))
+    }
+
+    @MainActor
+    func testLocalStorePersistsAtomicallyAndClearRetainsExperimentState() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let url = directory.appendingPathComponent("study.json")
+        var now = start
+        let store = ExposureStudyStore(fileURL: url, clock: { now })
+        store.startIfNeeded()
+        store.record(.popoverOpen, module: .quota, source: .statusItem)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let startedAt = store.record.experiment.startedAt
+        store.clearAggregates()
+        XCTAssertEqual(store.record.days, [])
+        XCTAssertEqual(store.record.experiment.startedAt, startedAt)
+
+        now = start.addingTimeInterval(72 * 60 * 60)
+        let reloaded = ExposureStudyStore(fileURL: url, clock: { now })
+        XCTAssertEqual(reloaded.phase, .treatment)
+        XCTAssertEqual(reloaded.record.experiment.startedAt, startedAt)
+        try? FileManager.default.removeItem(at: directory)
+    }
+}


### PR DESCRIPTION
## 背景与动机

当前状态栏被多个独立插槽（work / goals / AI news / mail brief…）占满，条目越多越难扫读。本实验把菜单栏收敛为**单一可组合入口**，并在展开后的 popover 里采用 **Primary + More** 两级曝光模型，验证减少暴露是否影响用户对模块的发现与使用。

## 实验设计

- **阶段机**：`notStarted → baseline(72h) → treatment(14d) → completed`；回滚立即进入 `rolledBack` 并恢复旧版曝光。
- **treatment 曝光模型**：
  - 状态栏/入口收敛为 **1 个条目**（主入口）。
  - Popover 内 Primary = 配额 + 你加星（primary favorites）的至多 2 个模块，其余全部折叠进 **More** 页面。
  - 数据按日聚合（事件计数、模块进入数、按来源的进入数、状态栏最大宽度），31 天上限，**不采集任何内容字段**（标题/正文/邮件元数据等一律不入库）。
- **对照组**：baseline 与 completed/rolledBack 阶段完整保留旧版曝光，可做前后对比。
- 数据落盘：`~/Library/Caches/.../exposure-study-v1.json`（原子写入）。

## 改动内容

- `KajiCore/ExposureExperimentLogic.swift`：阶段状态机与曝光面计算（新增）
- `KajiCore/ExposureStudyRecord.swift`：聚合记录 schema（新增）
- `Kaji/ExposureStudyStore.swift`：本地存储与阶段推进（新增）
- `Kaji/AppDelegate.swift`、`Kaji/KajiPopoverView.swift`：单入口 + Primary/More 导航与事件上报
- `Kaji/Prefs.swift`：`primaryFavorites`、`showsWorkCompactSignal`
- `Kaji/SettingsView.swift`：实验状态展示、加星切换、回滚入口
- `Tests/KajiTests/ExposureExperimentLogicTests.swift`：阶段边界、曝光面、持久化测试（新增）

## 验收标准

- [ ] `swift build` 通过
- [ ] `swift test` 通过（含新增 5 个用例：阶段边界/自动完成、回滚即恢复且不可重启、baseline 与完成阶段页面完全不变、Primary/More 稳定有界、schema 不含内容字段 + 本地存储原子持久化）
- [ ] baseline 阶段 UI 与当前 main 行为一致（回归保护）
- [ ] treatment 阶段状态栏收敛为单入口，popover 可见 Primary 与 More；加星/去星即时生效
- [ ] 回滚后立即恢复旧版曝光

## 回滚方式

1. **用户自助**：设置 > General > Exposure study > **Roll back**，立即恢复旧版曝光；聚合数据可一键清空（保留实验状态便于对比）。
2. **代码层面**：合入后如发现问题，直接 revert 本 PR 即可；回滚后旧版曝光路径是既有代码，无迁移负担。

## ⚠️ 已知边界（待后续调整）

Treatment 会在 **2026-09-11 16:28 UTC** 后自动到期并恢复旧版曝光（72h baseline + 14d treatment 写死的时长）。这是当前实验的临时边界，后续会调整成可配置/显式关闭，不做长期行为。