### PR TITLE
feat(menubar): show up to 3 quota rings again, with 5h/7d arc swap

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -261,14 +261,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         store.providers.filter { prefs.isVisible($0.id) }
     }
 
-    /// What the menubar actually draws: every visible ring on the legacy
-    /// rollback path, or exactly the single most-constrained provider in
-    /// treatment. Empty means no provider has data yet — StatusItemView then
-    /// falls back to its placeholder single ring.
+    /// What the menubar draws: up to three visible providers, most-constrained
+    /// first (5-hour used fraction). Restores multi-provider visibility that
+    /// round 2 collapsed to a single ring. Empty means no provider has data
+    /// yet — StatusItemView then falls back to its placeholder single ring.
     private var menuBarProviders: [ProviderView] {
-        guard !usesLegacyExposure else { return visibleProviders }
-        guard let leader = QuotaStore.mostConstrained(in: visibleProviders) else { return [] }
-        return [leader]
+        QuotaStore.mostConstrained(in: visibleProviders, count: 3)
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -385,8 +383,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private var statusItemLength: CGFloat {
-        let count = max(1, min(4, menuBarProviders.count))
-        var length = CGFloat(count) * 26 + 6
+        // 21pt ring + 5pt gap per visible ring (up to 3), + 6pt padding —
+        // the pre-round-2 multi-ring formula, restored.
+        let shown = max(1, min(3, menuBarProviders.count))
+        var length = CGFloat(shown) * 26 + 6
         // Compact monospaced `MM:SS` to the right of the rings (~40pt).
         if presentedWorkSlotLabel != nil {
             length += 40

--- a/Sources/Kaji/QuotaStore.swift
+++ b/Sources/Kaji/QuotaStore.swift
@@ -304,10 +304,20 @@ final class QuotaStore: ObservableObject {
     /// The provider closest to its limit among a given set.
     /// Providers without five-hour data are skipped; ties go to the earlier one.
     static func mostConstrained(in providers: [ProviderView]) -> ProviderView? {
-        providers.reduce(nil) { best, candidate in
-            guard let percent = candidate.fiveHourPercent else { return best }
-            guard let best, let bestPercent = best.fiveHourPercent else { return candidate }
-            return percent > bestPercent ? candidate : best
-        }
+        mostConstrained(in: providers, count: 1).first
+    }
+
+    /// This is what the menubar shows — up to three visible providers sorted
+    /// by 5-hour used percent descending (stable, so equal percents keep their
+    /// input order — "ties go to the earlier one"). Providers without five-hour
+    /// data are skipped; `count` merely caps the result, it never pads it.
+    static func mostConstrained(in providers: [ProviderView], count: Int) -> [ProviderView] {
+        let ranked = providers
+            .filter { $0.fiveHourPercent != nil }
+            .sorted {
+                guard let a = $0.fiveHourPercent, let b = $1.fiveHourPercent else { return false }
+                return a > b
+            }
+        return Array(ranked.prefix(max(0, count)))
     }
 }

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -4,11 +4,12 @@ import KajiCore
 // MARK: - StatusItemView
 //
 // The compact menubar indicator: one concentric DOUBLE ring per visible
-// provider, side by side. Each glyph carries the provider's identity AND two
-// quota signals at once:
-//   - CENTER  = the provider mark.
-//   - OUTER arc = the 5-hour window.
-//   - INNER arc = the 7-day window.
+// provider, side by side — up to three, most-constrained first. Each glyph
+// carries the provider's identity AND two quota signals at once:
+//   - CENTER = the provider mark.
+//   - OUTER arc = the 7-day window (dimmer — supportive context).
+//   - INNER arc = the 5-hour window (bright, near-limit thickened — the
+//     actionable number).
 // The exact % lives in the popover (click the item); the arc length already
 // shows roughly how full each window is.
 //
@@ -169,8 +170,11 @@ private struct WorkStatusSlot: View {
 
 // MARK: - DualRing
 //
-// Two concentric trim arcs (outer 5h, inner 7d) around a center provider logo.
-// Sized for the menubar (~21pt).
+// Two concentric trim arcs around a center provider logo, sized for the
+// menubar (~21pt). OUTER = the 7-day window (dimmer — supportive context);
+// INNER = the 5-hour window (bright `base`, thickened when near-limit — the
+// actionable number). The 5-hour signal sits at the center of the glyph, so
+// the urgent number stays the visually dominant one.
 private struct DualRing: View {
     let provider: ProviderView?
     let showRemaining: Bool
@@ -183,7 +187,7 @@ private struct DualRing: View {
     private let gap: CGFloat = 1.3
 
     private var base: Color { scheme == .dark ? .white : .black }
-    private var innerColor: Color { base.opacity(0.65) }
+    private var weekColor: Color { base.opacity(0.65) }
     private var trackColor: Color { base.opacity(0.22) }
 
     private var fiveFraction: Double {
@@ -198,11 +202,13 @@ private struct DualRing: View {
 
     var body: some View {
         ZStack {
-            ring(inset: 0,
-                 lineWidth: nearLimit ? outerLW + 0.9 : outerLW,
+            // OUTER = 7-day arc: dimmer, normal width.
+            ring(inset: 0, lineWidth: outerLW,
+                 fraction: weekFraction, color: weekColor)
+            // INNER = 5-hour arc: bright, thickened when near-limit.
+            ring(inset: outerLW + gap,
+                 lineWidth: nearLimit ? innerLW + 0.9 : innerLW,
                  fraction: fiveFraction, color: base)
-            ring(inset: outerLW + gap, lineWidth: innerLW,
-                 fraction: weekFraction, color: innerColor)
             if let provider {
                 ProviderLogo(key: provider.id, color: base, size: 9)
             }

--- a/Tests/KajiTests/QuotaStoreTests.swift
+++ b/Tests/KajiTests/QuotaStoreTests.swift
@@ -41,13 +41,60 @@ final class QuotaStoreTests: XCTestCase {
         )
     }
 
-    func testMostConstrainedReturnsNilWithoutData() {
-        XCTAssertNil(QuotaStore.mostConstrained(in: []))
-        XCTAssertNil(
-            QuotaStore.mostConstrained(in: [
-                provider("codex", fiveHourPercent: nil),
-                provider("claude", fiveHourPercent: nil),
-            ])
+    // MARK: - mostConstrained(in:count:)
+
+    func testMostConstrainedCountReturnsRankedList() {
+        let providers = [
+            provider("claude", fiveHourPercent: 56),
+            provider("codex", fiveHourPercent: 82),
+            provider("ark", fiveHourPercent: nil),
+            provider("cursor", fiveHourPercent: 63),
+        ]
+        XCTAssertEqual(
+            QuotaStore.mostConstrained(in: providers, count: 2).map(\.id),
+            ["codex", "cursor"]
+        )
+        // `count` only caps the result — no-data providers are dropped, never padded.
+        XCTAssertEqual(
+            QuotaStore.mostConstrained(in: providers, count: 4).map(\.id),
+            ["codex", "cursor", "claude"]
+        )
+    }
+
+    func testMostConstrainedCountTieBreaksToEarlierProvider() {
+        let providers = [
+            provider("codex", fiveHourPercent: 70),
+            provider("claude", fiveHourPercent: 70),
+            provider("cursor", fiveHourPercent: 50),
+        ]
+        XCTAssertEqual(
+            QuotaStore.mostConstrained(in: providers, count: 2).map(\.id),
+            ["codex", "claude"]
+        )
+    }
+
+    func testMostConstrainedCountBoundsAndEmpty() {
+        let providers = [
+            provider("codex", fiveHourPercent: 82),
+            provider("claude", fiveHourPercent: 56),
+        ]
+        XCTAssertEqual(QuotaStore.mostConstrained(in: providers, count: 0), [])
+        XCTAssertEqual(QuotaStore.mostConstrained(in: [], count: 3), [])
+        XCTAssertEqual(
+            QuotaStore.mostConstrained(in: [provider("ark", fiveHourPercent: nil)], count: 3),
+            []
+        )
+    }
+
+    func testMostConstrainedCountOneMatchesLegacySingle() {
+        let providers = [
+            provider("claude", fiveHourPercent: 56),
+            provider("codex", fiveHourPercent: 82),
+            provider("ark", fiveHourPercent: nil),
+        ]
+        XCTAssertEqual(
+            QuotaStore.mostConstrained(in: providers, count: 1).first?.id,
+            QuotaStore.mostConstrained(in: providers)?.id
         )
     }
 }


### PR DESCRIPTION
## What & why

Round 2 collapsed the menu bar quota indicator to a single most-constrained
ring (exposure experiment). Direct product feedback: the owner uses 2-3 quota
providers (Codex/Cursor/Claude) and wants to *see* them all again. This
restores multi-provider visibility as the permanent behavior — no runtime
toggle, no prototype scaffolding.

## Changes

- `AppDelegate.menuBarProviders`: unconditionally returns up to 3 visible
  providers, ranked by 5-hour used fraction (`QuotaStore.mostConstrained(in:count:)`).
  Removes the exposure-phase gating that collapsed to one ring.
- `DualRing` arc swap: OUTER = 7-day fraction (dimmer, `base.opacity(0.65)`),
  INNER = 5-hour fraction (bright `base`, thickened `+0.9` when near-limit).
  Both windows stay visible per provider; the urgent 5h signal becomes the
  visually dominant center arc.
- `statusItemLength`: restored the pre-round-2 multi-ring formula
  (21pt ring + 5pt gap each, up to 3, + 6pt padding). Round 2's other wins
  are kept (no AI News, no extra mail/launchd slots).
- `QuotaStoreTests`: ranked-list tests for `mostConstrained(in:count:)` kept —
  that API is now the production path.

The four-way widget-style A/B (separateRings/concentric/ringTickCluster,
UserDefaults toggle, poll timer) has been torn out completely — decision was
made, dead code removed.

## Verification

- `swift build` clean; `swift test`: 213 tests, 0 failures (full suite;
  one earlier run showed 2 transient failures, three subsequent full runs
  pass clean).
- Fresh live render of the installed app (real quota data: codex 96% /
  cursor 77.9% / claude 4% 5h) shows three 21pt DualRings, each with:
  - inner bright 5h arc — codex full & thickened (near-limit 96%),
    cursor 77.9%, claude 4% top sliver;
  - outer dim 7d arc — cursor's 5.3% sliver only (codex/claude have no 7d
    data today), at the dimmer opacity tier.
- Inspectable composite: `/tmp/kaji-widget-verify/final-shipped.png`.