### PR TITLE
docs: drop the video demo from both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,6 @@ Kaji starts small. Quota is on; everything else is opt-in. `Kaji` is Japanese `è
 
 <img src="dev_docs/assets/use-goals.png" width="560" alt="Goals panel: today's goals grouped by tag with completion dots" />
 
-<details>
-<summary>See it in motion (30s)</summary>
-
-https://github.com/user-attachments/assets/a345bc3f-d74e-4092-8e8f-5730b154d39c
-
-</details>
-
 ## Install
 
 ```sh

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,13 +42,6 @@ Kaji 默认很小：只开 Quota，其余模块按需开启。`Kaji` 来自日�
 
 <img src="dev_docs/assets/use-goals.png" width="560" alt="Goals 面板：按标签分组的今日目标" />
 
-<details>
-<summary>看动态演示（30 秒）</summary>
-
-https://github.com/user-attachments/assets/a345bc3f-d74e-4092-8e8f-5730b154d39c
-
-</details>
-
 ## 安装
 
 ```sh


### PR DESCRIPTION
Removes the `<details>See it in motion</details>` block and its user-attachments video from README.md and README.zh.md. The three still screenshots already cover the same ground.