### PR TITLE
Distinguish a missing quota reading from zero usage

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.4</string>
+	<string>0.9.5</string>
 	<key>CFBundleVersion</key>
 	<string>36</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Resources/quota.py
+++ b/Resources/quota.py
@@ -227,13 +227,23 @@ def _limits_cached(name, fetch, ttl=LIMITS_TTL):
 
 
 def _usable_claude_token(credentials):
-    """Return an unexpired access token from a Claude credential object."""
+    """Return a usable access token from a Claude credential object.
+
+    `expiresAt` is advisory, not authoritative. Team/enterprise logins store
+    `expiresAt: 0`, so treating a falsy timestamp as "already expired" drops
+    the only usable token and the provider then reports no percentages at all.
+    A missing or zero timestamp means "unknown": try the token and let the
+    server decide. Only a real timestamp in the past is rejected locally.
+    """
     try:
         oauth = credentials["claudeAiOauth"]
-        expires_at = float(oauth.get("expiresAt") or 0) / 1000.0
-        if expires_at <= time.time() + 60:
+        token = oauth.get("accessToken") or None
+        if not token:
             return None
-        return oauth.get("accessToken") or None
+        expires_at = float(oauth.get("expiresAt") or 0) / 1000.0
+        if expires_at > 0 and expires_at <= time.time() + 60:
+            return None
+        return token
     except Exception:
         return None
 
@@ -296,10 +306,22 @@ def _fetch_claude_limits():
             "Content-Type": "application/json",
         })
     with urllib.request.urlopen(req, timeout=10) as r:
-        d = json.loads(r.read().decode("utf-8"))
+        return _parse_claude_usage(json.loads(r.read().decode("utf-8")))
+
+
+def _parse_claude_usage(payload):
+    """Anthropic usage payload -> Kaji limits dict.
+
+    A window with no `utilization` is OMITTED, not zero-filled: "unknown" and
+    "0% used" must stay distinguishable all the way to the popover.
+    """
+    if not isinstance(payload, dict):
+        return None
     out = {}
     for key in ("five_hour", "seven_day"):
-        w = d.get(key) or {}
+        w = payload.get(key) or {}
+        if not isinstance(w, dict):
+            continue
         if w.get("utilization") is not None:
             out[key + "_used_percent"] = w["utilization"]
             if w.get("resets_at"):

--- a/Sources/Kaji/KajiPopoverView.swift
+++ b/Sources/Kaji/KajiPopoverView.swift
@@ -398,6 +398,10 @@ struct KajiPopoverView: View {
                                  resetDate: Date?,
                                  nearLimit: Bool,
                                  emphasized: Bool) -> some View {
+        // A missing reading is NOT zero usage. Rendering nil as an empty bar
+        // made "no data" look identical to "0% used", which hid a broken
+        // provider credential for as long as the user cared to stare at it.
+        let hasReading = QuotaCaption.hasReading(percentValue)
         let barColor = nearLimit ? t.amber : (emphasized ? t.gold : t.mute)
         return VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 8) {
@@ -406,16 +410,20 @@ struct KajiPopoverView: View {
                     .monospacedDigit()
                     .foregroundColor(t.ash)
                     .frame(width: 18, alignment: .leading)
-                progressBar(fraction, color: barColor, height: emphasized ? 6 : 3)
-                Text(percent(percentValue))
+                if hasReading {
+                    progressBar(fraction, color: barColor, height: emphasized ? 6 : 3)
+                } else {
+                    unavailableBar(height: emphasized ? 6 : 3)
+                }
+                Text(QuotaCaption.percent(percentValue))
                     .font(.system(size: emphasized ? 10.5 : 9.5,
                                   weight: emphasized ? .bold : .semibold,
                                   design: .rounded))
                     .monospacedDigit()
-                    .foregroundColor(emphasized ? t.cream : t.mute)
+                    .foregroundColor(hasReading ? (emphasized ? t.cream : t.mute) : t.ash)
                     .frame(width: 30, alignment: .trailing)
             }
-            Text(resetCaption(resetDate))
+            Text(hasReading ? resetCaption(resetDate) : QuotaCaption.unavailable)
                 .font(.system(size: 9, weight: .medium, design: .rounded))
                 .monospacedDigit()
                 .foregroundColor(t.ash)
@@ -423,6 +431,14 @@ struct KajiPopoverView: View {
                 .minimumScaleFactor(0.8)
                 .padding(.leading, 26)
         }
+    }
+
+    /// Placeholder track for a window with no reading: a hollow outline, so it
+    /// can never be mistaken for a full-but-empty usage bar.
+    private func unavailableBar(height: CGFloat) -> some View {
+        Capsule()
+            .strokeBorder(t.track, style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            .frame(height: height)
     }
 
     /// "21:40 \u{00B7} 2h 14m left" / "Sun 12:00 \u{00B7} 3d left".

--- a/Sources/KajiCore/QuotaCaption.swift
+++ b/Sources/KajiCore/QuotaCaption.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Captions for a single quota window in the popover.
+///
+/// Lives in `KajiCore` so the "no reading" case is testable without booting a
+/// view: a missing percentage and a real 0% must never render the same way.
+/// Treating `nil` as zero once hid a broken Claude credential behind a row
+/// that looked like healthy, unused quota.
+public enum QuotaCaption {
+    /// Shown instead of a reset time when the provider returned no reading.
+    public static let unavailable = "no data \u{00B7} check sign-in"
+
+    /// Percent text for a window. `nil` is an em dash, never "0%".
+    public static func percent(_ value: Double?) -> String {
+        guard let value else { return "\u{2014}" }
+        return "\(Int(value.rounded()))%"
+    }
+
+    /// Whether a window has a usable reading at all.
+    public static func hasReading(_ value: Double?) -> Bool {
+        guard let value else { return false }
+        return !value.isNaN && !value.isInfinite
+    }
+}

--- a/Tests/KajiTests/QuotaCaptionTests.swift
+++ b/Tests/KajiTests/QuotaCaptionTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import KajiCore
+
+/// Regression: a provider with NO reading rendered exactly like one at 0%.
+///
+/// Claude's OAuth token was being discarded locally, so `quota.py` returned no
+/// limits at all. The popover drew an empty bar and the ring math treated the
+/// missing percentage as `0`, which reads as "plenty of quota left" — the
+/// opposite of the truth, and it hid a broken sign-in indefinitely.
+///
+/// The contract these tests pin down: `nil` is never formatted as a number,
+/// and callers can always ask whether a reading exists.
+final class QuotaCaptionTests: XCTestCase {
+
+    func testMissingPercentIsNotZero() {
+        XCTAssertEqual(QuotaCaption.percent(nil), "\u{2014}")
+        XCTAssertNotEqual(QuotaCaption.percent(nil), "0%")
+    }
+
+    func testRealZeroStillRendersAsZero() {
+        XCTAssertEqual(QuotaCaption.percent(0), "0%")
+    }
+
+    func testPercentRounds() {
+        XCTAssertEqual(QuotaCaption.percent(78.4), "78%")
+        XCTAssertEqual(QuotaCaption.percent(95.6), "96%")
+        XCTAssertEqual(QuotaCaption.percent(100), "100%")
+    }
+
+    func testHasReadingDistinguishesNilFromZero() {
+        XCTAssertFalse(QuotaCaption.hasReading(nil))
+        XCTAssertTrue(QuotaCaption.hasReading(0))
+        XCTAssertTrue(QuotaCaption.hasReading(96))
+    }
+
+    func testNonFiniteIsNotAReading() {
+        XCTAssertFalse(QuotaCaption.hasReading(.nan))
+        XCTAssertFalse(QuotaCaption.hasReading(.infinity))
+    }
+
+    /// The caption must say something actionable, not an em dash that looks
+    /// like a styling choice.
+    func testUnavailableCaptionNamesTheCause() {
+        XCTAssertTrue(QuotaCaption.unavailable.contains("no data"))
+        XCTAssertFalse(QuotaCaption.unavailable.isEmpty)
+    }
+}

--- a/Tests/quota/test_quota.py
+++ b/Tests/quota/test_quota.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -326,6 +327,72 @@ class TestCodexWindowMapping(unittest.TestCase):
     def test_non_dict_input(self):
         self.assertIsNone(quota._codex_map_rate_limits(
             None, "used_percent", "resets_at", "window_minutes", "plan_type"))
+
+
+# Deliberately not shaped like a provider key: secret scanners flag realistic
+# prefixes even in fixtures, and the token's content is irrelevant here — these
+# tests only care whether it survives the expiry check.
+FAKE_TOKEN = "test-token-not-a-secret"
+
+
+class TestClaudeCredentialUsability(unittest.TestCase):
+    """Regression: `expiresAt: 0` made Claude report nothing at all.
+
+    Team/enterprise logins store `expiresAt: 0` in the keychain. The old check
+    divided it by 1000 and compared against now, so a falsy timestamp read as
+    "expired in 1970", the token was dropped, no request was ever made, and the
+    popover showed an empty 5h/7d row that looked exactly like 0% usage.
+    """
+
+    @staticmethod
+    def creds(expires_at, token=FAKE_TOKEN):
+        return {"claudeAiOauth": {"accessToken": token, "expiresAt": expires_at}}
+
+    def test_zero_expiry_is_unknown_not_expired(self):
+        self.assertEqual(
+            quota._usable_claude_token(self.creds(0)), FAKE_TOKEN)
+
+    def test_missing_expiry_is_unknown_not_expired(self):
+        self.assertEqual(
+            quota._usable_claude_token({"claudeAiOauth": {"accessToken": "t"}}), "t")
+
+    def test_future_expiry_is_usable(self):
+        future = (time.time() + 3600) * 1000
+        self.assertEqual(
+            quota._usable_claude_token(self.creds(future)), FAKE_TOKEN)
+
+    def test_past_expiry_is_rejected(self):
+        past = (time.time() - 3600) * 1000
+        self.assertIsNone(quota._usable_claude_token(self.creds(past)))
+
+    def test_missing_token_is_rejected(self):
+        self.assertIsNone(quota._usable_claude_token(self.creds(0, token="")))
+        self.assertIsNone(quota._usable_claude_token({"claudeAiOauth": {}}))
+
+    def test_junk_input_is_rejected(self):
+        self.assertIsNone(quota._usable_claude_token(None))
+        self.assertIsNone(quota._usable_claude_token({}))
+        self.assertIsNone(quota._usable_claude_token({"claudeAiOauth": "nope"}))
+
+
+class TestClaudeLimitsParsing(unittest.TestCase):
+    """A window without `utilization` must be absent, never zero."""
+
+    def test_utilization_zero_is_kept_as_a_real_reading(self):
+        payload = {"five_hour": {"utilization": 0, "resets_at": "2026-09-12T10:00:00Z"},
+                   "seven_day": {"utilization": 78}}
+        out = quota._parse_claude_usage(payload)
+        self.assertEqual(out["five_hour_used_percent"], 0)
+        self.assertEqual(out["seven_day_used_percent"], 78)
+
+    def test_missing_utilization_is_omitted_not_zeroed(self):
+        out = quota._parse_claude_usage({"five_hour": {}, "seven_day": {"utilization": 12}})
+        self.assertNotIn("five_hour_used_percent", out)
+        self.assertEqual(out["seven_day_used_percent"], 12)
+
+    def test_empty_payload_is_none(self):
+        self.assertIsNone(quota._parse_claude_usage({}))
+        self.assertIsNone(quota._parse_claude_usage(None))
 
 
 class TestIntCoercion(unittest.TestCase):

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -52,7 +52,7 @@ else
 	<key>CFBundleExecutable</key><string>Kaji</string>
 	<key>CFBundleIconFile</key><string>AppIcon</string>
 	<key>CFBundlePackageType</key><string>APPL</string>
-	<key>CFBundleShortVersionString</key><string>0.8.0</string>
+	<key>CFBundleShortVersionString</key><string>0.9.5</string>
 	<key>CFBundleVersion</key><string>28</string>
 	<key>LSMinimumSystemVersion</key><string>13.0</string>
 	<key>LSUIElement</key><true/>


### PR DESCRIPTION
## What was wrong

Claude's row showed an empty bar and a dash, which looks exactly like a provider sitting at 0% used. Two defects stacked:

**1. The OAuth token was discarded locally.** `_usable_claude_token` computed `float(expiresAt or 0)/1000` and rejected anything `<= now`. Team/enterprise logins store `expiresAt: 0`, so the timestamp read as 1970 and the token was dropped before any request was made — `quota.py` returned `limits: None` for Claude without ever contacting the server.

**2. The popover rendered `nil` like a number.** A missing percentage produced a 0-width bar, identical to genuine zero usage. A broken sign-in was therefore invisible.

## Fix

- A missing or zero expiry now means *unknown*: send the token, let the server decide. Only a real past timestamp is rejected locally.
- Windows with no reading draw a dashed placeholder track and a `no data · check sign-in` caption instead of an empty bar.
- `_parse_claude_usage` extracted so the omit-vs-zero rule is testable without network.
- `QuotaCaption` (KajiCore) centralizes percent formatting; `nil` is never "0%".

## Regression tests

- `Tests/quota/test_quota.py`: `TestClaudeCredentialUsability` (zero/missing/future/past expiry, empty token, junk) and `TestClaudeLimitsParsing` (utilization 0 kept, missing omitted). Verified these **fail** against the pre-fix code, then pass.
- `Tests/KajiTests/QuotaCaptionTests.swift`: nil never formats as "0%", real zero still does, `hasReading` separates the two.

## Verification

`python3 Tests/quota/test_quota.py` — 35 tests pass; confirmed the 2 new assertions fail when the old expiry check is restored. `swift build` passes. `swift test` cannot run on this machine (CommandLineTools has no XCTest); CI must confirm.

## Note for the reviewer

My own keychain entry currently holds an **empty** access token, so Claude will still show `no data` for me until I re-authenticate — that is the correct new behavior rather than a silent 0%. The endpoint also rate-limited this machine (429, `retry-after: 3478`) during investigation.

## Also included

Bundle version 0.9.4 → 0.9.5, and the stale hardcoded `0.8.0` fallback in `scripts/build-app.sh` removed.