### PR TITLE
fix(menubar): keep every enabled provider's ring, refetch stale quota windows

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.2</string>
+	<string>0.9.3</string>
 	<key>CFBundleVersion</key>
-	<string>34</string>
+	<string>35</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/Resources/quota.py
+++ b/Resources/quota.py
@@ -110,12 +110,29 @@ LIMITS_TTL = 180
 CLAUDE_LIMITS_TTL = 3600
 
 
+def _cache_is_current(data):
+    """A cached snapshot is only valid until its own windows reset. Claude's
+    TTL is an hour but its 5-hour window can reset inside that hour; serving
+    the cached payload then means `_scrub_expired` drops the percentage and the
+    provider reports nothing until the TTL lapses. Treat a passed reset as a
+    cache miss so the next poll refetches."""
+    if not isinstance(data, dict):
+        return False
+    for win in ("five_hour", "seven_day"):
+        reset = _reset_epoch(data.get(win + "_resets_at"))
+        if reset is not None and reset <= time.time():
+            return False
+    return True
+
+
 def _limits_cached(name, fetch, ttl=LIMITS_TTL):
     path = CACHE_DIR / name
     retry_path = path.with_name(path.name + ".retry-at")
     try:
         if time.time() - path.stat().st_mtime < ttl:
-            return json.loads(path.read_text())
+            cached = json.loads(path.read_text())
+            if _cache_is_current(cached):
+                return cached
     except Exception:
         pass
     retry_at = 0

--- a/Sources/Kaji/AppDelegate.swift
+++ b/Sources/Kaji/AppDelegate.swift
@@ -222,11 +222,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// What the menubar draws: up to three visible providers, most-constrained
-    /// first (5-hour used fraction). Restores multi-provider visibility that
-    /// round 2 collapsed to a single ring. Empty means no provider has data
-    /// yet — StatusItemView then falls back to its placeholder single ring.
+    /// first. Every enabled provider keeps its ring even without data — empty
+    /// only before the first quota snapshot arrives, when StatusItemView falls
+    /// back to its placeholder single ring.
     private var menuBarProviders: [ProviderView] {
-        QuotaStore.mostConstrained(in: visibleProviders, count: 3)
+        QuotaStore.menuBarOrder(in: visibleProviders, count: 3)
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/Kaji/QuotaStore.swift
+++ b/Sources/Kaji/QuotaStore.swift
@@ -296,28 +296,35 @@ final class QuotaStore: ObservableObject {
         providers = views
     }
 
-    /// The provider closest to its limit — drives the menubar indicator.
-    var mostConstrained: ProviderView? {
-        Self.mostConstrained(in: providers)
+    /// Ranking signal: how constrained a provider looks right now — the worse
+    /// of the two windows. `nil` only when the provider reports no quota at
+    /// all; such a provider still gets a ring (empty track), it just sorts last.
+    private static func constraintScore(_ p: ProviderView) -> Double? {
+        switch (p.fiveHourPercent, p.weekPercent) {
+        case let (five?, week?): return max(five, week)
+        case let (five?, nil): return five
+        case let (nil, week?): return week
+        case (nil, nil): return nil
+        }
     }
 
-    /// The provider closest to its limit among a given set.
-    /// Providers without five-hour data are skipped; ties go to the earlier one.
-    static func mostConstrained(in providers: [ProviderView]) -> ProviderView? {
-        mostConstrained(in: providers, count: 1).first
-    }
-
-    /// This is what the menubar shows — up to three visible providers sorted
-    /// by 5-hour used percent descending (stable, so equal percents keep their
-    /// input order — "ties go to the earlier one"). Providers without five-hour
-    /// data are skipped; `count` merely caps the result, it never pads it.
-    static func mostConstrained(in providers: [ProviderView], count: Int) -> [ProviderView] {
-        let ranked = providers
-            .filter { $0.fiveHourPercent != nil }
-            .sorted {
-                guard let a = $0.fiveHourPercent, let b = $1.fiveHourPercent else { return false }
-                return a > b
+    /// What the menubar draws: the user's visible providers, most-constrained
+    /// first, capped at `count`. Enabling a provider is an explicit request to
+    /// see it, so a missing percentage NEVER removes its ring — no-data
+    /// providers sort last and render an empty track. Ties and no-data
+    /// providers keep their input order.
+    static func menuBarOrder(in providers: [ProviderView], count: Int) -> [ProviderView] {
+        let ranked = providers.enumerated()
+            .sorted { a, b in
+                switch (constraintScore(a.element), constraintScore(b.element)) {
+                case let (x?, y?) where x != y: return x > y
+                case (_?, nil): return true
+                case (nil, _?): return false
+                // Explicit index tiebreak: Swift's sort is not guaranteed stable.
+                default: return a.offset < b.offset
+                }
             }
+            .map(\.element)
         return Array(ranked.prefix(max(0, count)))
     }
 }

--- a/Tests/KajiTests/QuotaStoreTests.swift
+++ b/Tests/KajiTests/QuotaStoreTests.swift
@@ -5,96 +5,90 @@ import XCTest
 final class QuotaStoreTests: XCTestCase {
     private func provider(
         _ id: String,
-        fiveHourPercent: Double?
+        fiveHourPercent: Double?,
+        weekPercent: Double? = nil
     ) -> ProviderView {
         ProviderView(
             id: id,
             mark: id,
             displayName: id,
             fiveHourPercent: fiveHourPercent,
-            weekPercent: nil,
+            weekPercent: weekPercent,
             resetDate: nil,
             weekResetDate: nil
         )
     }
 
-    func testMostConstrainedPicksHighestPercentAndSkipsNoData() {
+    func testMenuBarOrderRanksByConstraint() {
         let providers = [
             provider("claude", fiveHourPercent: 56),
             provider("codex", fiveHourPercent: 82),
-            provider("ark", fiveHourPercent: nil),
-        ]
-        XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers)?.id,
-            "codex"
-        )
-    }
-
-    func testMostConstrainedTieBreaksToEarlierProvider() {
-        let providers = [
-            provider("codex", fiveHourPercent: 70),
-            provider("claude", fiveHourPercent: 70),
-        ]
-        XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers)?.id,
-            "codex"
-        )
-    }
-
-    // MARK: - mostConstrained(in:count:)
-
-    func testMostConstrainedCountReturnsRankedList() {
-        let providers = [
-            provider("claude", fiveHourPercent: 56),
-            provider("codex", fiveHourPercent: 82),
-            provider("ark", fiveHourPercent: nil),
             provider("cursor", fiveHourPercent: 63),
         ]
         XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers, count: 2).map(\.id),
+            QuotaStore.menuBarOrder(in: providers, count: 2).map(\.id),
             ["codex", "cursor"]
-        )
-        // `count` only caps the result — no-data providers are dropped, never padded.
-        XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers, count: 4).map(\.id),
-            ["codex", "cursor", "claude"]
         )
     }
 
-    func testMostConstrainedCountTieBreaksToEarlierProvider() {
+    func testMenuBarOrderTieBreaksToEarlierProvider() {
         let providers = [
             provider("codex", fiveHourPercent: 70),
             provider("claude", fiveHourPercent: 70),
             provider("cursor", fiveHourPercent: 50),
         ]
         XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers, count: 2).map(\.id),
+            QuotaStore.menuBarOrder(in: providers, count: 2).map(\.id),
             ["codex", "claude"]
         )
     }
 
-    func testMostConstrainedCountBoundsAndEmpty() {
+    /// Enabling a provider is an explicit request to see it: a missing
+    /// percentage must never remove its ring, only push it to the end.
+    func testMenuBarOrderKeepsProvidersWithoutData() {
         let providers = [
-            provider("codex", fiveHourPercent: 82),
-            provider("claude", fiveHourPercent: 56),
+            provider("ark", fiveHourPercent: nil),
+            provider("claude", fiveHourPercent: nil, weekPercent: 8),
+            provider("codex", fiveHourPercent: 2),
         ]
-        XCTAssertEqual(QuotaStore.mostConstrained(in: providers, count: 0), [])
-        XCTAssertEqual(QuotaStore.mostConstrained(in: [], count: 3), [])
         XCTAssertEqual(
-            QuotaStore.mostConstrained(in: [provider("ark", fiveHourPercent: nil)], count: 3),
-            []
+            QuotaStore.menuBarOrder(in: providers, count: 3).map(\.id),
+            ["claude", "codex", "ark"]
         )
     }
 
-    func testMostConstrainedCountOneMatchesLegacySingle() {
+    /// No-data providers keep their input order among themselves.
+    func testMenuBarOrderNoDataProvidersKeepInputOrder() {
         let providers = [
-            provider("claude", fiveHourPercent: 56),
-            provider("codex", fiveHourPercent: 82),
+            provider("minimax", fiveHourPercent: nil),
             provider("ark", fiveHourPercent: nil),
         ]
         XCTAssertEqual(
-            QuotaStore.mostConstrained(in: providers, count: 1).first?.id,
-            QuotaStore.mostConstrained(in: providers)?.id
+            QuotaStore.menuBarOrder(in: providers, count: 3).map(\.id),
+            ["minimax", "ark"]
         )
+    }
+
+    /// Score is the worse of the two windows, not whichever field is present.
+    func testMenuBarOrderUsesMaxOfBothWindows() {
+        let providers = [
+            provider("claude", fiveHourPercent: nil, weekPercent: 40),
+            provider("codex", fiveHourPercent: 2, weekPercent: 90),
+        ]
+        XCTAssertEqual(
+            QuotaStore.menuBarOrder(in: providers, count: 1).map(\.id),
+            ["codex"]
+        )
+    }
+
+    func testMenuBarOrderBoundsAndEmpty() {
+        let providers = [
+            provider("codex", fiveHourPercent: 82),
+            provider("claude", fiveHourPercent: 56),
+        ]
+        XCTAssertEqual(QuotaStore.menuBarOrder(in: providers, count: 0), [])
+        XCTAssertEqual(QuotaStore.menuBarOrder(in: [], count: 3), [])
+        // `count` caps, never pads.
+        XCTAssertEqual(QuotaStore.menuBarOrder(in: providers, count: 9).count, 2)
     }
 }


### PR DESCRIPTION
## What

- Menubar ranking no longer drops providers without quota data. `QuotaStore.mostConstrained(in:count:)` → `menuBarOrder(in:count:)`: score is `max(5h, 7d)`, no-data providers sort last and render an empty track. Enabling a provider is an explicit request to see it.
- `quota.py`: a cached limits snapshot is now invalid once any of its own `*_resets_at` has passed. Claude's TTL is 3600s but its 5-hour window resets inside that hour — the stale-but-'fresh' cache was scrubbed by `_scrub_expired`, so Claude reported no 5-hour usage for up to an hour after every reset.
- Version 0.9.3 (build 35).

## Symptom

Two providers enabled (`claude`, `codex`), only the Codex ring drawn.

## Verification

- `swift test`: 157 passed, 0 failures. QuotaStoreTests rewritten for the no-drop contract (no-data kept and ordered last, input order preserved among no-data, max-of-both-windows, bounds).
- `python3 Resources/quota.py --json` now returns `five_hour_used_percent: 2.0` alongside `seven_day_used_percent: 8.0` for claude; cache file refreshed.
- Installed build: `kaji state` shows claude `fiveHourPercent: 2, weekPercent: 8`; menubar screenshot shows both rings.