### PR TITLE
feat(settings): simplify module row controls

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -131,10 +131,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.rebuildExposureSurfaces() }
             .store(in: &cancellables)
-        prefs.$showsWorkCompactSignal
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.updateStatusItem() }
-            .store(in: &cancellables)
         exposureStudy.didChangePhase
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.rebuildExposureSurfaces() }
@@ -296,7 +292,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let view = StatusItemView(providers: menuBarProviders,
                                   showRemaining: prefs.showRemaining,
                                   updateAvailable: updateChecker.available != nil,
-                                  workSlotLabel: presentedWorkSlotLabel,
+                                  workSlotLabel: workStatusSlotLabel,
                                   goalsSlotLabel: goalsStatusSlotLabel,
                                   mailBriefSlotLabel: usesLegacyExposure ? MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount) : nil,
                                   showsMailBriefSlot: usesLegacyExposure && prefs.isModuleEnabled(.mailBrief),
@@ -322,7 +318,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hostingView?.rootView = StatusItemView(providers: menuBarProviders,
                                                showRemaining: prefs.showRemaining,
                                                updateAvailable: updateChecker.available != nil,
-                                               workSlotLabel: presentedWorkSlotLabel,
+                                               workSlotLabel: workStatusSlotLabel,
                                                goalsSlotLabel: goalsStatusSlotLabel,
                                                mailBriefSlotLabel: usesLegacyExposure ? MenuBarSlotLogic.mailBriefLabel(enabled: prefs.isModuleEnabled(.mailBrief), actCount: mailBriefStore.actCount) : nil,
                                                showsMailBriefSlot: usesLegacyExposure && prefs.isModuleEnabled(.mailBrief),
@@ -336,11 +332,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private var usesLegacyExposure: Bool { exposureStudy.phase.usesLegacyExposure }
-
-    private var presentedWorkSlotLabel: String? {
-        guard usesLegacyExposure || prefs.showsWorkCompactSignal else { return nil }
-        return workStatusSlotLabel
-    }
 
     private func rebuildExposureSurfaces() {
         updateStatusItem()
@@ -388,7 +379,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let shown = max(1, min(3, menuBarProviders.count))
         var length = CGFloat(shown) * 26 + 6
         // Compact monospaced `MM:SS` to the right of the rings (~40pt).
-        if presentedWorkSlotLabel != nil {
+        if workStatusSlotLabel != nil {
             length += 40
         }
         if let goalsStatusSlotLabel {

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -38,9 +38,6 @@ final class Prefs: ObservableObject {
             defaults.set(normalized.map(\.rawValue), forKey: Key.primaryFavorites)
         }
     }
-    @Published var showsWorkCompactSignal: Bool {
-        didSet { defaults.set(showsWorkCompactSignal, forKey: Key.showsWorkCompactSignal) }
-    }
     @Published var language: Lang {
         didSet { defaults.set(language.rawValue, forKey: Key.language) }
     }
@@ -105,7 +102,6 @@ final class Prefs: ObservableObject {
         static let visibleProviders = "visibleProviders"
         static let enabledModules = "enabledModules"
         static let primaryFavorites = "exposureExperimentPrimaryFavorites"
-        static let showsWorkCompactSignal = "exposureExperimentShowsWorkCompactSignal"
         static let language = "language"
         static let menubarStyle = "menubarStyle"
         static let showRemaining = "showRemaining"
@@ -134,7 +130,7 @@ final class Prefs: ObservableObject {
             visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep,
             mailBriefHour, mailBriefMinute,
             mailBriefBatchSize, mailBriefConcurrency, mailBriefModel, goalGrouping,
-            primaryFavorites, showsWorkCompactSignal
+            primaryFavorites
         ]
     }
 
@@ -142,6 +138,9 @@ final class Prefs: ObservableObject {
         self.defaults = defaults
         let d = defaults
         d.removeObject(forKey: "mcpEnabled")
+        // Work compact-signal toggle removed in the settings simplification:
+        // hardcoded always-on, matching the shipped default. Drop the orphan value.
+        d.removeObject(forKey: "exposureExperimentShowsWorkCompactSignal")
         let hadExistingPreferences = Key.existingPreferenceKeys.contains {
             d.object(forKey: $0) != nil
         }
@@ -183,10 +182,6 @@ final class Prefs: ObservableObject {
             savedFavorites,
             enabled: normalizedEnabled
         )
-        showsWorkCompactSignal = d.object(forKey: Key.showsWorkCompactSignal) == nil
-            ? true
-            : d.bool(forKey: Key.showsWorkCompactSignal)
-
         let languageResolution = LanguagePrefsLogic.resolve(
             storedRawValue: d.string(forKey: Key.language),
             hadExistingPreferences: hadExistingPreferences,

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -536,24 +536,13 @@ struct SettingsView: View {
             }
             .disabled(lockedOn)
             if exposurePhase == .treatment, id != .quota, on {
-                Button {
+                segment(
+                    L10n.t(.showInBar, prefs.language),
+                    on: prefs.primaryFavorites.contains(id),
+                    accessibilityIdentifier: "kaji.module.\(id.rawValue).primary"
+                ) {
                     togglePrimaryFavorite(id)
-                } label: {
-                    Image(systemName: prefs.primaryFavorites.contains(id) ? "star.fill" : "star")
                 }
-                .buttonStyle(.plain)
-                .help("Primary favorite")
-                .accessibilityIdentifier("kaji.module.\(id.rawValue).primary")
-            }
-            if exposurePhase == .treatment, id == .work, on {
-                Button {
-                    prefs.showsWorkCompactSignal.toggle()
-                } label: {
-                    Image(systemName: prefs.showsWorkCompactSignal ? "menubar.rectangle" : "rectangle")
-                }
-                .buttonStyle(.plain)
-                .help("Show compact Work signal")
-                .accessibilityIdentifier("kaji.module.work.status-signal")
             }
         }
     }

--- a/Sources/KajiCore/LanguageLocalization.swift
+++ b/Sources/KajiCore/LanguageLocalization.swift
@@ -50,7 +50,7 @@ public enum L10n {
     public enum K: CaseIterable, Sendable {
         case fiveHQuota, week, quit, stale, waiting, needPython
         case quitApp, settings, advancedSettings, appearance, language, providers, show
-        case hide, on, off
+        case hide, on, off, showInBar
         case usage, showUsed, showRemaining
         case updateTo, checkUpdates, updateChecking, updateCurrent, updateFailed
         case system, keepAwake, keepAwakeOn, keepAwakeOff, keepAwakeTurningOn, keepAwakeTurningOff, keepAwakeFailed
@@ -105,6 +105,7 @@ public enum L10n {
         .hide: .init(en: "Hide", zh: "隐藏", ptBR: "Ocultar", es: "Ocultar"),
         .on: .init(en: "On", zh: "开", ptBR: "Sim", es: "Sí"),
         .off: .init(en: "Off", zh: "关", ptBR: "Não", es: "No"),
+        .showInBar: .init(en: "Show", zh: "显示", ptBR: "Mostrar", es: "Mostrar"),
         .usage: .init(en: "Usage", zh: "用量", ptBR: "Uso", es: "Uso"),
         .showUsed: .init(en: "Used", zh: "已用", ptBR: "Usado", es: "Usado"),
         .showRemaining: .init(en: "Remaining", zh: "剩余", ptBR: "Restante", es: "Restante"),


### PR DESCRIPTION
Module rows now show exactly two clear controls: the On/Off selector and a text "Show" toggle instead of the star icon. The two-favorite cap is unchanged.