### PR TITLE
Fix token counting and codex quota window mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: swift build
         run: swift build
 
+      # Quota reader accuracy: token de-duplication, cache-token accounting,
+      # local day boundary and codex rate-limit window mapping. Pure stdlib,
+      # temp-dir fixtures, no network and no user data.
+      - name: quota.py accuracy tests
+        run: python3 Tests/quota/test_quota.py
+
       # Unit + in-process UI tests (see Tests/KajiTests/UITestHarness.swift).
       # These boot the real AppDelegate/status-item/popover object graph
       # and invoke the real click-handler closure — no self-skipping.

--- a/Resources/quota.py
+++ b/Resources/quota.py
@@ -811,11 +811,25 @@ def codex():
         _, rl, _, _ = _codex_scan_rollout(p)
         if not rl:
             continue
-        limits = _codex_map_rate_limits(rl, "used_percent", "resets_at",
+        mapped = _codex_map_rate_limits(rl, "used_percent", "resets_at",
                                         "window_minutes", "plan_type")
-        break
+        # A rate_limits event carrying only a plan label is not a reading —
+        # keep walking back instead of giving up on this session.
+        if mapped:
+            limits = mapped
+            break
 
-    return len(files_recent), (tokens_today or None), last, limits, by_project, context
+    # Sessions active TODAY, matching the token window. `files_recent` spans 24h
+    # so a session that ran past midnight still contributes today's events.
+    sessions_today = 0
+    for p in files_recent:
+        try:
+            if p.stat().st_mtime >= TODAY_START:
+                sessions_today += 1
+        except OSError:
+            pass
+
+    return sessions_today, (tokens_today or None), last, limits, by_project, context
 
 
 

--- a/Resources/quota.py
+++ b/Resources/quota.py
@@ -46,6 +46,46 @@ from urllib.parse import quote
 HOME = Path.home()
 # Overridable for tests.
 CODEX_SESSIONS = Path(os.environ.get("HELM_CODEX_SESSIONS") or HOME / ".codex" / "sessions")
+
+
+def _claude_project_roots():
+    """Every directory Claude Code may write session JSONL into.
+
+    Claude Code honours CODEX-style config relocation via CLAUDE_CONFIG_DIR
+    (comma-separated, as ccusage supports), and older/XDG installs use
+    ~/.config/claude. Reading only ~/.claude/projects silently reports 0 tokens
+    for anyone with a relocated config dir.
+    """
+    roots, seen = [], set()
+
+    def add(base):
+        p = (Path(base).expanduser() / "projects").resolve()
+        key = str(p)
+        if key in seen:
+            return
+        seen.add(key)
+        if p.is_dir():
+            roots.append(p)
+
+    override = os.environ.get("HELM_CLAUDE_PROJECTS")
+    if override:
+        for part in override.split(","):
+            if part.strip():
+                p = Path(part.strip()).expanduser().resolve()
+                if str(p) not in seen:
+                    seen.add(str(p))
+                    if p.is_dir():
+                        roots.append(p)
+        return roots
+
+    cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    if cfg:
+        for part in cfg.split(","):
+            if part.strip():
+                add(part.strip())
+    add(HOME / ".claude")
+    add(HOME / ".config" / "claude")
+    return roots
 ARK_AGENT_KEY = Path(os.environ.get("HELM_ARK_AGENT_KEY") or HOME / ".config" / "ark" / "agent-key")
 
 
@@ -89,7 +129,19 @@ VOLC_SK = _secret("VOLCENGINE_SECRET_ACCESS_KEY", "VOLCENGINE_SECRET_KEY",
                   "VOLC_SECRET_ACCESS_KEY", "VOLC_SECRET_KEY")
 VOLC_SESSION_TOKEN = _secret("VOLCENGINE_SESSION_TOKEN", "VOLC_SESSION_TOKEN")
 NOW = time.time()
-TODAY_START = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
+# LOCAL midnight, not UTC. "Today" must mean the user's day: at UTC+8 a UTC
+# boundary starts today at 08:00 local and silently discards the whole morning
+# (and at UTC-5 it counts part of yesterday evening). ccusage buckets by local
+# date for the same reason.
+TODAY_START = datetime.now().astimezone().replace(
+    hour=0, minute=0, second=0, microsecond=0).timestamp()
+
+
+def _int(value):
+    """A token count as int. Missing/None/garbage -> 0 (bool is not a count)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return int(value)
 
 
 def ago(ts: float) -> str:
@@ -368,12 +420,55 @@ def cursor_limits():
     return _limits_cached("cursor-limits-cache.json", _fetch_cursor_limits)
 
 
+def _codex_map_rate_limits(rl, pct_key, reset_key, window_key, plan_key):
+    """A codex rateLimits object -> Kaji's {five_hour,seven_day} limits dict.
+
+    Mapped by WINDOW LENGTH, never by the `primary`/`secondary` slot name.
+    Codex reuses `primary` for whichever window is currently authoritative: on
+    a plan with only a weekly cap, `primary.window_minutes == 10080` and
+    `secondary` is null. Trusting the slot name paints a 7-day figure onto the
+    5-hour ring — that is the "codex ring is wrong" bug. ≤ 24h counts as the
+    5-hour window, anything longer as the 7-day window.
+    """
+    if not isinstance(rl, dict):
+        return None
+    out = {}
+    for slot in ("primary", "secondary"):
+        w = rl.get(slot)
+        if not isinstance(w, dict) or w.get(pct_key) is None:
+            continue
+        mins = w.get(window_key)
+        if isinstance(mins, (int, float)) and not isinstance(mins, bool):
+            key = "five_hour" if mins <= 1440 else "seven_day"
+        else:
+            # No window length: fall back to the slot's conventional meaning.
+            key = "five_hour" if slot == "primary" else "seven_day"
+        # First writer wins so a genuine 5h window is not overwritten by a
+        # second short window reported in the other slot.
+        if key + "_used_percent" in out:
+            continue
+        out[key + "_used_percent"] = w[pct_key]
+        if w.get(reset_key) is not None:
+            out[key + "_resets_at"] = w[reset_key]
+    if rl.get(plan_key):
+        out["plan"] = rl[plan_key]
+    # A dict carrying only a plan label is not a usable limits reading.
+    if not any(k.endswith("_used_percent") for k in out):
+        return None
+    return out
+
+
 def _fetch_codex_limits():
     """codex app-server JSON-RPC account/rateLimits/read (official path)."""
     import queue as _queue
     import threading
+    # `-a untrusted` was REMOVED from codex's approval policy enum (0.153.x
+    # accepts only on-request|never); passing it makes the CLI exit before
+    # serving any JSON-RPC, so the live path silently never worked and every
+    # reading came from the stale session-file fallback. `never` is the
+    # non-interactive choice, paired with read-only sandboxing.
     proc = subprocess.Popen(
-        ["codex", "-s", "read-only", "-a", "untrusted", "app-server"],
+        ["codex", "-s", "read-only", "-a", "never", "app-server"],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL, text=True)
     # Drain stdout on a background thread. select()+text readline() can leave a
@@ -416,16 +511,8 @@ def _fetch_codex_limits():
                 continue
             if d.get("id") == 2:
                 rl = (d.get("result") or {}).get("rateLimits") or {}
-                out = {}
-                for src, key in (("primary", "five_hour"), ("secondary", "seven_day")):
-                    w = rl.get(src) or {}
-                    if w.get("usedPercent") is not None:
-                        out[key + "_used_percent"] = w["usedPercent"]
-                        if w.get("resetsAt") is not None:
-                            out[key + "_resets_at"] = w["resetsAt"]
-                if rl.get("planType"):
-                    out["plan"] = rl["planType"]
-                return out or None
+                return _codex_map_rate_limits(
+                    rl, "usedPercent", "resetsAt", "windowDurationMins", "planType")
         return None
     finally:
         try:
@@ -448,17 +535,26 @@ def claude_code():
 
     by_project: {munged project dir name: tokens_today} — keys match
     munge_cwd(session cwd), so a fleet session maps to its own burn.
+
+    Counting rules (aligned with ccusage):
+      * tokens = input + output + cache_creation + cache_read. Cache reads are
+        ~99% of real traffic; input+output alone tracks almost nothing.
+      * every usage record is de-duplicated on (message.id, requestId). Resumed,
+        branched and compacted sessions REWRITE earlier turns into new files, so
+        a naive sum counts the same API call several times.
+      * `model == "<synthetic>"` rows are local error placeholders, not billed.
+      * subagent/sidechain files are real billed usage and must be included.
     """
-    base = HOME / ".claude" / "projects"
-    if not base.exists():
+    roots = _claude_project_roots()
+    if not roots:
         return 0, 0, None, {}, {}
     tokens_today, last = 0, None
     session_ids_today = set()
     by_project = {}
     context = {}        # proj -> {"used": n, "window": w, "ts": newest-seen}
-    for jsonl in base.rglob("*.jsonl"):
-        if "subagents" in str(jsonl):
-            continue
+    seen_usage = set()  # (message.id, requestId) across ALL files
+    for base in roots:
+      for jsonl in base.rglob("*.jsonl"):
         try:
             mtime = jsonl.stat().st_mtime
         except OSError:
@@ -488,25 +584,33 @@ def claude_code():
                         sid = d.get("sessionId")
                         if sid:
                             session_ids_today.add(sid)
-                        usage = d.get("message", {}).get("usage") if isinstance(d.get("message"), dict) else None
-                        if usage:
-                            n = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
-                            tokens_today += n
-                            by_project[proj] = by_project.get(proj, 0) + n
-                            # Live context size = the newest prompt's full input
-                            # (incl. cache reads/creations). Window by model:
-                            # "[1m]" models 1M, else 200k.
-                            cur = context.get(proj)
-                            if cur is None or ts > cur["ts"]:
-                                used = (usage.get("input_tokens", 0)
-                                        + usage.get("cache_read_input_tokens", 0)
-                                        + usage.get("cache_creation_input_tokens", 0))
-                                model = (d.get("message") or {}).get("model") or ""
-                                window = 1_000_000 if ("[1m]" in model or "fable" in model) else 200_000
-                                if used > window:
-                                    window = 1_000_000
-                                if used:
-                                    context[proj] = {"used": used, "window": window, "ts": ts}
+                        msg = d.get("message") if isinstance(d.get("message"), dict) else None
+                        usage = msg.get("usage") if msg else None
+                        if not isinstance(usage, dict) or not usage:
+                            continue
+                        if msg.get("model") == "<synthetic>":
+                            continue
+                        used = (_int(usage.get("input_tokens"))
+                                + _int(usage.get("cache_read_input_tokens"))
+                                + _int(usage.get("cache_creation_input_tokens")))
+                        # Context is a point-in-time snapshot of the newest
+                        # prompt, so it is read BEFORE the dedup gate (a
+                        # duplicated record still describes the real context).
+                        cur = context.get(proj)
+                        if used and (cur is None or ts > cur["ts"]):
+                            model = msg.get("model") or ""
+                            window = 1_000_000 if ("[1m]" in model or "fable" in model) else 200_000
+                            if used > window:
+                                window = 1_000_000
+                            context[proj] = {"used": used, "window": window, "ts": ts}
+                        key = (msg.get("id"), d.get("requestId"))
+                        if key[0] and key[1]:
+                            if key in seen_usage:
+                                continue
+                            seen_usage.add(key)
+                        n = used + _int(usage.get("output_tokens"))
+                        tokens_today += n
+                        by_project[proj] = by_project.get(proj, 0) + n
         except Exception:
             pass
     for v in context.values():
@@ -578,10 +682,23 @@ def opencode():
     return sessions_today, (tokens_today if tokens_today else None), last
 
 
-def _codex_last_token_count(path):
-    """Last token_count payload + session cwd in a rollout file:
-    (info, rate_limits, cwd)."""
+def _codex_scan_rollout(path):
+    """Scan one rollout file: (info, rate_limits, cwd, tokens_today).
+
+    `info`/`rate_limits` are the LAST seen (freshest snapshot in this session).
+
+    `tokens_today` needs care. A token_count event carries a session-CUMULATIVE
+    `total_token_usage` plus the per-turn `last_token_usage`. Summing the final
+    cumulative value attributes a session's ENTIRE lifetime to today — a
+    long-lived session started three weeks ago (10.6M tokens here) lands wholly
+    in today's total. So we sum `last_token_usage` over events TIMESTAMPED today
+    instead, skipping events whose cumulative snapshot is byte-identical to the
+    previous one (the TUI re-emits the same token_count on redraw//status, which
+    would otherwise double-count the last turn).
+    """
     info, rl, cwd = None, None, None
+    tokens_today = 0
+    prev_total = None
     try:
         with open(path, encoding="utf-8", errors="replace") as f:
             for line in f:
@@ -606,11 +723,23 @@ def _codex_last_token_count(path):
                     continue
                 if payload.get("type") != "token_count":
                     continue
-                info = payload.get("info") or info
+                cur = payload.get("info")
                 rl = payload.get("rate_limits") or rl
+                if not isinstance(cur, dict):
+                    continue
+                info = cur
+                total = cur.get("total_token_usage")
+                if total == prev_total:
+                    continue
+                prev_total = total
+                ts = _reset_epoch(rec.get("timestamp"))
+                if ts is None or ts < TODAY_START:
+                    continue
+                last = cur.get("last_token_usage") or {}
+                tokens_today += _int(last.get("total_tokens"))
     except OSError:
         pass
-    return info, rl, cwd
+    return info, rl, cwd, tokens_today
 
 
 def _codex_rollout_files():
@@ -638,11 +767,11 @@ def _codex_recent_rollout_files(hours=24):
 def codex():
     """Returns (sessions_today, tokens_today, last_active_ts, limits|None, by_project, context).
 
-    tokens: token_count events are session-CUMULATIVE — take the LAST event
-    per file and sum across sessions active in the last 24h. Directory dates are
-    not reliable for a menu bar app because UTC/local day boundaries differ.
+    tokens: per-turn `last_token_usage` summed over events timestamped today
+    (see _codex_scan_rollout) across sessions touched in the last 24h.
     limits: from the freshest session overall (account-level, not today-bound):
-    {primary_used_percent?, secondary_used_percent?, *_resets_at?, plan?}.
+    {five_hour_*, seven_day_*, plan?} — mapped by WINDOW LENGTH, not by the
+    primary/secondary slot name.
     """
     base = CODEX_SESSIONS
     if not base.exists():
@@ -654,22 +783,22 @@ def codex():
     context = {}        # cwd -> {"used", "window"} from the freshest session
     ctx_mtime = {}
     for p in files_recent:
-        info, _, cwd = _codex_last_token_count(p)
+        info, _, cwd, n = _codex_scan_rollout(p)
         try:
             m = p.stat().st_mtime
         except OSError:
             m = 0
-        if info:
-            n = ((info.get("total_token_usage") or {}).get("total_tokens") or 0)
+        if n:
             tokens_today += n
             if cwd:
                 by_project[cwd] = by_project.get(cwd, 0) + n
-                lt = info.get("last_token_usage") or {}
-                used = (lt.get("input_tokens") or 0) + (lt.get("cached_input_tokens") or 0)
-                window = info.get("model_context_window") or 0
-                if used and window and m >= ctx_mtime.get(cwd, 0):
-                    context[cwd] = {"used": used, "window": window}
-                    ctx_mtime[cwd] = m
+        if info and cwd:
+            lt = info.get("last_token_usage") or {}
+            used = _int(lt.get("input_tokens")) + _int(lt.get("cached_input_tokens"))
+            window = info.get("model_context_window") or 0
+            if used and window and m >= ctx_mtime.get(cwd, 0):
+                context[cwd] = {"used": used, "window": window}
+                ctx_mtime[cwd] = m
         last = max(last or 0, m) if m else last
 
     limits = None
@@ -679,19 +808,11 @@ def codex():
     # no token_count yet (rl=None) — using only all_files[-1] would then drop
     # account limits even though the 2nd-freshest session has fresh ones.
     for p in reversed(all_files):
-        _, rl, _ = _codex_last_token_count(p)
+        _, rl, _, _ = _codex_scan_rollout(p)
         if not rl:
             continue
-        limits = {}
-        for src, key in (("primary", "five_hour"), ("secondary", "seven_day")):
-            window = rl.get(src)
-            if isinstance(window, dict) and window.get("used_percent") is not None:
-                limits[key + "_used_percent"] = window["used_percent"]
-                if window.get("resets_at") is not None:
-                    limits[key + "_resets_at"] = window["resets_at"]
-        if rl.get("plan_type"):
-            limits["plan"] = rl["plan_type"]
-        limits = limits or None
+        limits = _codex_map_rate_limits(rl, "used_percent", "resets_at",
+                                        "window_minutes", "plan_type")
         break
 
     return len(files_recent), (tokens_today or None), last, limits, by_project, context
@@ -1139,10 +1260,11 @@ def emit_table():
         tok_s = "—" if tok is None else fmt_tokens(tok)
         print(f"{label.get(name, name):<14} {sess_s:<16} {tok_s:<13} {fmt_last(last)}{extra}")
     print()
-    print("Note: claude-code tokens summed from message.usage (today only).")
+    print("Note: claude-code tokens = input+output+cache from message.usage, de-duplicated")
+    print("            on (message.id, requestId), local day only.")
     print("      opencode tokens summed from storage/message/*.json (today).")
-    print("      codex tokens = last token_count per session (cumulative), today's UTC dir;")
-    print("            quota %% from rate_limits in the freshest session.")
+    print("      codex tokens = per-turn last_token_usage over today's token_count events;")
+    print("            quota %% from app-server, mapped by window length.")
     print("      cursor limits from DashboardService period usage (API/Auto); no today tokens.")
     print("      kiro session files store no token counts (sessions only).")
 

--- a/Tests/quota/test_quota.py
+++ b/Tests/quota/test_quota.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Accuracy tests for Resources/quota.py token counting and window mapping.
+
+These guard the four regressions that made the numbers wrong:
+  1. Claude usage records were summed without de-duplication, so resumed /
+     branched / compacted sessions counted the same API call many times.
+  2. Claude token totals ignored cache tokens, which are ~99% of real traffic.
+  3. "Today" used a UTC midnight boundary, dropping the user's morning east
+     of UTC.
+  4. Codex rate limits were mapped by the primary/secondary slot NAME, so a
+     weekly-only plan painted its 7-day percentage onto the 5-hour ring.
+
+Pure stdlib, no network, no user data: every fixture is written into a temp
+dir and the module's paths are redirected with HELM_* env vars.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TMP = tempfile.mkdtemp(prefix="quota-test-")
+CLAUDE_PROJECTS = Path(TMP) / "claude" / "projects"
+CODEX_SESSIONS = Path(TMP) / "codex" / "sessions"
+CLAUDE_PROJECTS.mkdir(parents=True)
+CODEX_SESSIONS.mkdir(parents=True)
+
+# Must be set BEFORE import: CODEX_SESSIONS is resolved at module load.
+os.environ["HELM_CLAUDE_PROJECTS"] = str(CLAUDE_PROJECTS)
+os.environ["HELM_CODEX_SESSIONS"] = str(CODEX_SESSIONS)
+os.environ["HELM_ARK_AGENT_KEY"] = str(Path(TMP) / "no-such-key")
+
+sys.path.insert(0, str(ROOT / "Resources"))
+import quota  # noqa: E402
+
+
+def iso(ts):
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# A moment safely inside today's local window, and one safely inside yesterday.
+TODAY = quota.TODAY_START + 3600
+YESTERDAY = quota.TODAY_START - 7200
+
+
+def usage_row(msg_id, req_id, *, ts=TODAY, inp=10, out=5, cread=1000,
+              ccreate=100, model="claude-opus-5", session="s1"):
+    return {
+        "timestamp": iso(ts),
+        "sessionId": session,
+        "requestId": req_id,
+        "message": {
+            "id": msg_id,
+            "model": model,
+            "usage": {
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cache_read_input_tokens": cread,
+                "cache_creation_input_tokens": ccreate,
+            },
+        },
+    }
+
+
+def write_jsonl(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def clear_claude():
+    for p in CLAUDE_PROJECTS.rglob("*.jsonl"):
+        p.unlink()
+
+
+class TestLocalDayBoundary(unittest.TestCase):
+    def test_boundary_is_local_midnight(self):
+        start = datetime.fromtimestamp(quota.TODAY_START).astimezone()
+        self.assertEqual((start.hour, start.minute, start.second), (0, 0, 0),
+                         "TODAY_START must land on LOCAL midnight, not UTC")
+
+    def test_records_before_local_midnight_excluded(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [
+            usage_row("m-old", "r-old", ts=YESTERDAY),
+            usage_row("m-new", "r-new", ts=TODAY),
+        ])
+        _, tokens, _, _, _ = quota.claude_code()
+        self.assertEqual(tokens, 1115, "only today's record should be counted")
+
+
+class TestClaudeTokenCounting(unittest.TestCase):
+    def test_cache_tokens_are_included(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [
+            usage_row("m1", "r1", inp=10, out=5, cread=1000, ccreate=100),
+        ])
+        _, tokens, _, by_project, _ = quota.claude_code()
+        self.assertEqual(tokens, 1115)
+        self.assertEqual(by_project["proj-a"], 1115)
+
+    def test_duplicate_records_counted_once_across_files(self):
+        clear_claude()
+        rows = [usage_row("m1", "r1"), usage_row("m2", "r2")]
+        # A resumed session rewrites the same turns into a second file.
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", rows)
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "b.jsonl", rows + [usage_row("m3", "r3")])
+        _, tokens, _, _, _ = quota.claude_code()
+        self.assertEqual(tokens, 3 * 1115, "each (message.id, requestId) counts once")
+
+    def test_records_without_dedup_key_still_counted(self):
+        clear_claude()
+        rows = [usage_row("m1", "r1")]
+        rows.append({"timestamp": iso(TODAY), "sessionId": "s1",
+                     "message": {"model": "claude-opus-5",
+                                 "usage": {"input_tokens": 7, "output_tokens": 3}}})
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", rows)
+        _, tokens, _, _, _ = quota.claude_code()
+        self.assertEqual(tokens, 1115 + 10)
+
+    def test_synthetic_rows_excluded(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [
+            usage_row("m1", "r1"),
+            usage_row("m2", "r2", model="<synthetic>"),
+        ])
+        _, tokens, _, _, _ = quota.claude_code()
+        self.assertEqual(tokens, 1115, "<synthetic> placeholders are not billed")
+
+    def test_subagent_files_included(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [usage_row("m1", "r1")])
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "subagents" / "s.jsonl",
+                    [usage_row("m2", "r2")])
+        _, tokens, _, _, _ = quota.claude_code()
+        self.assertEqual(tokens, 2 * 1115, "sidechain turns are real usage")
+
+    def test_context_window_from_newest_record(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [
+            usage_row("m1", "r1", ts=TODAY, cread=5000),
+            usage_row("m2", "r2", ts=TODAY + 60, cread=9000),
+        ])
+        _, _, _, _, context = quota.claude_code()
+        self.assertEqual(context["proj-a"]["used"], 9000 + 10 + 100)
+        self.assertEqual(context["proj-a"]["window"], 200_000)
+
+    def test_million_window_model(self):
+        clear_claude()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [
+            usage_row("m1", "r1", model="claude-sonnet-4-5[1m]", cread=400_000),
+        ])
+        _, _, _, _, context = quota.claude_code()
+        self.assertEqual(context["proj-a"]["window"], 1_000_000)
+
+    def test_multiple_config_roots(self):
+        clear_claude()
+        other = Path(TMP) / "claude-alt" / "projects"
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [usage_row("m1", "r1")])
+        write_jsonl(other / "proj-b" / "b.jsonl", [usage_row("m2", "r2")])
+        prev = os.environ["HELM_CLAUDE_PROJECTS"]
+        os.environ["HELM_CLAUDE_PROJECTS"] = f"{CLAUDE_PROJECTS},{other}"
+        try:
+            _, tokens, _, by_project, _ = quota.claude_code()
+        finally:
+            os.environ["HELM_CLAUDE_PROJECTS"] = prev
+        self.assertEqual(tokens, 2 * 1115)
+        self.assertEqual(sorted(by_project), ["proj-a", "proj-b"])
+
+    def test_missing_root_is_not_an_error(self):
+        prev = os.environ["HELM_CLAUDE_PROJECTS"]
+        os.environ["HELM_CLAUDE_PROJECTS"] = str(Path(TMP) / "nope")
+        try:
+            self.assertEqual(quota.claude_code(), (0, 0, None, {}, {}))
+        finally:
+            os.environ["HELM_CLAUDE_PROJECTS"] = prev
+
+
+def codex_rollout(name, events, cwd="/tmp/work"):
+    day = datetime.now().astimezone().strftime("%Y/%m/%d")
+    p = CODEX_SESSIONS / day / f"rollout-{name}.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    rows = [{"timestamp": iso(TODAY), "type": "session_meta",
+             "payload": {"session_id": name, "cwd": cwd}}]
+    rows += events
+    write_jsonl(p, rows)
+    return p
+
+
+def token_count(total, last, ts=TODAY, rate_limits=None, window=237_500):
+    payload = {
+        "type": "token_count",
+        "info": {
+            "total_token_usage": {"total_tokens": total},
+            "last_token_usage": {"total_tokens": last,
+                                 "input_tokens": last, "cached_input_tokens": 0},
+            "model_context_window": window,
+        },
+    }
+    if rate_limits is not None:
+        payload["rate_limits"] = rate_limits
+    return {"timestamp": iso(ts), "type": "event_msg", "payload": payload}
+
+
+def clear_codex():
+    for p in CODEX_SESSIONS.rglob("*.jsonl"):
+        p.unlink()
+
+
+class TestCodexTokenCounting(unittest.TestCase):
+    def test_sums_per_turn_usage_not_lifetime_cumulative(self):
+        clear_codex()
+        # A session carried over from previous days: cumulative is 1_000_000 but
+        # only 300 + 400 tokens were spent today.
+        codex_rollout("s1", [
+            token_count(999_300, 500, ts=YESTERDAY),
+            token_count(999_600, 300, ts=TODAY),
+            token_count(1_000_000, 400, ts=TODAY),
+        ])
+        _, tokens, _, _, _, _ = quota.codex()
+        self.assertEqual(tokens, 700,
+                         "only today's turns count, not the session lifetime")
+
+    def test_repeated_identical_snapshots_not_double_counted(self):
+        clear_codex()
+        codex_rollout("s1", [
+            token_count(1000, 1000, ts=TODAY),
+            token_count(1000, 1000, ts=TODAY),   # TUI re-emit on redraw
+            token_count(1500, 500, ts=TODAY),
+        ])
+        _, tokens, _, _, _, _ = quota.codex()
+        self.assertEqual(tokens, 1500)
+
+    def test_tokens_attributed_to_session_cwd(self):
+        clear_codex()
+        codex_rollout("s1", [token_count(100, 100)], cwd="/tmp/a")
+        codex_rollout("s2", [token_count(250, 250)], cwd="/tmp/b")
+        _, tokens, _, _, by_project, _ = quota.codex()
+        self.assertEqual(tokens, 350)
+        self.assertEqual(by_project, {"/tmp/a": 100, "/tmp/b": 250})
+
+    def test_context_uses_model_context_window(self):
+        clear_codex()
+        codex_rollout("s1", [token_count(100, 40, window=237_500)], cwd="/tmp/a")
+        _, _, _, _, _, context = quota.codex()
+        self.assertEqual(context["/tmp/a"], {"used": 40, "window": 237_500})
+
+    def test_no_sessions_reports_none(self):
+        clear_codex()
+        sessions, tokens, _, _, _, _ = quota.codex()
+        self.assertEqual((sessions, tokens), (0, None))
+
+
+class TestCodexWindowMapping(unittest.TestCase):
+    """Slot NAME must never decide which ring a percentage lands on."""
+
+    def test_weekly_only_plan_does_not_fill_the_five_hour_ring(self):
+        rl = {"primary": {"used_percent": 100.0, "window_minutes": 10080,
+                          "resets_at": 1789437979},
+              "secondary": None, "plan_type": "prolite"}
+        out = quota._codex_map_rate_limits(
+            rl, "used_percent", "resets_at", "window_minutes", "plan_type")
+        self.assertNotIn("five_hour_used_percent", out)
+        self.assertEqual(out["seven_day_used_percent"], 100.0)
+        self.assertEqual(out["seven_day_resets_at"], 1789437979)
+        self.assertEqual(out["plan"], "prolite")
+
+    def test_standard_two_window_plan(self):
+        rl = {"primary": {"used_percent": 12.0, "window_minutes": 300},
+              "secondary": {"used_percent": 44.0, "window_minutes": 10080}}
+        out = quota._codex_map_rate_limits(
+            rl, "used_percent", "resets_at", "window_minutes", "plan_type")
+        self.assertEqual(out["five_hour_used_percent"], 12.0)
+        self.assertEqual(out["seven_day_used_percent"], 44.0)
+
+    def test_app_server_camel_case_keys(self):
+        rl = {"primary": {"usedPercent": 100, "windowDurationMins": 10080,
+                          "resetsAt": 1789437979},
+              "secondary": None, "planType": "prolite"}
+        out = quota._codex_map_rate_limits(
+            rl, "usedPercent", "resetsAt", "windowDurationMins", "planType")
+        self.assertEqual(out.get("seven_day_used_percent"), 100)
+        self.assertIsNone(out.get("five_hour_used_percent"))
+
+    def test_missing_window_length_falls_back_to_slot_meaning(self):
+        rl = {"primary": {"used_percent": 30.0},
+              "secondary": {"used_percent": 60.0}}
+        out = quota._codex_map_rate_limits(
+            rl, "used_percent", "resets_at", "window_minutes", "plan_type")
+        self.assertEqual(out["five_hour_used_percent"], 30.0)
+        self.assertEqual(out["seven_day_used_percent"], 60.0)
+
+    def test_plan_label_alone_is_not_a_reading(self):
+        self.assertIsNone(quota._codex_map_rate_limits(
+            {"primary": None, "secondary": None, "plan_type": "prolite"},
+            "used_percent", "resets_at", "window_minutes", "plan_type"))
+
+    def test_non_dict_input(self):
+        self.assertIsNone(quota._codex_map_rate_limits(
+            None, "used_percent", "resets_at", "window_minutes", "plan_type"))
+
+
+class TestIntCoercion(unittest.TestCase):
+    def test_rejects_bool_and_junk(self):
+        self.assertEqual(quota._int(True), 0)
+        self.assertEqual(quota._int(None), 0)
+        self.assertEqual(quota._int("500"), 0)
+        self.assertEqual(quota._int(7), 7)
+        self.assertEqual(quota._int(7.9), 7)
+
+
+class TestJSONShape(unittest.TestCase):
+    def test_emit_json_is_valid_and_has_expected_keys(self):
+        clear_claude()
+        clear_codex()
+        write_jsonl(CLAUDE_PROJECTS / "proj-a" / "a.jsonl", [usage_row("m1", "r1")])
+        codex_rollout("s1", [token_count(100, 100)], cwd="/tmp/a")
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            quota.emit_json()
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["claude"]["tokens_today"], 1115)
+        self.assertEqual(data["codex"]["tokens_today"], 100)
+        self.assertEqual(data["codex"]["by_project"], {"/tmp/a": 100})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Tests/quota/test_quota.py
+++ b/Tests/quota/test_quota.py
@@ -249,6 +249,16 @@ class TestCodexTokenCounting(unittest.TestCase):
         _, _, _, _, _, context = quota.codex()
         self.assertEqual(context["/tmp/a"], {"used": 40, "window": 237_500})
 
+    def test_sessions_today_uses_local_day(self):
+        clear_codex()
+        # Touched within 24h but before local midnight -> not "today".
+        p = codex_rollout("s1", [token_count(100, 100, ts=YESTERDAY)])
+        os.utime(p, (YESTERDAY, YESTERDAY))
+        codex_rollout("s2", [token_count(200, 200, ts=TODAY)])
+        sessions, tokens, _, _, _, _ = quota.codex()
+        self.assertEqual(sessions, 1)
+        self.assertEqual(tokens, 200)
+
     def test_no_sessions_reports_none(self):
         clear_codex()
         sessions, tokens, _, _, _, _ = quota.codex()
@@ -298,6 +308,20 @@ class TestCodexWindowMapping(unittest.TestCase):
         self.assertIsNone(quota._codex_map_rate_limits(
             {"primary": None, "secondary": None, "plan_type": "prolite"},
             "used_percent", "resets_at", "window_minutes", "plan_type"))
+
+    def test_walk_continues_past_a_plan_only_rate_limits_event(self):
+        clear_codex()
+        newest = codex_rollout("s2", [token_count(
+            100, 100, rate_limits={"primary": None, "secondary": None,
+                                   "plan_type": "prolite"})])
+        older = codex_rollout("s1", [token_count(
+            50, 50, rate_limits={"primary": {"used_percent": 22.0,
+                                             "window_minutes": 300}})])
+        os.utime(older, (TODAY - 600, TODAY - 600))
+        os.utime(newest, (TODAY, TODAY))
+        _, _, _, limits, _, _ = quota.codex()
+        self.assertEqual(limits["five_hour_used_percent"], 22.0,
+                         "a plan-label-only event must not end the search")
 
     def test_non_dict_input(self):
         self.assertIsNone(quota._codex_map_rate_limits(

--- a/dev_docs/README.md
+++ b/dev_docs/README.md
@@ -33,6 +33,7 @@ Feature specs、bug-fix notes、implementation plans、单次 UI 调整和逐版
 | --- | --- |
 | [integrate/sleep-helper.md](integrate/sleep-helper.md) | Sleep helper 边界 |
 | [integrate/localization.md](integrate/localization.md) | 本地化约束 |
+| [integrate/usage-accounting.md](integrate/usage-accounting.md) | Token 计数与额度窗口映射规则 |
 
 ### Ship
 

--- a/dev_docs/integrate/usage-accounting.md
+++ b/dev_docs/integrate/usage-accounting.md
@@ -1,0 +1,57 @@
+# 用量读取契约
+
+`Resources/quota.py` 是 Kaji 唯一的用量数据源。它读取各 harness 的本地会话文件与
+账号接口，输出 `tokens_today` 与 `limits`。这份文档记录**必须保持不变的计数规则**，
+因为每一条都对应一个已经出现过的错误读数。
+
+## 时间边界
+
+`TODAY_START` 是**本地午夜**，不是 UTC 午夜。
+
+UTC 边界在 UTC+8 会让"今天"从本地 08:00 才开始，整个上午的用量被静默丢弃；在
+UTC-5 又会把昨晚算进今天。所有 harness 共用这一个边界。
+
+## Claude Code
+
+会话记录在 `~/.claude/projects/**/*.jsonl`，每行一条 `message.usage`。
+
+| 规则 | 原因 |
+| --- | --- |
+| tokens = `input + output + cache_creation + cache_read` | cache 读取约占真实流量 99%；只算 input+output 等于几乎什么都没统计 |
+| 按 `(message.id, requestId)` 全局去重 | resume / 分支 / compact 会把旧轮次**重写**进新文件，裸求和会把同一次 API 调用算多遍 |
+| 跳过 `model == "<synthetic>"` | 本地错误占位，不计费 |
+| 包含 `subagents/` 下的文件 | sidechain 轮次是真实计费用量 |
+| 扫描 `CLAUDE_CONFIG_DIR`（逗号分隔）、`~/.claude`、`~/.config/claude` | 迁移过 config 目录的用户否则永远读到 0 |
+
+`context`（当前上下文占用）在去重**之前**读取：重复记录描述的仍是真实上下文大小。
+
+计数口径与社区工具 `ccusage` 对齐，便于交叉核对。
+
+## Codex
+
+会话记录在 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` 的 `token_count` 事件。
+
+- 事件里的 `total_token_usage` 是**会话累计**，`last_token_usage` 是本轮增量。
+  `tokens_today` 必须累加**时间戳落在今天**的 `last_token_usage`。取最后一条累计值
+  会把一个跨周会话的全部历史算进它最后活跃的那一天。
+- 跳过累计值与上一条完全相同的事件：TUI 重绘会重复发送同一个 `token_count`。
+- 额度百分比按**窗口时长**映射，绝不按 `primary` / `secondary` 槽位名：
+
+  ```
+  window_minutes <= 1440  ->  five_hour
+  window_minutes >  1440  ->  seven_day
+  ```
+
+  Codex 把 `primary` 用作"当前生效的窗口"。只有周额度的套餐会给出
+  `primary.window_minutes == 10080` 且 `secondary == null`——信任槽位名就会把
+  7 天数字画到 5 小时环上。
+
+- 实时读数走 `codex -s read-only -a never app-server` 的
+  `account/rateLimits/read`。审批策略枚举里**没有** `untrusted`（0.153.x 只接受
+  `on-request` / `never`），传错值会让 CLI 在响应任何 JSON-RPC 之前退出，于是所有读数
+  静默退化成过期的会话文件。
+
+## 测试
+
+`Tests/quota/test_quota.py`（纯标准库、临时目录 fixture、无网络、不读用户数据）覆盖
+上面每一条规则，由 CI 在 `swift test` 之前运行。改动计数逻辑必须保持它为绿。


### PR DESCRIPTION
Both the Claude and the Codex numbers were inaccurate, for different reasons. Verified against real local session data.

## Codex

| Bug | Effect |
|---|---|
| Rate-limit windows mapped by `primary`/`secondary` **slot name** | Codex uses `primary` for whichever window is currently authoritative. On a weekly-only plan it reports `primary.window_minutes == 10080` with `secondary == null`, so the 7-day figure was painted onto the **5-hour ring**. |
| `codex -a untrusted app-server` | `untrusted` was removed from the approval-policy enum (0.153.x accepts only `on-request`/`never`), so the CLI exited before answering any JSON-RPC. The live query **never worked**; every reading silently fell back to a stale session file. |
| `tokens_today` = final cumulative `total_token_usage` per session | That value is session-lifetime, so a session started weeks ago landed entirely in today's total, up to **14x** inflation on local data. Now sums per-turn `last_token_usage` over events timestamped today, skipping identical snapshots re-emitted on TUI redraw. |

Before/after on this machine at the same instant: `used 5h 34%` (stale file, wrong ring) becomes `used wk 100% (prolite)` (live, correct ring).

## Claude Code

| Bug | Measured on local data |
|---|---|
| Cache tokens excluded from the total | Cache is **99.3%** of traffic (4.73B vs 31M input+output). The figure tracked almost nothing. |
| No de-duplication | **68%** of usage rows were repeats: resumed, branched and compacted sessions rewrite earlier turns into new files. Now keyed on `(message.id, requestId)`, as ccusage does. |
| `<synthetic>` rows counted | Local error placeholders, not billed. |
| `subagents/` files skipped | Sidechain turns are real billed usage. |
| Only `~/.claude/projects` read | Now also `CLAUDE_CONFIG_DIR` (comma-separated) and `~/.config/claude`. |

Replaying a real busy day: 290,103 becomes 5,214,460 tokens (18x).

## Shared

`TODAY_START` is now **local** midnight. The UTC boundary meant "today" began at 08:00 local at UTC+8, silently discarding the whole morning.

## Verification

- `Tests/quota/test_quota.py`: 24 new cases, stdlib only, temp-dir fixtures, no network and no user data. Confirmed to **fail against the pre-fix code** (11 failures / 9 errors) and pass after. Wired into CI ahead of `swift test`.
- `swift build` and `swift test` green (157 tests).
- Live `quota.py --json` produces correct windows for claude, codex and cursor.

Counting rules recorded in `dev_docs/integrate/usage-accounting.md`.
