### PR TITLE
fix(exposure): remove auto-revert — treatment is steady state

### DIFF
--- a/Sources/KajiCore/ExposureExperimentLogic.swift
+++ b/Sources/KajiCore/ExposureExperimentLogic.swift
@@ -4,7 +4,6 @@ public enum ExposureExperimentPhase: String, Codable, Sendable {
     case notStarted
     case baseline
     case treatment
-    case completed
     case rolledBack
 
     public var usesLegacyExposure: Bool {
@@ -31,15 +30,13 @@ public enum ExposureEntrySource: String, Codable, CaseIterable, Sendable {
 
 public enum ExposureExperimentLogic {
     public static let baselineDuration: TimeInterval = 72 * 60 * 60
-    public static let treatmentDuration: TimeInterval = 14 * 24 * 60 * 60
 
     public static func phase(state: ExposureExperimentState, now: Date) -> ExposureExperimentPhase {
         guard let start = state.startedAt else { return .notStarted }
         if let rollback = state.rolledBackAt, rollback <= now { return .rolledBack }
         let elapsed = now.timeIntervalSince(start)
         if elapsed < 0 || elapsed < baselineDuration { return .baseline }
-        if elapsed < baselineDuration + treatmentDuration { return .treatment }
-        return .completed
+        return .treatment
     }
 
     public static func start(state: inout ExposureExperimentState, now: Date) {
@@ -49,7 +46,7 @@ public enum ExposureExperimentLogic {
     }
 
     public static func rollback(state: inout ExposureExperimentState, now: Date) {
-        guard state.startedAt != nil, phase(state: state, now: now) != .completed else { return }
+        guard state.startedAt != nil else { return }
         state.rolledBackAt = now
     }
 

--- a/Tests/KajiTests/ExposureExperimentLogicTests.swift
+++ b/Tests/KajiTests/ExposureExperimentLogicTests.swift
@@ -5,13 +5,15 @@ import XCTest
 final class ExposureExperimentLogicTests: XCTestCase {
     private let start = Date(timeIntervalSince1970: 1_800_000_000)
 
-    func testExactElapsedPhaseBoundariesAndAutomaticCompletion() {
+    func testExactElapsedPhaseBoundariesAndTreatmentSteadyState() {
         let state = ExposureExperimentState(startedAt: start)
         XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start), .baseline)
         XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(72 * 60 * 60 - 0.001)), .baseline)
         XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(72 * 60 * 60)), .treatment)
         XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval((72 + 14 * 24) * 60 * 60 - 0.001)), .treatment)
-        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval((72 + 14 * 24) * 60 * 60)), .completed)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval((72 + 14 * 24) * 60 * 60)), .treatment)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(30 * 86_400)), .treatment)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: start.addingTimeInterval(60 * 86_400)), .treatment)
     }
 
     func testRollbackImmediatelyRestoresLegacyAndCannotRestart() {
@@ -26,9 +28,24 @@ final class ExposureExperimentLogicTests: XCTestCase {
         XCTAssertEqual(state.startedAt, originalStart)
     }
 
-    func testBaselineAndCompletedPreserveExistingPagesExactly() {
+    func testTreatmentIsSteadyStateAndManualRollbackRestoresLegacy() {
+        let day30 = start.addingTimeInterval(30 * 86_400)
+        let state = ExposureExperimentState(startedAt: start)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: state, now: day30), .treatment)
+        XCTAssertFalse(ExposureExperimentLogic.phase(state: state, now: day30).usesLegacyExposure)
+
+        var mutable = state
+        let originalStart = mutable.startedAt
+        ExposureExperimentLogic.rollback(state: &mutable, now: day30)
+        XCTAssertEqual(ExposureExperimentLogic.phase(state: mutable, now: day30), .rolledBack)
+        XCTAssertTrue(ExposureExperimentLogic.phase(state: mutable, now: day30).usesLegacyExposure)
+        ExposureExperimentLogic.start(state: &mutable, now: day30.addingTimeInterval(1))
+        XCTAssertEqual(mutable.startedAt, originalStart)
+    }
+
+    func testBaselineAndRolledBackPreserveExistingPagesExactly() {
         let enabled = Set(KajiModuleID.allCases)
-        for phase in [ExposureExperimentPhase.notStarted, .baseline, .completed, .rolledBack] {
+        for phase in [ExposureExperimentPhase.notStarted, .baseline, .rolledBack] {
             XCTAssertEqual(
                 ExposureExperimentLogic.visiblePopoverModules(phase: phase, enabled: enabled, favorites: [.goals, .work]),
                 ModulePrefsLogic.popoverPages(enabled: enabled)


### PR DESCRIPTION
## 变更内容

移除曝光实验的自动回退倒计时，治疗模式（treatment）成为永久稳态：

- `ExposureExperimentLogic.phase(state:now:)` 在 72h baseline 之后**永远返回 `.treatment`**，不再在 14 天后自动进入 `.completed` 并静默切回旧的（多 slot）legacy 布局。
- 删除了不再被任何代码引用的 `.completed` 枚举 case（已全仓排查，包括 `ExposureStudyStore` 与测试）。
- 删除了仅用于自动回退边界的 `treatmentDuration` 常量。
- **baseline 语义保持不变**：新开启的研究仍先跑 72h baseline，再进入 treatment。
- `usesLegacyExposure` 语义不变：`.treatment`（含长时运行）为 false，`.rolledBack` 等仍为 true。

## 原因

用户决定：治疗模式作为实验的稳态长期保留，不再按时间自动回退；只有手动回滚才恢复 legacy 曝光。

## 回滚机制仍然有效

- 手动回滚（`.rolledBack`）与原来完全一致：立即恢复 legacy 布局，且 `start(state:now:)` 在已存在 `startedAt` 时不会自动重启实验。
- 新增测试覆盖：第 30 天以后仍处于 treatment 且 `usesLegacyExposure == false`；治疗期间手动回滚后恢复 legacy、不可自动重启。

## 测试

- `swift build` ✅
- `swift test --filter ExposureExperimentLogicTests` ✅（7 个用例通过）
- `swift test` 全量 ✅（212 个用例，0 失败）
- `./scripts/build-app.sh` ✅（ad-hoc 签名成功）

## CI 预期

- 等待 CI 跑完；预期全部通过（测试与本地全量一致，无新增外部依赖）。