### PR TITLE
Redesign quota rows as a minimal two-window list

### DIFF
--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -357,10 +357,16 @@ struct KajiPopoverView: View {
     }
 
 
+    // Quota row (minimal list style):
+    //   provider mark + name
+    //   5h  [====      ]  42%   21:40 \u{00B7} 2h 14m left
+    //   7d  [========  ]  78%   Sun 12:00 \u{00B7} 3d left
+    // No card chrome: whitespace separates providers so the popover reads as
+    // one quiet list. Weight (bar height, percent size) encodes priority,
+    // not extra words.
     private func quotaRow(_ provider: ProviderView) -> some View {
         let windows = CursorLimitsLogic.windowLabels(for: provider.id)
-        let secondary = provider.id == "cursor" ? windows.secondary : "7d"
-        return VStack(alignment: .leading, spacing: 5) {
+        return VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 7) {
                 ProviderLogo(key: provider.id, color: provider.isNearLimit ? t.amber : t.gold, size: 12)
                 Text(provider.displayName)
@@ -368,34 +374,64 @@ struct KajiPopoverView: View {
                     .foregroundColor(t.cream)
                     .lineLimit(1)
                 Spacer(minLength: 6)
-                Text(percent(provider.fiveHourPercent))
-                    .font(.system(size: 12, weight: .bold, design: .rounded))
+            }
+            quotaWindowLine(label: windows.primary,
+                            percentValue: provider.fiveHourPercent,
+                            fraction: provider.usedFraction,
+                            resetDate: provider.resetDate,
+                            nearLimit: provider.isNearLimit,
+                            emphasized: true)
+            quotaWindowLine(label: windows.secondary,
+                            percentValue: provider.weekPercent,
+                            fraction: provider.weekFraction,
+                            resetDate: provider.weekResetDate,
+                            nearLimit: provider.weekNearLimit,
+                            emphasized: false)
+        }
+    }
+
+    /// One quota window as a single aligned line, plus a tiny reset caption.
+    /// The caption answers both "when" (wall clock) and "how long" (time left).
+    private func quotaWindowLine(label: String,
+                                 percentValue: Double?,
+                                 fraction: Double,
+                                 resetDate: Date?,
+                                 nearLimit: Bool,
+                                 emphasized: Bool) -> some View {
+        let barColor = nearLimit ? t.amber : (emphasized ? t.gold : t.mute)
+        return VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                     .monospacedDigit()
-                    .foregroundColor(provider.isNearLimit ? t.amber : t.gold)
+                    .foregroundColor(t.ash)
+                    .frame(width: 18, alignment: .leading)
+                progressBar(fraction, color: barColor, height: emphasized ? 6 : 3)
+                Text(percent(percentValue))
+                    .font(.system(size: emphasized ? 10.5 : 9.5,
+                                  weight: emphasized ? .bold : .semibold,
+                                  design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(emphasized ? t.cream : t.mute)
+                    .frame(width: 30, alignment: .trailing)
             }
-            progressBar(provider.usedFraction, color: provider.isNearLimit ? t.amber : t.gold)
-            HStack(spacing: 6) {
-                Text(windows.primary)
-                Text(ResetFormat.short(provider.resetDate))
-                    .foregroundColor(t.gold.opacity(0.9))
-                Spacer(minLength: 6)
-                Text(secondary)
-                Text(percent(provider.weekPercent))
-                    .foregroundColor(provider.weekNearLimit ? t.amber : t.gold.opacity(0.9))
-            }
-            .font(.system(size: 9.5, weight: .medium, design: .rounded))
-            .foregroundColor(t.mute)
+            Text(resetCaption(resetDate))
+                .font(.system(size: 9, weight: .medium, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(t.ash)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .padding(.leading, 26)
         }
-        .padding(8)
-        .background {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(scheme == .light ? Color.white.opacity(0.92) : t.panel.opacity(0.75))
-        }
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(scheme == .light ? Color.black.opacity(0.08) : t.cream.opacity(0.06), lineWidth: 0.5)
-        )
-        .shadow(color: scheme == .light ? Color.black.opacity(0.06) : .clear, radius: 4, y: 1)
+    }
+
+    /// "21:40 \u{00B7} 2h 14m left" / "Sun 12:00 \u{00B7} 3d left".
+    private func resetCaption(_ date: Date?) -> String {
+        guard let date else { return "\u{2014}" }
+        let clock = ResetFormat.resetClock(date)
+        guard let left = ResetFormat.dur(date) else { return clock }
+        if left == "now" { return "resetting" }
+        return "\(clock) \u{00B7} \(ResetFormat.coarse(left)) left"
     }
 
     private func quotaWindowRow(label: String, value: Double, resetDate: Date?, nearLimit: Bool) -> some View {
@@ -1703,7 +1739,7 @@ struct KajiPopoverView: View {
     }
 
 
-    private func progressBar(_ value: Double, color: Color) -> some View {
+    private func progressBar(_ value: Double, color: Color, height: CGFloat = 7) -> some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
                 Capsule().fill(t.track.opacity(0.7))
@@ -1712,7 +1748,7 @@ struct KajiPopoverView: View {
                     .frame(width: max(4, geo.size.width * min(max(value, 0), 1)))
             }
         }
-        .frame(height: 7)
+        .frame(height: height)
     }
 
     private func percent(_ value: Double?) -> String {

--- a/Sources/Kaji/RingGauge.swift
+++ b/Sources/Kaji/RingGauge.swift
@@ -194,6 +194,28 @@ enum ResetFormat {
         return lang == .zh ? "\(d) \u{540E}\u{91CD}\u{7F6E}" : "resets in \(d)"          // 后重置
     }
 
+    /// Coarser countdown for tight captions: days drop the hour remainder
+    /// ("3d 4h" -> "3d"); sub-day durations stay exact.
+    static func coarse(_ dur: String) -> String {
+        guard let dIdx = dur.firstIndex(of: "d") else { return dur }
+        return String(dur[dur.startIndex...dIdx])
+    }
+
+    /// Wall-clock reset stamp. Today: "21:40"; within a week: "Sun 12:00";
+    /// later: "6-29 12:00".
+    static func resetClock(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale.current
+        if Calendar.current.isDateInToday(date) {
+            f.dateFormat = "HH:mm"
+        } else if date.timeIntervalSinceNow < 6 * 24 * 3600 {
+            f.dateFormat = "EEE HH:mm"
+        } else {
+            f.dateFormat = "M-d HH:mm"
+        }
+        return f.string(from: date)
+    }
+
     /// "—" when no date; "2h 14m" countdown otherwise. (compat helper)
     static func short(_ date: Date?) -> String { dur(date) ?? "\u{2014}" }
 


### PR DESCRIPTION
The popover row showed one bar for two windows, so the 7-day figure had no visual weight and neither window said when it resets.

Each window now gets its own aligned line (label, bar, percent) plus a small caption with the reset wall clock and the time left. Card chrome is dropped so providers read as one quiet list, and hierarchy comes from bar height and percent weight rather than extra words.

- `quotaRow` renders provider mark + name, then a 5h and a 7d line
- `ResetFormat.resetClock` formats the reset stamp (today `21:40`, this week `Sun 12:00`, later `6-29 12:00`)
- `ResetFormat.coarse` trims multi-day countdowns to `3d`
- `progressBar` takes an optional height so the 7d bar reads as subordinate

Local SwiftPM is broken on this machine (no Xcode; the manifest fails to link PackageDescription), so verification here was `swiftc -parse` only. CI must confirm `swift build` and `swift test`, particularly `PopoverHeightBudgetTests` since each provider row changes height.