### PR TITLE
Add live System status and compact menu bar displays

### DIFF
--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -104,6 +104,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.updateStatusItem() }
             .store(in: &cancellables)
+        prefs.$workTimeDisplayStyle
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateStatusItem() }
+            .store(in: &cancellables)
+        prefs.$goalMenuBarDisplayStyle
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateStatusItem() }
+            .store(in: &cancellables)
         prefs.$visibleProviders
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.rebuildPopoverContentIfShown() }
@@ -247,6 +255,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                   updateAvailable: updateChecker.available != nil,
                                   workSlotLabel: workStatusSlotLabel,
                                   goalsSlotLabel: goalsStatusSlotLabel,
+                                  goalsSlotShowsCalendar: goalsStatusSlotShowsCalendar,
                                   systemSlotSnapshot: systemStatusSlotSnapshot,
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
@@ -270,6 +279,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                updateAvailable: updateChecker.available != nil,
                                                workSlotLabel: workStatusSlotLabel,
                                                goalsSlotLabel: goalsStatusSlotLabel,
+                                               goalsSlotShowsCalendar: goalsStatusSlotShowsCalendar,
                                                systemSlotSnapshot: systemStatusSlotSnapshot,
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
@@ -297,17 +307,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             workEnabled: prefs.isModuleEnabled(.work),
             phase: phase,
             focusRemaining: focusRemaining,
-            breakRemaining: workSession.breakRemaining
+            breakRemaining: workSession.breakRemaining,
+            displayStyle: prefs.workTimeDisplayStyle
         )
     }
 
     private var goalsStatusSlotLabel: String? {
-        MenuBarSlotLogic.goalsLabel(
-            enabled: prefs.isModuleEnabled(.goals),
-            goals: dailyGoals.todayGoalEntries,
-            scheduledCompleted: fixedPlanStore.todayScheduledCompletedCount,
-            scheduledTotal: fixedPlanStore.todayScheduledEntries.count
-        )
+        guard prefs.isModuleEnabled(.goals) else { return nil }
+        switch prefs.goalMenuBarDisplayStyle {
+        case .incompleteCount:
+            return String(MenuBarSlotLogic.incompleteCount(
+                goals: dailyGoals.allGoalEntries,
+                scheduledCompleted: fixedPlanStore.todayScheduledCompletedCount,
+                scheduledTotal: fixedPlanStore.todayScheduledEntries.count
+            ))
+        case .todayFraction:
+            return MenuBarSlotLogic.goalsLabel(
+                enabled: true,
+                goals: dailyGoals.todayGoalEntries,
+                scheduledCompleted: fixedPlanStore.todayScheduledCompletedCount,
+                scheduledTotal: fixedPlanStore.todayScheduledEntries.count
+            )
+        }
+    }
+
+    private var goalsStatusSlotShowsCalendar: Bool {
+        prefs.goalMenuBarDisplayStyle == .todayFraction
     }
     private var systemStatusSlotSnapshot: SystemLoadSnapshot? {
         guard prefs.isModuleEnabled(.system) else { return nil }
@@ -324,15 +349,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the pre-round-2 multi-ring formula, restored.
         let shown = max(1, min(3, menuBarProviders.count))
         var length = CGFloat(shown) * 26 + 6
-        // Compact monospaced `MM:SS` to the right of the rings (~40pt).
-        if workStatusSlotLabel != nil {
-            length += 40
+        if let workStatusSlotLabel {
+            length += 5 + CGFloat(workStatusSlotLabel.count) * 7
         }
         if let goalsStatusSlotLabel {
-            length += 20 + CGFloat(goalsStatusSlotLabel.count) * 7
+            let iconWidth: CGFloat = goalsStatusSlotShowsCalendar ? 12 : 0
+            length += 9 + iconWidth + CGFloat(goalsStatusSlotLabel.count) * 7
         }
         if systemStatusSlotSnapshot != nil {
-            length += 29
+            length += 21
         }
         return length
     }

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -254,8 +254,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                   showRemaining: prefs.showRemaining,
                                   updateAvailable: updateChecker.available != nil,
                                   workSlotLabel: workStatusSlotLabel,
+                                  workSlotShowsIcon: prefs.workTimeDisplayStyle == .minutesOnly,
                                   goalsSlotLabel: goalsStatusSlotLabel,
-                                  goalsSlotShowsCalendar: goalsStatusSlotShowsCalendar,
                                   systemSlotSnapshot: systemStatusSlotSnapshot,
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
@@ -278,8 +278,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                showRemaining: prefs.showRemaining,
                                                updateAvailable: updateChecker.available != nil,
                                                workSlotLabel: workStatusSlotLabel,
+                                               workSlotShowsIcon: prefs.workTimeDisplayStyle == .minutesOnly,
                                                goalsSlotLabel: goalsStatusSlotLabel,
-                                               goalsSlotShowsCalendar: goalsStatusSlotShowsCalendar,
                                                systemSlotSnapshot: systemStatusSlotSnapshot,
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
@@ -331,9 +331,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private var goalsStatusSlotShowsCalendar: Bool {
-        prefs.goalMenuBarDisplayStyle == .todayFraction
-    }
     private var systemStatusSlotSnapshot: SystemLoadSnapshot? {
         guard prefs.isModuleEnabled(.system) else { return nil }
         let snapshot = systemMonitor.snapshot
@@ -350,11 +347,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let shown = max(1, min(3, menuBarProviders.count))
         var length = CGFloat(shown) * 26 + 6
         if let workStatusSlotLabel {
-            length += 5 + CGFloat(workStatusSlotLabel.count) * 7
+            let iconWidth: CGFloat = prefs.workTimeDisplayStyle == .minutesOnly ? 11 : 0
+            length += 5 + iconWidth + CGFloat(workStatusSlotLabel.count) * 7
         }
         if let goalsStatusSlotLabel {
-            let iconWidth: CGFloat = goalsStatusSlotShowsCalendar ? 12 : 0
-            length += 9 + iconWidth + CGFloat(goalsStatusSlotLabel.count) * 7
+            length += 21 + CGFloat(goalsStatusSlotLabel.count) * 7
         }
         if systemStatusSlotSnapshot != nil {
             length += 21

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -152,6 +152,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.updateStatusItem() }
             .store(in: &cancellables)
+        systemMonitor.$snapshot
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateStatusItem() }
+            .store(in: &cancellables)
         prefs.$launchAtLogin
             .removeDuplicates()
             .receive(on: RunLoop.main)
@@ -243,9 +247,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                   updateAvailable: updateChecker.available != nil,
                                   workSlotLabel: workStatusSlotLabel,
                                   goalsSlotLabel: goalsStatusSlotLabel,
+                                  systemSlotSnapshot: systemStatusSlotSnapshot,
                                   onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                   onWorkClick: { [weak self] in self?.showPopover(.work) },
-                                  onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) })
+                                  onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
+                                  onSystemClick: { [weak self] in self?.showPopover(.system) })
         hostingView = KajiHostingView(rootView: view)
         hostingView.configureKajiHost()
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -264,9 +270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                updateAvailable: updateChecker.available != nil,
                                                workSlotLabel: workStatusSlotLabel,
                                                goalsSlotLabel: goalsStatusSlotLabel,
+                                               systemSlotSnapshot: systemStatusSlotSnapshot,
                                                onQuotaClick: { [weak self] in self?.showPopover(.quota) },
                                                onWorkClick: { [weak self] in self?.showPopover(.work) },
-                                               onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) })
+                                               onGoalsClick: { [weak self] in self?.showPopover(.goalsToday) },
+                                               onSystemClick: { [weak self] in self?.showPopover(.system) })
         statusItem.length = statusItemLength
     }
 
@@ -301,6 +309,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             scheduledTotal: fixedPlanStore.todayScheduledEntries.count
         )
     }
+    private var systemStatusSlotSnapshot: SystemLoadSnapshot? {
+        guard prefs.isModuleEnabled(.system) else { return nil }
+        let snapshot = systemMonitor.snapshot
+        return SystemLoadSnapshot(cpuPercent: snapshot.cpuPercent,
+                                  memoryPercent: snapshot.memoryPercent,
+                                  diskPercent: snapshot.diskPercent)
+    }
+
 
 
     private var statusItemLength: CGFloat {
@@ -314,6 +330,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if let goalsStatusSlotLabel {
             length += 20 + CGFloat(goalsStatusSlotLabel.count) * 7
+        }
+        if systemStatusSlotSnapshot != nil {
+            length += 29
         }
         return length
     }
@@ -410,7 +429,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if prefs.isModuleEnabled(.work) { return .work }
             if prefs.isModuleEnabled(.goals) { return .goalsToday }
             return .quota
-        case .work, .goalsToday:
+        case .work, .goalsToday, .system:
             return .quota
         }
     }
@@ -423,6 +442,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return popoverNavigation.panel == .work
         case .goalsToday:
             return popoverNavigation.panel == .goals
+        case .system:
+            return popoverNavigation.panel == .system
         }
     }
 
@@ -443,6 +464,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             popoverNavigation.panel = .goals
             popoverNavigation.goalHorizon = .today
+        case .system:
+            guard prefs.isModuleEnabled(.system) else {
+                popoverNavigation.panel = .quota
+                break
+            }
+            popoverNavigation.panel = .system
         }
     }
 

--- a/Sources/Kaji/DailyGoalStore.swift
+++ b/Sources/Kaji/DailyGoalStore.swift
@@ -85,6 +85,11 @@ final class DailyGoalStore: ObservableObject {
 
     var goals: [DailyGoal] { visibleGoals(for: .today) }
     var todayGoalEntries: [DailyGoal] { state.today }
+    var allGoalEntries: [DailyGoal] {
+        let merged = state.today + state.week + state.longTerm + state.yesterdayPending
+        var seen = Set<UUID>()
+        return merged.filter { seen.insert($0.id).inserted }
+    }
     var completedCount: Int { summary(for: .today).completed }
     var history: [String: DailyGoalHistoryDay] { state.history }
     var pendingGoals: [DailyGoal] {

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -510,12 +510,73 @@ struct KajiPopoverView: View {
 
     private var systemPanel: some View {
         VStack(alignment: .leading, spacing: 10) {
+            systemLoadOverview
+            topProcesses
             diskOverview
             diskCategoryBreakdown
         }
         .onAppear {
+            systemMonitor.refresh()
             systemMonitor.scanDiskInsights()
         }
+    }
+
+    private var systemLoadOverview: some View {
+        let snapshot = systemMonitor.snapshot
+        return VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("系统负载", detail: snapshot.hasSample ? "实时" : "采集中", image: "cpu")
+            HStack(spacing: 8) {
+                systemMetric("CPU", snapshot.cpuPercent)
+                systemMetric("内存", snapshot.memoryPercent)
+                systemMetric("磁盘", snapshot.diskPercent)
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10).fill(t.panel.opacity(0.78)))
+    }
+
+    private func systemMetric(_ title: String, _ value: Double) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.system(size: 9.5, weight: .semibold, design: .rounded))
+                .foregroundColor(t.mute)
+            Text(String(format: "%.0f%%", value))
+                .font(.system(size: 17, weight: .bold, design: .monospaced))
+                .monospacedDigit()
+                .foregroundColor(t.cream)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var topProcesses: some View {
+        let processes = systemMonitor.snapshot.topProcesses
+        return VStack(alignment: .leading, spacing: 7) {
+            sectionHeader("进程", detail: "CPU / 内存", image: "list.bullet")
+            if processes.isEmpty {
+                Text(systemMonitor.isRefreshing ? "正在采集进程…" : "暂无进程数据")
+                    .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    .foregroundColor(t.mute)
+                    .frame(maxWidth: .infinity, minHeight: 24, alignment: .center)
+            } else {
+                ForEach(processes.prefix(5)) { process in
+                    HStack(spacing: 8) {
+                        Text(process.command)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(String(format: "%.1f%%", process.cpu))
+                            .frame(width: 48, alignment: .trailing)
+                        Text(String(format: "%.1f%%", process.memory))
+                            .frame(width: 48, alignment: .trailing)
+                    }
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .monospacedDigit()
+                    .foregroundColor(t.cream)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 10).fill(t.panel.opacity(0.62)))
     }
 
     private var diskOverview: some View {

--- a/Sources/Kaji/Prefs.swift
+++ b/Sources/Kaji/Prefs.swift
@@ -65,6 +65,12 @@ final class Prefs: ObservableObject {
     @Published var breakOverlayEnabled: Bool {
         didSet { defaults.set(breakOverlayEnabled, forKey: Key.breakOverlayEnabled) }
     }
+    @Published var workTimeDisplayStyle: WorkTimeDisplayStyle {
+        didSet { defaults.set(workTimeDisplayStyle.rawValue, forKey: Key.workTimeDisplayStyle) }
+    }
+    @Published var goalMenuBarDisplayStyle: GoalMenuBarDisplayStyle {
+        didSet { defaults.set(goalMenuBarDisplayStyle.rawValue, forKey: Key.goalMenuBarDisplayStyle) }
+    }
     @Published var autoCleanEnabled: Bool {
         didSet { defaults.set(autoCleanEnabled, forKey: Key.autoCleanEnabled) }
     }
@@ -86,6 +92,8 @@ final class Prefs: ObservableObject {
         static let breakMinutes = "breakMinutes"
         static let allowBreakSkip = "allowBreakSkip"
         static let breakOverlayEnabled = "breakOverlayEnabled"
+        static let workTimeDisplayStyle = "workTimeDisplayStyle"
+        static let goalMenuBarDisplayStyle = "goalMenuBarDisplayStyle"
         static let visibleProvidersV2 = "visibleProvidersV2"
         /// One-shot: insert `cursor` into saved visible set on upgrade to 0.6.1.
         static let visibleProvidersCursor = "visibleProvidersCursor"
@@ -98,9 +106,10 @@ final class Prefs: ObservableObject {
         static let existingPreferenceKeys = [
             visibleProviders, enabledModules, language, menubarStyle,
             showRemaining, focusMinutes, breakMinutes,
-            allowBreakSkip, breakOverlayEnabled, visibleProvidersV2,
-            visibleProvidersCursor, autoCleanEnabled, launchAtLogin, preventSleep,
-            goalGrouping, primaryFavorites
+            allowBreakSkip, breakOverlayEnabled, workTimeDisplayStyle,
+            goalMenuBarDisplayStyle, visibleProvidersV2, visibleProvidersCursor,
+            autoCleanEnabled, launchAtLogin, preventSleep, goalGrouping,
+            primaryFavorites
         ]
     }
 
@@ -187,6 +196,12 @@ final class Prefs: ObservableObject {
         } else {
             breakOverlayEnabled = true
         }
+        workTimeDisplayStyle = WorkTimeDisplayStyle(
+            rawValue: d.string(forKey: Key.workTimeDisplayStyle) ?? ""
+        ) ?? .minutesOnly
+        goalMenuBarDisplayStyle = GoalMenuBarDisplayStyle(
+            rawValue: d.string(forKey: Key.goalMenuBarDisplayStyle) ?? ""
+        ) ?? .incompleteCount
         if d.object(forKey: Key.autoCleanEnabled) != nil {
             autoCleanEnabled = d.bool(forKey: Key.autoCleanEnabled)
         } else {

--- a/Sources/Kaji/SettingsView.swift
+++ b/Sources/Kaji/SettingsView.swift
@@ -319,6 +319,26 @@ struct SettingsView: View {
                     togglePrimaryFavorite(id)
                 }
             }
+            if id == .work, on {
+                segment(
+                    prefs.workTimeDisplayStyle == .minutesOnly ? "12m" : "MM:SS",
+                    on: prefs.workTimeDisplayStyle == .minutesOnly,
+                    accessibilityIdentifier: "kaji.module.work.time-display"
+                ) {
+                    prefs.workTimeDisplayStyle = prefs.workTimeDisplayStyle == .minutesOnly
+                        ? .exactSeconds : .minutesOnly
+                }
+            }
+            if id == .goals, on {
+                segment(
+                    prefs.goalMenuBarDisplayStyle == .incompleteCount ? "15" : "n/n",
+                    on: prefs.goalMenuBarDisplayStyle == .incompleteCount,
+                    accessibilityIdentifier: "kaji.module.goals.count-display"
+                ) {
+                    prefs.goalMenuBarDisplayStyle = prefs.goalMenuBarDisplayStyle == .incompleteCount
+                        ? .todayFraction : .incompleteCount
+                }
+            }
         }
     }
 

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -14,6 +14,12 @@ import KajiCore
 // shows roughly how full each window is.
 //
 // Glyphs are always adaptive mono (system Light / Dark) — no Color product path.
+struct SystemLoadSnapshot: Equatable {
+    let cpuPercent: Double
+    let memoryPercent: Double
+    let diskPercent: Double
+}
+
 struct StatusItemView: View {
     let providers: [ProviderView]
     var showRemaining: Bool = false
@@ -26,9 +32,12 @@ struct StatusItemView: View {
     var workSlotLabel: String? = nil
     /// Optional today's completion summary (`n/n`) when Goals is enabled.
     var goalsSlotLabel: String? = nil
+    /// Optional live system load bars when System is enabled.
+    var systemSlotSnapshot: SystemLoadSnapshot? = nil
     var onQuotaClick: () -> Void = {}
     var onWorkClick: () -> Void = {}
     var onGoalsClick: () -> Void = {}
+    var onSystemClick: () -> Void = {}
 
     @Environment(\.colorScheme) private var scheme
 
@@ -61,6 +70,14 @@ struct StatusItemView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+            }
+            if let systemSlotSnapshot {
+                Button(action: onSystemClick) {
+                    SystemStatusSlot(snapshot: systemSlotSnapshot)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("kaji.status.system")
             }
         }
         .padding(.horizontal, 3)
@@ -100,6 +117,44 @@ private struct GoalsStatusSlot: View {
         .padding(.horizontal, 2)
     }
 }
+private struct SystemStatusSlot: View {
+    let snapshot: SystemLoadSnapshot
+
+    @Environment(\.colorScheme) private var scheme
+
+    private var base: Color {
+        scheme == .dark ? .white : .black
+    }
+
+    var body: some View {
+        VStack(spacing: 3) {
+            loadBar(snapshot.cpuPercent)
+            loadBar(snapshot.memoryPercent)
+            loadBar(snapshot.diskPercent)
+        }
+        .frame(width: 24, height: 21)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("CPU \(rounded(snapshot.cpuPercent))%, memory \(rounded(snapshot.memoryPercent))%, disk \(rounded(snapshot.diskPercent))%")
+    }
+
+    private func loadBar(_ percent: Double) -> some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(base.opacity(0.22))
+                Capsule()
+                    .fill(base.opacity(0.65))
+                    .frame(width: geometry.size.width * min(max(percent / 100, 0), 1))
+            }
+        }
+        .frame(height: 3)
+    }
+
+    private func rounded(_ value: Double) -> Int {
+        Int(value.rounded())
+    }
+}
+
 
 // MARK: - WorkStatusSlot
 //

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -30,9 +30,9 @@ struct StatusItemView: View {
     /// Optional work countdown in the user's selected display style.
     /// `nil` when the work module is disabled — no slot rendered.
     var workSlotLabel: String? = nil
+    var workSlotShowsIcon: Bool = false
     /// Optional Goals summary when Goals is enabled.
     var goalsSlotLabel: String? = nil
-    var goalsSlotShowsCalendar: Bool = false
     /// Optional live system load bars when System is enabled.
     var systemSlotSnapshot: SystemLoadSnapshot? = nil
     var onQuotaClick: () -> Void = {}
@@ -60,15 +60,15 @@ struct StatusItemView: View {
             .accessibilityIdentifier("kaji.status.quota")
             if let workSlotLabel {
                 Button(action: onWorkClick) {
-                    WorkStatusSlot(label: workSlotLabel)
+                    WorkStatusSlot(label: workSlotLabel,
+                                   showsIcon: workSlotShowsIcon)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
             }
             if let goalsSlotLabel {
                 Button(action: onGoalsClick) {
-                    GoalsStatusSlot(label: goalsSlotLabel,
-                                    showsCalendar: goalsSlotShowsCalendar)
+                    GoalsStatusSlot(label: goalsSlotLabel)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -98,7 +98,6 @@ struct StatusItemView: View {
 
 private struct GoalsStatusSlot: View {
     let label: String
-    let showsCalendar: Bool
 
     @Environment(\.colorScheme) private var scheme
 
@@ -108,10 +107,8 @@ private struct GoalsStatusSlot: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            if showsCalendar {
-                Image(systemName: "calendar")
-                    .font(.system(size: 10, weight: .medium))
-            }
+            Image(systemName: "calendar")
+                .font(.system(size: 10, weight: .medium))
             Text(label)
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .monospacedDigit()
@@ -167,6 +164,7 @@ private struct SystemStatusSlot: View {
 // never shows the string "BREAK" (spec §4).
 private struct WorkStatusSlot: View {
     let label: String
+    let showsIcon: Bool
 
     @Environment(\.colorScheme) private var scheme
 
@@ -175,12 +173,18 @@ private struct WorkStatusSlot: View {
     }
 
     var body: some View {
-        Text(label)
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
-            .foregroundStyle(color)
-            .monospacedDigit()
-            .lineLimit(1)
-            .fixedSize()
+        HStack(spacing: 2) {
+            if showsIcon {
+                Image(systemName: "clock")
+                    .font(.system(size: 9, weight: .medium))
+            }
+            Text(label)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .monospacedDigit()
+        }
+        .foregroundStyle(color)
+        .lineLimit(1)
+        .fixedSize()
     }
 }
 

--- a/Sources/Kaji/StatusItemView.swift
+++ b/Sources/Kaji/StatusItemView.swift
@@ -27,11 +27,12 @@ struct StatusItemView: View {
     /// corner of the glyph as a passive "update available" cue (open popover ->
     /// "Update to vX" to act on it). No notification permission needed.
     var updateAvailable: Bool = false
-    /// Optional work countdown (`MM:SS`) to the right of the rings.
+    /// Optional work countdown in the user's selected display style.
     /// `nil` when the work module is disabled — no slot rendered.
     var workSlotLabel: String? = nil
-    /// Optional today's completion summary (`n/n`) when Goals is enabled.
+    /// Optional Goals summary when Goals is enabled.
     var goalsSlotLabel: String? = nil
+    var goalsSlotShowsCalendar: Bool = false
     /// Optional live system load bars when System is enabled.
     var systemSlotSnapshot: SystemLoadSnapshot? = nil
     var onQuotaClick: () -> Void = {}
@@ -66,7 +67,8 @@ struct StatusItemView: View {
             }
             if let goalsSlotLabel {
                 Button(action: onGoalsClick) {
-                    GoalsStatusSlot(label: goalsSlotLabel)
+                    GoalsStatusSlot(label: goalsSlotLabel,
+                                    showsCalendar: goalsSlotShowsCalendar)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -96,6 +98,7 @@ struct StatusItemView: View {
 
 private struct GoalsStatusSlot: View {
     let label: String
+    let showsCalendar: Bool
 
     @Environment(\.colorScheme) private var scheme
 
@@ -105,8 +108,10 @@ private struct GoalsStatusSlot: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            Image(systemName: "calendar")
-                .font(.system(size: 10, weight: .medium))
+            if showsCalendar {
+                Image(systemName: "calendar")
+                    .font(.system(size: 10, weight: .medium))
+            }
             Text(label)
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .monospacedDigit()
@@ -132,7 +137,7 @@ private struct SystemStatusSlot: View {
             loadBar(snapshot.memoryPercent)
             loadBar(snapshot.diskPercent)
         }
-        .frame(width: 24, height: 21)
+        .frame(width: 16, height: 21)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("CPU \(rounded(snapshot.cpuPercent))%, memory \(rounded(snapshot.memoryPercent))%, disk \(rounded(snapshot.diskPercent))%")
     }

--- a/Sources/Kaji/SystemMonitor.swift
+++ b/Sources/Kaji/SystemMonitor.swift
@@ -120,7 +120,14 @@ final class SystemMonitor: ObservableObject {
     }
 
     func start() {
+        guard timer == nil else { return }
+        refresh()
         scanDiskInsights()
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refresh()
+            }
+        }
     }
 
     func stop() {

--- a/Sources/KajiCore/GoalHorizonModel.swift
+++ b/Sources/KajiCore/GoalHorizonModel.swift
@@ -229,6 +229,7 @@ public enum MenuBarDestination: Equatable, Sendable {
     case quota
     case work
     case goalsToday
+    case system
 }
 
 public enum MenuBarSlotLogic {
@@ -251,6 +252,7 @@ public enum MenuBarSlotLogic {
         case .quota, .background: .quota
         case .work: .work
         case .goals: .goalsToday
+        case .system: .system
         }
     }
 
@@ -260,5 +262,6 @@ public enum MenuBarSlot: Equatable, Sendable {
     case quota
     case work
     case goals
+    case system
     case background
 }

--- a/Sources/KajiCore/GoalHorizonModel.swift
+++ b/Sources/KajiCore/GoalHorizonModel.swift
@@ -225,6 +225,11 @@ public enum GoalHorizonLogic {
 
 }
 
+public enum GoalMenuBarDisplayStyle: String, Codable, Sendable, Equatable {
+    case incompleteCount
+    case todayFraction
+}
+
 public enum MenuBarDestination: Equatable, Sendable {
     case quota
     case work
@@ -246,6 +251,17 @@ public enum MenuBarSlotLogic {
         let fixedDone = fixedPlanCompleted == true ? 1 : 0
         return "\(summary.completed + fixedDone + scheduledCompleted)/\(summary.total + fixedTotal + scheduledTotal)"
     }
+    public static func incompleteCount(
+        goals: [GoalItem],
+        scheduledCompleted: Int = 0,
+        scheduledTotal: Int = 0
+    ) -> Int {
+        let incompleteGoals = goals.filter {
+            !$0.isDone && !$0.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }.count
+        return incompleteGoals + max(0, scheduledTotal - scheduledCompleted)
+    }
+
 
     public static func destination(for slot: MenuBarSlot) -> MenuBarDestination {
         switch slot {

--- a/Sources/KajiCore/WorkStatusSlotModel.swift
+++ b/Sources/KajiCore/WorkStatusSlotModel.swift
@@ -9,29 +9,47 @@ public enum WorkStatusSlotPhase: String, Sendable, Equatable {
     case breakDue
     case breaking
 }
+public enum WorkTimeDisplayStyle: String, Codable, Sendable, Equatable {
+    case minutesOnly
+    case exactSeconds
+}
+
 
 /// Pure display model for the optional work countdown in the status item.
 ///
 /// Spec: `dev_docs/specs/2026-07-24-work-status-slot.md`
 ///
-/// User-visible states when work is enabled:
-/// - `working` → remaining focus `MM:SS`
-/// - `breakDue` or `breaking` → remaining break `MM:SS` (never `"BREAK"`)
+/// - `working` → remaining focus in the selected display style
+/// - `breakDue` or `breaking` → remaining break in the selected display style
+/// Minutes-only rounds up so a running session never displays `0m`.
 public enum WorkStatusSlotModel {
     /// Returns the menu-bar label, or `nil` when the work module is off.
     public static func label(
         workEnabled: Bool,
         phase: WorkStatusSlotPhase,
         focusRemaining: TimeInterval,
-        breakRemaining: TimeInterval
+        breakRemaining: TimeInterval,
+        displayStyle: WorkTimeDisplayStyle = .exactSeconds
     ) -> String? {
         guard workEnabled else { return nil }
+        let remaining: TimeInterval
         switch phase {
         case .working:
-            return clock(focusRemaining)
+            remaining = focusRemaining
         case .breakDue, .breaking:
-            return clock(breakRemaining)
+            remaining = breakRemaining
         }
+        switch displayStyle {
+        case .minutesOnly:
+            return minutes(remaining)
+        case .exactSeconds:
+            return clock(remaining)
+        }
+    }
+
+    private static func minutes(_ seconds: TimeInterval) -> String {
+        let clamped = max(0, seconds)
+        return "\(Int(ceil(clamped / 60)))m"
     }
 
     private static func clock(_ seconds: TimeInterval) -> String {

--- a/Tests/KajiTests/MenuBarDisplayPrefsTests.swift
+++ b/Tests/KajiTests/MenuBarDisplayPrefsTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import KajiCore
+@testable import Kaji
+
+@MainActor
+final class MenuBarDisplayPrefsTests: XCTestCase {
+    func testNewDefaultsUseMinutesAndIncompleteCount() {
+        let defaults = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let prefs = Prefs(defaults: defaults)
+
+        XCTAssertEqual(prefs.workTimeDisplayStyle, .minutesOnly)
+        XCTAssertEqual(prefs.goalMenuBarDisplayStyle, .incompleteCount)
+    }
+
+    func testLegacyDisplayChoicesPersist() {
+        let defaults = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+
+        var prefs: Prefs? = Prefs(defaults: defaults)
+        prefs?.workTimeDisplayStyle = .exactSeconds
+        prefs?.goalMenuBarDisplayStyle = .todayFraction
+        prefs = nil
+
+        let reloaded = Prefs(defaults: defaults)
+        XCTAssertEqual(reloaded.workTimeDisplayStyle, .exactSeconds)
+        XCTAssertEqual(reloaded.goalMenuBarDisplayStyle, .todayFraction)
+    }
+
+    private var defaultsSuiteName: String {
+        "MenuBarDisplayPrefsTests"
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        return defaults
+    }
+}

--- a/Tests/KajiTests/MenuBarSlotLogicTests.swift
+++ b/Tests/KajiTests/MenuBarSlotLogicTests.swift
@@ -42,6 +42,23 @@ final class MenuBarSlotLogicTests: XCTestCase {
     func testEmptyGoalsStillShowsEntryPoint() {
         XCTAssertEqual(MenuBarSlotLogic.goalsLabel(enabled: true, goals: []), "0/0")
     }
+    func testIncompleteCountIncludesAllOpenGoalsAndActiveSchedules() {
+        let goals = [
+            GoalItem(id: UUID(), title: "Open today", isDone: false),
+            GoalItem(id: UUID(), title: "Open long-term", isDone: false),
+            GoalItem(id: UUID(), title: "Done", isDone: true),
+            GoalItem(id: UUID(), title: "   ", isDone: false),
+        ]
+        XCTAssertEqual(
+            MenuBarSlotLogic.incompleteCount(
+                goals: goals,
+                scheduledCompleted: 1,
+                scheduledTotal: 4
+            ),
+            5
+        )
+    }
+
 
     func testSlotDestinations() {
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .quota), .quota)

--- a/Tests/KajiTests/MenuBarSlotLogicTests.swift
+++ b/Tests/KajiTests/MenuBarSlotLogicTests.swift
@@ -47,6 +47,7 @@ final class MenuBarSlotLogicTests: XCTestCase {
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .quota), .quota)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .work), .work)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .goals), .goalsToday)
+        XCTAssertEqual(MenuBarSlotLogic.destination(for: .system), .system)
         XCTAssertEqual(MenuBarSlotLogic.destination(for: .background), .quota)
     }
 

--- a/Tests/KajiTests/WorkStatusSlotModelTests.swift
+++ b/Tests/KajiTests/WorkStatusSlotModelTests.swift
@@ -139,4 +139,40 @@ final class WorkStatusSlotModelTests: XCTestCase {
             XCTAssertNil(label)
         }
     }
+
+    func testMinutesOnlyRoundsUpRemainingPartialMinute() {
+        XCTAssertEqual(
+            WorkStatusSlotModel.label(
+                workEnabled: true,
+                phase: .working,
+                focusRemaining: 12 * 60 + 34,
+                breakRemaining: 0,
+                displayStyle: .minutesOnly
+            ),
+            "13m"
+        )
+    }
+
+    func testMinutesOnlyShowsZeroOnlyAtZero() {
+        XCTAssertEqual(
+            WorkStatusSlotModel.label(
+                workEnabled: true,
+                phase: .breaking,
+                focusRemaining: 0,
+                breakRemaining: 1,
+                displayStyle: .minutesOnly
+            ),
+            "1m"
+        )
+        XCTAssertEqual(
+            WorkStatusSlotModel.label(
+                workEnabled: true,
+                phase: .breaking,
+                focusRemaining: 0,
+                breakRemaining: 0,
+                displayStyle: .minutesOnly
+            ),
+            "0m"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add System as a fourth menu-bar slot with live CPU / memory / disk bars and a read-only enriched System panel
- keep the bars ordered CPU, memory, disk and shorten their track from 24pt to 16pt
- default Work to a clock + whole-minutes label, with a persisted Settings control for legacy MM:SS
- default Goals to calendar + total incomplete count, with a persisted Settings control for the classic today fraction

## Verification
- `swift test` — 157 tests passed
- `./scripts/build-local.sh --no-open`
- installed and exercised both default and legacy menu-bar modes with real local data

No reclaim, auto-clean, or cleanup stub methods are exposed or wired.