### PR TITLE
Release v0.9.4

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.3</string>
+	<string>0.9.4</string>
 	<key>CFBundleVersion</key>
-	<string>35</string>
+	<string>36</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Patch release: quota accuracy fixes from #59.

- Codex quota rings mapped by window length, so a weekly-only plan no longer paints its 7-day figure onto the 5-hour ring.
- Codex live rate-limit query fixed (`-a untrusted` is no longer a valid approval policy), so readings stop falling back to a stale session file.
- Codex `tokens_today` counts today's turns instead of a session's whole lifetime.
- Claude token totals include cache tokens, de-duplicate rewritten turns, skip `<synthetic>` placeholders, include subagent files, and honour `CLAUDE_CONFIG_DIR`.
- "Today" starts at local midnight instead of UTC.

Bumps CFBundleShortVersionString to 0.9.4 and CFBundleVersion to 36.